### PR TITLE
perf(grpc): right-size broadcast encoding buffers

### DIFF
--- a/client/benches/submit_blob_allocations/native.rs
+++ b/client/benches/submit_blob_allocations/native.rs
@@ -305,6 +305,9 @@ async fn profile_broadcast(config: &Config, profile_path: &Path) -> Result<Profi
         Ok(response) => {
             black_box(response);
         }
+        Err(error) if error.is_network_error() => {
+            return Err(format!("broadcast benchmark transport failed: {error}").into());
+        }
         Err(error) => println!("server response after receiving transport payload: {error}"),
     }
     Ok(summary)

--- a/client/benches/submit_blob_latency/native.rs
+++ b/client/benches/submit_blob_latency/native.rs
@@ -108,7 +108,13 @@ fn bench_broadcast_tx(c: &mut Criterion, runtime: &Runtime, client: &GrpcClient)
                         let start = Instant::now();
                         let result = client.broadcast_tx(tx_bytes, BroadcastMode::Sync).await;
                         elapsed += start.elapsed();
-                        black_box(result).ok();
+                        if let Err(error) = &result {
+                            assert!(
+                                !error.is_network_error(),
+                                "broadcast_tx benchmark transport failed: {error}"
+                            );
+                        }
+                        let _ = black_box(result);
                     }
                     elapsed
                 })

--- a/grpc/src/builder.rs
+++ b/grpc/src/builder.rs
@@ -555,7 +555,7 @@ mod tests {
             &mut self,
             _cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<Result<(), Self::Error>> {
-            std::task::Poll::Ready(Ok(()))
+            std::task::Poll::Pending
         }
 
         fn call(&mut self, _request: http::Request<TonicBody>) -> Self::Future {
@@ -710,6 +710,25 @@ mod tests {
 
         let Error::TonicError(error) = client
             .get_node_config()
+            .timeout(Duration::from_millis(10))
+            .await
+            .unwrap_err()
+        else {
+            panic!("expected a tonic timeout error");
+        };
+
+        assert_eq!(error.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    #[async_test]
+    async fn broadcast_tx_timeout_includes_transport_readiness() {
+        let client = GrpcClientBuilder::new()
+            .transport(PendingTransport)
+            .build()
+            .unwrap();
+
+        let Error::TonicError(error) = client
+            .broadcast_tx(vec![], crate::grpc::BroadcastMode::Sync)
             .timeout(Duration::from_millis(10))
             .await
             .unwrap_err()

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -29,6 +29,7 @@ use celestia_proto::cosmos::base::node::v1beta1::service_client::ServiceClient a
 use celestia_proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient as TendermintServiceClient;
 use celestia_proto::cosmos::staking::v1beta1::query_client::QueryClient as StakingQueryClient;
 use celestia_proto::cosmos::tx::v1beta1::service_client::ServiceClient as TxServiceClient;
+use celestia_proto::cosmos::tx::v1beta1::{BroadcastTxRequest, BroadcastTxResponse};
 use celestia_proto::tendermint_celestia_mods::rpc::grpc::ValidatorSetResponse;
 use celestia_proto::tendermint_celestia_mods::rpc::grpc::block_api_client::BlockApiClient as FibreBlockApiClient;
 use celestia_types::blob::{BlobParams, MsgPayForBlobs, RawBlobTx, RawMsgPayForBlobs};
@@ -78,6 +79,49 @@ struct AccountGuard<'a> {
     base: MutexGuard<'a, BaseAccount>,
     pubkey: &'a VerifyingKey,
     signer: &'a BoxedDocSigner,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BroadcastTxCodec {
+    buffer_settings: tonic::codec::BufferSettings,
+}
+
+impl BroadcastTxCodec {
+    fn new(request: &BroadcastTxRequest) -> Self {
+        let frame_size = request
+            .encoded_len()
+            .checked_add(5)
+            .expect("protobuf request is limited to 256 MiB");
+
+        Self {
+            buffer_settings: tonic::codec::BufferSettings::new(frame_size, frame_size),
+        }
+    }
+}
+
+impl tonic::codec::Codec for BroadcastTxCodec {
+    type Encode = BroadcastTxRequest;
+    type Decode = BroadcastTxResponse;
+    type Encoder = <tonic::codec::ProstCodec<
+        BroadcastTxRequest,
+        BroadcastTxResponse,
+    > as tonic::codec::Codec>::Encoder;
+    type Decoder = <tonic::codec::ProstCodec<
+        BroadcastTxRequest,
+        BroadcastTxResponse,
+    > as tonic::codec::Codec>::Decoder;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        tonic::codec::ProstCodec::<BroadcastTxRequest, BroadcastTxResponse>::raw_encoder(
+            self.buffer_settings,
+        )
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        tonic::codec::ProstCodec::<BroadcastTxRequest, BroadcastTxResponse>::raw_decoder(
+            tonic::codec::BufferSettings::default(),
+        )
+    }
 }
 
 impl AccountState {
@@ -208,8 +252,82 @@ impl GrpcClient {
     // cosmos.tx
 
     /// Broadcast prepared and serialised transaction
-    #[grpc_method(TxServiceClient::broadcast_tx)]
-    fn broadcast_tx(&self, tx_bytes: Vec<u8>, mode: BroadcastMode) -> AsyncGrpcCall<TxResponse>;
+    pub fn broadcast_tx(
+        &self,
+        tx_bytes: Vec<u8>,
+        mode: BroadcastMode,
+    ) -> AsyncGrpcCall<TxResponse> {
+        let failover = self.inner.failover.clone();
+        let param = BroadcastTxRequest {
+            tx_bytes,
+            mode: mode.into(),
+        };
+
+        AsyncGrpcCall::new(move |call_context: Context| async move {
+            // 256 MiB, future proof as Celestia blocks grow.
+            const MAX_MSG_SIZE: usize = 256 * 1024 * 1024;
+
+            failover
+                .run(move |transport: Arc<BoxedTransport>| {
+                    let param = param.clone();
+                    let call_context = call_context.clone();
+
+                    async move {
+                        let transport_context = &transport.metadata.context;
+                        let mut merged_context = transport_context.clone();
+                        merged_context.extend(&call_context);
+
+                        let mut request = tonic::Request::from_parts(
+                            merged_context.metadata.clone(),
+                            tonic::Extensions::new(),
+                            param,
+                        );
+                        request.extensions_mut().insert(tonic::GrpcMethod::new(
+                            "cosmos.tx.v1beta1.Service",
+                            "BroadcastTx",
+                        ));
+
+                        // Same defaults as `grpc_method`: the timeout is sent
+                        // to the server and also enforced locally below.
+                        let request_timeout = merged_context
+                            .timeout
+                            .unwrap_or_else(|| Duration::from_secs(30));
+                        request.set_timeout(request_timeout);
+
+                        let codec = BroadcastTxCodec::new(request.get_ref());
+                        let path = http::uri::PathAndQuery::from_static(
+                            "/cosmos.tx.v1beta1.Service/BroadcastTx",
+                        );
+                        let mut client = tonic::client::Grpc::new((*transport).clone())
+                            .max_decoding_message_size(MAX_MSG_SIZE)
+                            .max_encoding_message_size(MAX_MSG_SIZE);
+
+                        client.ready().await.map_err(|error| {
+                            tonic::Status::unknown(format!(
+                                "Service was not ready: {}",
+                                Into::<tonic::codegen::StdError>::into(error)
+                            ))
+                        })?;
+
+                        let future = client.unary(request, path, codec);
+
+                        #[cfg(target_arch = "wasm32")]
+                        let future = send_wrapper::SendWrapper::new(future);
+
+                        match lumina_utils::time::timeout(request_timeout, future).await {
+                            Ok(Ok(response)) => crate::grpc::FromGrpcResponse::try_from_response(
+                                response.into_inner(),
+                            ),
+                            Ok(Err(error)) => Err(Error::from(error)),
+                            Err(_) => Err(Error::from(tonic::Status::deadline_exceeded(
+                                "request timed out",
+                            ))),
+                        }
+                    }
+                })
+                .await
+        })
+    }
 
     /// Get Tx
     #[grpc_method(TxServiceClient::get_tx)]

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -302,14 +302,15 @@ impl GrpcClient {
                             .max_decoding_message_size(MAX_MSG_SIZE)
                             .max_encoding_message_size(MAX_MSG_SIZE);
 
-                        client.ready().await.map_err(|error| {
-                            tonic::Status::unknown(format!(
-                                "Service was not ready: {}",
-                                Into::<tonic::codegen::StdError>::into(error)
-                            ))
-                        })?;
-
-                        let future = client.unary(request, path, codec);
+                        let future = async move {
+                            client.ready().await.map_err(|error| {
+                                tonic::Status::unknown(format!(
+                                    "Service was not ready: {}",
+                                    Into::<tonic::codegen::StdError>::into(error)
+                                ))
+                            })?;
+                            client.unary(request, path, codec).await
+                        };
 
                         #[cfg(target_arch = "wasm32")]
                         let future = send_wrapper::SendWrapper::new(future);

--- a/types/benches/blob/native.rs
+++ b/types/benches/blob/native.rs
@@ -34,8 +34,7 @@ use celestia_types::nmt::Namespace;
 use celestia_types::state::{AccAddress, Id};
 use celestia_types::{Blob, Commitment};
 use criterion::{
-    BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, Throughput, criterion_group,
-    measurement::WallTime,
+    BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, Throughput, measurement::WallTime,
 };
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
@@ -155,13 +154,12 @@ fn bench_commitment_from_shares(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_blob_new,
-    bench_blob_validate,
-    bench_blob_to_shares,
-    bench_commitment_from_shares
-);
+fn run_benches(c: &mut Criterion) {
+    bench_blob_new(c);
+    bench_blob_validate(c);
+    bench_blob_to_shares(c);
+    bench_commitment_from_shares(c);
+}
 
 /// Put glibc's allocator in a steady state before measuring.
 ///
@@ -180,6 +178,7 @@ pub(super) fn pin_allocator_state() {
 
 pub(super) fn main() {
     pin_allocator_state();
-    benches();
-    Criterion::default().configure_from_args().final_summary();
+    let mut criterion = Criterion::default().configure_from_args();
+    run_benches(&mut criterion);
+    criterion.final_summary();
 }


### PR DESCRIPTION
## Overview

Use a request-sized protobuf codec for `GrpcClient::broadcast_tx`.

Tonic normally grows its encode buffer while serializing large requests. The
custom codec allocates the required frame size up front while preserving the
existing path, metadata, timeout, failover, and message limits.

The local timeout covers both transport readiness and the RPC call. A focused
regression test exercises a transport that never becomes ready.

## Results vs #982

| Phase | Total allocated before | Total allocated after |
|---|---:|---:|
| broadcast | 28.08 MiB | 14.07 MiB |
| grpc-submit | 86.62 MiB | 72.61 MiB |
| full | 117.10 MiB | 103.09 MiB |

Peak live memory for the 7 MiB request falls from 49.01 MiB to 42.01 MiB in
the gRPC-submit phase.

Client-side latency is unchanged within run-to-run noise; the benefit is lower
allocation volume and peak memory.
