### PR TITLE
chore(fibre): use more existing types instead of bytes and strings

### DIFF
--- a/client/src/fibre.rs
+++ b/client/src/fibre.rs
@@ -9,6 +9,7 @@ use celestia_fibre::{
     Blob, BlobID, DownloadOptions, FibreClient, FibreError, SignedPaymentPromise,
 };
 use celestia_grpc::{SubmittedTx, TxConfig};
+use celestia_types::nmt::Namespace;
 use k256::ecdsa::SigningKey;
 
 use crate::Error;
@@ -38,7 +39,7 @@ impl FibreApi {
     pub async fn upload(
         &self,
         signing_key: &SigningKey,
-        namespace: &[u8],
+        namespace: Namespace,
         blob: Blob,
     ) -> Result<SignedPaymentPromise, FibreError> {
         self.fibre_client.upload(signing_key, namespace, blob).await
@@ -55,7 +56,7 @@ impl FibreApi {
     pub async fn put(
         &self,
         signing_key: &SigningKey,
-        namespace: &[u8],
+        namespace: Namespace,
         data: &[u8],
     ) -> Result<SubmittedTx, Error> {
         let grpc = self.inner.grpc()?;
@@ -65,7 +66,7 @@ impl FibreApi {
 
         let msg = self
             .fibre_client
-            .upload_and_prepare(signing_key, namespace, data, &signer_address.to_string())
+            .upload_and_prepare(signing_key, namespace, data, &signer_address)
             .await
             .map_err(fibre_err)?;
 

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -10,6 +10,8 @@
 use std::sync::Arc;
 
 use celestia_proto::celestia::fibre::v1::MsgPayForFibre;
+use celestia_types::nmt::Namespace;
+use celestia_types::state::AccAddress;
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio_util::sync::CancellationToken;
 
@@ -33,7 +35,7 @@ impl FibreClient {
     pub async fn upload(
         &self,
         signing_key: &k256::ecdsa::SigningKey,
-        namespace: &[u8],
+        namespace: Namespace,
         blob: Blob,
     ) -> Result<SignedPaymentPromise, FibreError> {
         if self.cancel_token.is_cancelled() {
@@ -55,7 +57,7 @@ impl FibreClient {
         let mut promise = PaymentPromise {
             chain_id: self.cfg.chain_id.clone(),
             height: val_set.height,
-            namespace: namespace.to_vec(),
+            namespace,
             upload_size: upload_size_u32,
             blob_version: blob.config().blob_version as u32,
             commitment: blob.id().commitment(),
@@ -110,9 +112,9 @@ impl FibreClient {
     pub async fn upload_and_prepare(
         &self,
         signing_key: &k256::ecdsa::SigningKey,
-        namespace: &[u8],
+        namespace: Namespace,
         data: &[u8],
-        signer_address: &str,
+        signer_address: &AccAddress,
     ) -> Result<MsgPayForFibre, FibreError> {
         if self.cancel_token.is_cancelled() {
             return Err(FibreError::ClientClosed);
@@ -264,6 +266,7 @@ impl FibreClient {
 mod tests {
     use std::sync::Arc;
 
+    use celestia_types::nmt::Namespace;
     use k256::ecdsa::SigningKey;
     use rand::rngs::OsRng;
 
@@ -302,8 +305,8 @@ mod tests {
 
         let sk = test_signing_key();
         let blob = make_test_blob();
-        let namespace = vec![0u8; 29];
-        let result = client.upload(&sk, &namespace, blob).await;
+        let namespace = Namespace::from_raw(&[0u8; 29]).unwrap();
+        let result = client.upload(&sk, namespace, blob).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             FibreError::ClientClosed => {}
@@ -332,9 +335,9 @@ mod tests {
         let sk = test_signing_key();
         let client = build_test_client(val_set, connector, "test-chain");
         let blob = make_test_blob();
-        let namespace = vec![0u8; 29];
+        let namespace = Namespace::from_raw(&[0u8; 29]).unwrap();
 
-        let result = client.upload(&sk, &namespace, blob).await;
+        let result = client.upload(&sk, namespace, blob).await;
         assert!(result.is_ok(), "upload should succeed: {:?}", result.err());
 
         let signed = result.unwrap();
@@ -381,11 +384,11 @@ mod tests {
 
         let client = build_test_client(val_set, connector, "test-chain");
         let blob = make_test_blob();
-        let namespace = vec![0u8; 29];
+        let namespace = Namespace::from_raw(&[0u8; 29]).unwrap();
 
         // Upload returns once signature threshold is met.
         client
-            .upload(&test_signing_key(), &namespace, blob)
+            .upload(&test_signing_key(), namespace, blob)
             .await
             .unwrap();
 
@@ -428,9 +431,9 @@ mod tests {
 
         let client = build_test_client(val_set, failing_connector, "test-chain");
         let blob = make_test_blob();
-        let namespace = vec![0u8; 29];
+        let namespace = Namespace::from_raw(&[0u8; 29]).unwrap();
 
-        let result = client.upload(&test_signing_key(), &namespace, blob).await;
+        let result = client.upload(&test_signing_key(), namespace, blob).await;
         assert!(
             result.is_ok(),
             "upload should succeed with 3/5 validators: {:?}",
@@ -484,9 +487,9 @@ mod tests {
 
         let client = build_test_client(val_set, failing_connector, "test-chain");
         let blob = make_test_blob();
-        let namespace = vec![0u8; 29];
+        let namespace = Namespace::from_raw(&[0u8; 29]).unwrap();
 
-        let result = client.upload(&test_signing_key(), &namespace, blob).await;
+        let result = client.upload(&test_signing_key(), namespace, blob).await;
         assert!(
             result.is_err(),
             "upload should fail when not enough signatures"
@@ -511,11 +514,15 @@ mod tests {
         let client = build_test_client(val_set, connector, "test-chain");
         client.close();
 
-        let namespace = vec![0u8; 29];
+        let namespace = Namespace::from_raw(&[0u8; 29]).unwrap();
         let data = vec![1u8; 100];
         let sk = test_signing_key();
+        let signer: celestia_types::state::AccAddress =
+            "celestia1377k5an3f94v6wyaceu0cf4nq6gk2jtpc46g7h"
+                .parse()
+                .unwrap();
         let result = client
-            .upload_and_prepare(&sk, &namespace, &data, "celestia1test")
+            .upload_and_prepare(&sk, namespace, &data, &signer)
             .await;
         assert!(result.is_err());
         match result.unwrap_err() {

--- a/fibre/src/domain/config.rs
+++ b/fibre/src/domain/config.rs
@@ -3,23 +3,22 @@
 //! Defines the fundamental protocol constants from which all other
 //! configuration values are derived.
 
+use std::num::NonZeroU64;
+
 /// Fraction represented as numerator/denominator.
+///
+/// Both fields are non-zero: threshold math divides by each of them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Fraction {
     /// The numerator of the fraction.
-    pub numerator: u64,
+    pub numerator: NonZeroU64,
     /// The denominator of the fraction.
-    pub denominator: u64,
+    pub denominator: NonZeroU64,
 }
 
 impl Fraction {
     /// Creates a new `Fraction`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `denominator` is zero.
-    pub const fn new(numerator: u64, denominator: u64) -> Self {
-        assert!(denominator != 0, "Fraction denominator must not be zero");
+    pub const fn new(numerator: NonZeroU64, denominator: NonZeroU64) -> Self {
         Self {
             numerator,
             denominator,
@@ -59,8 +58,8 @@ pub const DEFAULT_PROTOCOL_PARAMS: ProtocolParams = ProtocolParams {
     encoding_ratio: 0.25, // 3x parity (12288 parity rows, 16384 total)
     max_validator_count: 100,
     unique_decoding_security_bits: 100,
-    safety_threshold: Fraction::new(2, 3),
-    liveness_threshold: Fraction::new(1, 3),
+    safety_threshold: Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap()),
+    liveness_threshold: Fraction::new(NonZeroU64::new(1).unwrap(), NonZeroU64::new(3).unwrap()),
     max_blob_size: 1 << 27, // 128 MiB
     min_row_size: 64,       // 1 << 6
 };
@@ -85,13 +84,18 @@ impl ProtocolParams {
     /// Returns the maximum number of rows a single validator could receive.
     pub fn max_rows_per_validator(&self) -> usize {
         // maxStake = 1 - safety_threshold
-        let max_stake_num =
-            (self.safety_threshold.denominator - self.safety_threshold.numerator) as usize;
-        let max_stake_den = self.safety_threshold.denominator as usize;
+        let max_stake_num = self
+            .safety_threshold
+            .denominator
+            .get()
+            .checked_sub(self.safety_threshold.numerator.get())
+            .expect("safety threshold numerator must not exceed denominator")
+            as usize;
+        let max_stake_den = self.safety_threshold.denominator.get() as usize;
 
         // rows = ceil(rows * max_stake / liveness_threshold)
-        let num = self.rows * max_stake_num * self.liveness_threshold.denominator as usize;
-        let den = max_stake_den * self.liveness_threshold.numerator as usize;
+        let num = self.rows * max_stake_num * self.liveness_threshold.denominator.get() as usize;
+        let den = max_stake_den * self.liveness_threshold.numerator.get() as usize;
         ceil_div(num, den)
     }
 
@@ -126,8 +130,8 @@ impl ProtocolParams {
 
     /// Returns the minimum number of validators needed to reconstruct the original data.
     pub fn validators_for_reconstruction(&self) -> usize {
-        let num = self.liveness_threshold.numerator as usize;
-        let den = self.liveness_threshold.denominator as usize;
+        let num = self.liveness_threshold.numerator.get() as usize;
+        let den = self.liveness_threshold.denominator.get() as usize;
         1usize.max(ceil_div(self.max_validator_count * num, den))
     }
 
@@ -447,43 +451,32 @@ mod tests {
     #[test]
     fn fibre_client_config_default() {
         let cfg = FibreClientConfig::default();
-        assert_eq!(
-            cfg.safety_threshold,
-            Fraction {
-                numerator: 2,
-                denominator: 3
-            }
-        );
-        assert_eq!(
-            cfg.liveness_threshold,
-            Fraction {
-                numerator: 1,
-                denominator: 3
-            }
-        );
+        assert_eq!(cfg.safety_threshold, crate::test_utils::fraction(2, 3));
+        assert_eq!(cfg.liveness_threshold, crate::test_utils::fraction(1, 3));
         assert_eq!(cfg.min_rows_per_validator, 148);
         assert_eq!(cfg.upload_concurrency, 100);
         assert_eq!(cfg.download_concurrency, 100);
     }
 
     #[test]
-    fn fraction_new_valid() {
-        let f = Fraction::new(1, 3);
-        assert_eq!(f.numerator, 1);
-        assert_eq!(f.denominator, 3);
-    }
+    #[should_panic(expected = "safety threshold numerator must not exceed denominator")]
+    fn safety_threshold_above_one_panics() {
+        let params = ProtocolParams {
+            safety_threshold: Fraction::new(
+                NonZeroU64::new(3).unwrap(),
+                NonZeroU64::new(2).unwrap(),
+            ),
+            ..DEFAULT_PROTOCOL_PARAMS
+        };
 
-    #[test]
-    #[should_panic(expected = "Fraction denominator must not be zero")]
-    fn fraction_new_zero_denominator_panics() {
-        Fraction::new(1, 0);
+        params.max_rows_per_validator();
     }
 
     #[test]
     fn liveness_threshold_must_exceed_encoding_ratio() {
         let p = &DEFAULT_PROTOCOL_PARAMS;
-        let liveness_ratio =
-            p.liveness_threshold.numerator as f64 / p.liveness_threshold.denominator as f64;
+        let liveness_ratio = p.liveness_threshold.numerator.get() as f64
+            / p.liveness_threshold.denominator.get() as f64;
         assert!(
             liveness_ratio >= p.encoding_ratio,
             "LivenessThreshold ({liveness_ratio}) must be >= EncodingRatio ({})",

--- a/fibre/src/domain/error.rs
+++ b/fibre/src/domain/error.rs
@@ -77,18 +77,10 @@ pub enum FibreError {
         reason: String,
     },
 
-    /// Signature verification failed (e.g., validator or payment promise signature).
-    #[error("signature verification failed")]
-    SignatureVerificationFailed,
-
     // -- PaymentPromise errors --
     /// The payment promise failed validation.
     #[error("payment promise validation failed: {0}")]
     InvalidPaymentPromise(String),
-
-    /// Signing the payment promise failed.
-    #[error("signing payment promise failed: {0}")]
-    SigningFailed(String),
 
     // -- Connection errors --
     /// No host address was found for a validator.

--- a/fibre/src/domain/payment_promise.rs
+++ b/fibre/src/domain/payment_promise.rs
@@ -6,6 +6,7 @@
 
 use std::time::SystemTime;
 
+use celestia_types::nmt::{NS_SIZE, Namespace};
 use k256::ecdsa::signature::Signer;
 use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
@@ -20,9 +21,6 @@ pub const SIGN_BYTES_PREFIX: &[u8] = b"fibre/pp:v0";
 /// Size of the secp256k1 compressed public key (33 bytes).
 const PUBKEY_SIZE: usize = 33;
 
-/// Size of the Celestia namespace (29 bytes).
-const NAMESPACE_SIZE: usize = 29;
-
 /// Size of a secp256k1 signature in compact format (32 bytes r + 32 bytes s).
 const SIGNATURE_SIZE: usize = 64;
 
@@ -33,8 +31,7 @@ const MAX_CHAIN_ID_SIZE: usize = 20;
 const TIMESTAMP_BINARY_SIZE: usize = 15;
 
 /// Fixed-size portion of sign bytes (excluding prefix and variable-length chain_id).
-const SIGN_BYTES_FIXED_SIZE: usize =
-    PUBKEY_SIZE + NAMESPACE_SIZE + 4 + 32 + 4 + 8 + TIMESTAMP_BINARY_SIZE;
+const SIGN_BYTES_FIXED_SIZE: usize = PUBKEY_SIZE + NS_SIZE + 4 + 32 + 4 + 8 + TIMESTAMP_BINARY_SIZE;
 
 /// A promise to pay for fibre blob storage.
 ///
@@ -46,8 +43,8 @@ pub struct PaymentPromise {
     pub chain_id: String,
     /// Height used to determine the validator set.
     pub height: u64,
-    /// The 29-byte namespace the blob is associated with.
-    pub namespace: Vec<u8>,
+    /// The namespace the blob is associated with.
+    pub namespace: Namespace,
     /// Upload size of the blob (with padding, without parity), matching `Blob::upload_size()`.
     pub upload_size: u32,
     /// Version of the blob format.
@@ -70,14 +67,6 @@ impl PaymentPromise {
     /// suitable for wrapping with CometBFT domain separation via
     /// [`raw_bytes_message_sign_bytes`].
     fn stripped_sign_bytes(&self) -> Result<Vec<u8>, FibreError> {
-        if self.namespace.len() != NAMESPACE_SIZE {
-            return Err(FibreError::InvalidPaymentPromise(format!(
-                "namespace must be {} bytes, got {}",
-                NAMESPACE_SIZE,
-                self.namespace.len()
-            )));
-        }
-
         let timestamp_bytes = marshal_binary_time(self.creation_timestamp)?;
 
         let mut buf = Vec::with_capacity(SIGN_BYTES_FIXED_SIZE);
@@ -88,7 +77,7 @@ impl PaymentPromise {
         buf.extend_from_slice(&pubkey_bytes);
 
         // Append namespace (29 bytes)
-        buf.extend_from_slice(&self.namespace);
+        buf.extend_from_slice(self.namespace.as_bytes());
 
         // Append blob_size (4 bytes, big-endian)
         buf.extend_from_slice(&self.upload_size.to_be_bytes());
@@ -137,7 +126,7 @@ impl PaymentPromise {
             height = self.height,
             upload_size = self.upload_size,
             blob_version = self.blob_version,
-            namespace_hex = %hex::encode(&self.namespace),
+            namespace_hex = %hex::encode(self.namespace.as_bytes()),
             commitment_hex = %hex::encode(self.commitment),
             pubkey_hex = %hex::encode(self.signer_pubkey.to_sec1_bytes().as_ref()),
             "signing payment promise"
@@ -172,15 +161,6 @@ impl PaymentPromise {
                 "chain id length {} exceeds maximum {}",
                 self.chain_id.len(),
                 MAX_CHAIN_ID_SIZE
-            )));
-        }
-
-        // Namespace must be exactly NAMESPACE_SIZE bytes
-        if self.namespace.len() != NAMESPACE_SIZE {
-            return Err(FibreError::InvalidPaymentPromise(format!(
-                "namespace must be {} bytes, got {}",
-                NAMESPACE_SIZE,
-                self.namespace.len()
             )));
         }
 
@@ -260,7 +240,8 @@ pub struct SignedPaymentPromise {
     /// The payment commitment promise that was signed by validators.
     pub promise: PaymentPromise,
     /// Signatures from validators confirming they received and stored the blob.
-    /// Ordered by validator set position; `None` entries for non-signers.
+    /// Ordered by validator set position (the on-chain code maps
+    /// `signatures[i]` to `validator[i]`); `None` entries for non-signers.
     pub validator_signatures: Vec<Option<Vec<u8>>>,
 }
 
@@ -372,7 +353,7 @@ mod tests {
         let promise = PaymentPromise {
             chain_id: "test-chain-1".to_string(),
             height: 12345,
-            namespace: vec![0u8; NAMESPACE_SIZE],
+            namespace: Namespace::from_raw(&[0u8; NS_SIZE]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
             commitment: [1u8; 32],
@@ -422,10 +403,10 @@ mod tests {
 
         // Namespace (29 bytes)
         assert_eq!(
-            &stripped[offset..offset + NAMESPACE_SIZE],
-            &promise.namespace
+            &stripped[offset..offset + NS_SIZE],
+            promise.namespace.as_bytes()
         );
-        offset += NAMESPACE_SIZE;
+        offset += NS_SIZE;
 
         // Upload size (4 bytes BE)
         assert_eq!(
@@ -490,20 +471,6 @@ mod tests {
         promise.chain_id = String::new();
         promise.sign(&signing_key).unwrap();
         assert!(promise.validate().is_err());
-    }
-
-    #[test]
-    fn validate_fails_with_wrong_namespace_length() {
-        let (signing_key, mut promise) = make_test_promise();
-        promise.namespace = vec![0u8; 10]; // wrong length
-        promise.sign(&signing_key).unwrap_err(); // stripped_sign_bytes fails
-    }
-
-    #[test]
-    fn stripped_sign_bytes_fails_with_wrong_namespace_length() {
-        let (_, mut promise) = make_test_promise();
-        promise.namespace = vec![0u8; 30]; // wrong length
-        assert!(promise.sign_bytes().is_err());
     }
 
     #[test]
@@ -630,7 +597,7 @@ mod tests {
         let mut promise = PaymentPromise {
             chain_id: "mocha-4".to_string(),
             height: 100,
-            namespace: vec![0u8; NAMESPACE_SIZE],
+            namespace: Namespace::from_raw(&[0u8; NS_SIZE]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
             commitment: [0xABu8; 32],
@@ -739,7 +706,7 @@ mod tests {
         let mut promise = PaymentPromise {
             chain_id: "mocha-4".to_string(),
             height: 100,
-            namespace: vec![0u8; NAMESPACE_SIZE],
+            namespace: Namespace::from_raw(&[0u8; NS_SIZE]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
             commitment: [0xABu8; 32],
@@ -782,7 +749,7 @@ mod tests {
         let reconstructed = PaymentPromise {
             chain_id: decoded_proto.chain_id,
             height: decoded_proto.height as u64,
-            namespace: decoded_proto.namespace,
+            namespace: Namespace::from_raw(&decoded_proto.namespace).unwrap(),
             upload_size: decoded_proto.blob_size,
             blob_version: decoded_proto.blob_version,
             commitment: decoded_proto.commitment.try_into().unwrap(),

--- a/fibre/src/roundtrip_test.rs
+++ b/fibre/src/roundtrip_test.rs
@@ -39,7 +39,7 @@ async fn upload_then_download_roundtrip() {
     let signed = client
         .upload(
             &k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng),
-            &[0u8; 29],
+            celestia_types::nmt::Namespace::from_raw(&[0u8; 29]).unwrap(),
             blob,
         )
         .await;
@@ -117,7 +117,7 @@ async fn roundtrip_with_partial_validator_failure() {
     let signed = client
         .upload(
             &k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng),
-            &[0u8; 29],
+            celestia_types::nmt::Namespace::from_raw(&[0u8; 29]).unwrap(),
             blob,
         )
         .await;

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -4,6 +4,7 @@
 //! roundtrip tests.
 
 use std::collections::HashMap;
+use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
@@ -231,18 +232,20 @@ pub(crate) fn test_blob_config() -> BlobConfig {
     BlobConfig::new_test(0, 4, 4, 4096, 4, 64)
 }
 
+/// Shorthand for building a [`Fraction`] in tests.
+pub(crate) fn fraction(numerator: u64, denominator: u64) -> Fraction {
+    Fraction::new(
+        NonZeroU64::new(numerator).unwrap(),
+        NonZeroU64::new(denominator).unwrap(),
+    )
+}
+
 /// Standard test client configuration.
 pub(crate) fn test_client_config(chain_id: &str) -> FibreClientConfig {
     FibreClientConfig {
         chain_id: chain_id.to_string(),
-        safety_threshold: Fraction {
-            numerator: 2,
-            denominator: 3,
-        },
-        liveness_threshold: Fraction {
-            numerator: 1,
-            denominator: 3,
-        },
+        safety_threshold: fraction(2, 3),
+        liveness_threshold: fraction(1, 3),
         min_rows_per_validator: 1,
         max_message_size: 1 << 20,
         upload_concurrency: 10,

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -30,7 +30,7 @@ impl From<&PaymentPromise> for proto::PaymentPromise {
         proto::PaymentPromise {
             chain_id: pp.chain_id.clone(),
             height: pp.height as i64,
-            namespace: pp.namespace.clone(),
+            namespace: pp.namespace.as_bytes().to_vec(),
             blob_size: pp.upload_size,
             blob_version: pp.blob_version,
             commitment: pp.commitment.to_vec(),
@@ -195,7 +195,7 @@ mod tests {
         let pp = PaymentPromise {
             chain_id: "test-chain".into(),
             height: 42,
-            namespace: vec![0u8; 29],
+            namespace: celestia_types::nmt::Namespace::from_raw(&[0u8; 29]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
             commitment: [7u8; 32],

--- a/fibre/src/validator/mod.rs
+++ b/fibre/src/validator/mod.rs
@@ -85,8 +85,8 @@ impl ValidatorSet {
             .map(|v| {
                 let num = (original_rows as i64)
                     * v.voting_power
-                    * (liveness_threshold.denominator as i64);
-                let den = total_voting_power * (liveness_threshold.numerator as i64);
+                    * (liveness_threshold.denominator.get() as i64);
+                let den = total_voting_power * (liveness_threshold.numerator.get() as i64);
                 let rows = ((num + den - 1) / den) as usize;
                 (rows.max(min_rows).min(original_rows), v)
             })
@@ -145,8 +145,8 @@ impl ValidatorSet {
 
         let total_voting_power = self.total_voting_power();
         let total_distributed_rows = (original_rows as i64)
-            * (liveness_threshold.denominator as i64)
-            / (liveness_threshold.numerator as i64);
+            * (liveness_threshold.denominator.get() as i64)
+            / (liveness_threshold.numerator.get() as i64);
         let min_stake = ((min_rows as i64) * total_voting_power + total_distributed_rows - 1)
             / total_distributed_rows;
 
@@ -355,10 +355,7 @@ mod assignment_tests {
     }
 
     fn default_liveness() -> Fraction {
-        Fraction {
-            numerator: 1,
-            denominator: 3,
-        }
+        crate::test_utils::fraction(1, 3)
     }
 
     #[test]
@@ -561,16 +558,7 @@ mod assignment_tests {
             *byte = (i + 1) as u8;
         }
 
-        let map = set.assign(
-            commitment,
-            16,
-            8,
-            2,
-            Fraction {
-                numerator: 1,
-                denominator: 3,
-            },
-        );
+        let map = set.assign(commitment, 16, 8, 2, crate::test_utils::fraction(1, 3));
 
         assert_eq!(map.get(0).unwrap(), &vec![3, 13, 15, 12, 1, 7, 0, 8]);
         assert_eq!(map.get(1).unwrap(), &vec![4, 10, 11, 2, 9, 14, 6, 5]);
@@ -615,10 +603,7 @@ mod selection_tests {
     }
 
     fn default_liveness() -> Fraction {
-        Fraction {
-            numerator: 1,
-            denominator: 3,
-        }
+        crate::test_utils::fraction(1, 3)
     }
 
     #[test]

--- a/fibre/src/validator/signature_set.rs
+++ b/fibre/src/validator/signature_set.rs
@@ -50,8 +50,9 @@ impl SignatureSet {
         required_bytes_signed: Vec<u8>,
     ) -> Self {
         let total_voting_power: i64 = validators.iter().map(|v| v.voting_power).sum();
-        let min_required_voting_power = total_voting_power * target_voting_power.numerator as i64
-            / target_voting_power.denominator as i64;
+        let min_required_voting_power = total_voting_power
+            * target_voting_power.numerator.get() as i64
+            / target_voting_power.denominator.get() as i64;
 
         let capacity = validators.len();
         Self {
@@ -143,6 +144,8 @@ impl ValidatorSet {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
+
+    use crate::test_utils::fraction;
     use rand::RngCore;
 
     /// Helper: generate a ValidatorInfo with a fresh ed25519 keypair.
@@ -178,14 +181,7 @@ mod tests {
         let data = b"hello world";
         let sig = sign(&sk, data);
 
-        let ss = SignatureSet::new(
-            vec![val.clone()],
-            Fraction {
-                numerator: 1,
-                denominator: 2,
-            },
-            data.to_vec(),
-        );
+        let ss = SignatureSet::new(vec![val.clone()], fraction(1, 2), data.to_vec());
 
         let result = ss.add(&val, &sig);
         assert!(result.is_ok(), "valid signature should be accepted");
@@ -199,14 +195,7 @@ mod tests {
         let (wrong_sk, _) = make_validator(10);
         let bad_sig = sign(&wrong_sk, data);
 
-        let ss = SignatureSet::new(
-            vec![val.clone()],
-            Fraction {
-                numerator: 1,
-                denominator: 2,
-            },
-            data.to_vec(),
-        );
+        let ss = SignatureSet::new(vec![val.clone()], fraction(1, 2), data.to_vec());
 
         let result = ss.add(&val, &bad_sig);
         assert!(result.is_err(), "invalid signature should be rejected");
@@ -230,10 +219,7 @@ mod tests {
 
         let ss = SignatureSet::new(
             vec![v1.clone(), v2.clone(), v3.clone()],
-            Fraction {
-                numerator: 2,
-                denominator: 3,
-            },
+            fraction(2, 3),
             data.to_vec(),
         );
 
@@ -260,10 +246,7 @@ mod tests {
 
         let ss = SignatureSet::new(
             vec![v1.clone(), v2.clone(), v3.clone()],
-            Fraction {
-                numerator: 1,
-                denominator: 3,
-            },
+            fraction(1, 3),
             data.to_vec(),
         );
 
@@ -291,14 +274,7 @@ mod tests {
 
         let data = b"fail test";
 
-        let ss = SignatureSet::new(
-            vec![v1.clone(), v2.clone()],
-            Fraction {
-                numerator: 2,
-                denominator: 3,
-            },
-            data.to_vec(),
-        );
+        let ss = SignatureSet::new(vec![v1.clone(), v2.clone()], fraction(2, 3), data.to_vec());
 
         // Only v1 signs. Total power = 10, required = 30 * 2 / 3 = 20.
         ss.add(&v1, &sign(&sk1, data)).unwrap();
@@ -324,14 +300,7 @@ mod tests {
         let (sk, v) = make_validator(25);
         let data = b"dup test";
 
-        let ss = SignatureSet::new(
-            vec![v.clone()],
-            Fraction {
-                numerator: 2,
-                denominator: 3,
-            },
-            data.to_vec(),
-        );
+        let ss = SignatureSet::new(vec![v.clone()], fraction(2, 3), data.to_vec());
 
         // min_required = 25 * 2 / 3 = 16 (integer division).
         // First add: power = 25 >= 16 => true

--- a/grpc/src/tx_client_v2/tests.rs
+++ b/grpc/src/tx_client_v2/tests.rs
@@ -369,7 +369,7 @@ impl ServerReturn {
 type ActionFunc =
     dyn for<'a> Fn(&'a RoutedCall, &mut NetworkState) -> ActionResult + Send + Sync + 'static;
 type MatchFunc = dyn for<'a> Fn(&'a RoutedCall) -> bool + Send + Sync + 'static;
-type PeriodicFunc = dyn for<'a> Fn(&mut NetworkState) + Send + Sync + 'static;
+type PeriodicFunc = dyn Fn(&mut NetworkState) + Send + Sync + 'static;
 
 struct ActionResult {
     ret: ServerReturn,
@@ -464,7 +464,7 @@ struct PeriodicCall {
 impl PeriodicCall {
     fn new<F>(call: F) -> Self
     where
-        F: for<'a> Fn(&mut NetworkState) + Send + Sync + 'static,
+        F: Fn(&mut NetworkState) + Send + Sync + 'static,
     {
         Self {
             call: Arc::new(call),
@@ -602,7 +602,7 @@ impl CallLogEntry {
     fn println(&self) {
         println!(
             "logging call: {}, {:?}, {:?}",
-            self.kind, self.seq, &self.ids
+            self.kind, self.seq, self.ids
         );
     }
 }

--- a/node/src/block_ranges.rs
+++ b/node/src/block_ranges.rs
@@ -824,6 +824,8 @@ fn calc_overlap(
 }
 
 #[cfg(test)]
+// One-element arrays here really are arrays of ranges, not a shorthand for a range of values.
+#[allow(clippy::single_range_in_vec_init)]
 mod tests {
     use super::*;
 

--- a/node/src/pruner.rs
+++ b/node/src/pruner.rs
@@ -584,6 +584,8 @@ where
 }
 
 #[cfg(test)]
+// One-element arrays here really are arrays of ranges, not a shorthand for a range of values.
+#[allow(clippy::single_range_in_vec_init)]
 mod test {
     use blockstore::block::{Block, CidError};
     use celestia_types::test_utils::ExtendedHeaderGenerator;

--- a/node/src/store.rs
+++ b/node/src/store.rs
@@ -342,6 +342,8 @@ fn to_headers_range(bounds: impl RangeBounds<u64>, last_index: u64) -> Result<Ra
 }
 
 #[cfg(test)]
+// One-element arrays here really are arrays of ranges, not a shorthand for a range of values.
+#[allow(clippy::single_range_in_vec_init)]
 mod tests {
     use super::*;
     use crate::test_utils::ExtendedHeaderGeneratorExt;

--- a/node/src/store/indexed_db_store.rs
+++ b/node/src/store/indexed_db_store.rs
@@ -976,6 +976,8 @@ mod v4 {
 }
 
 #[cfg(test)]
+// One-element arrays here really are arrays of ranges, not a shorthand for a range of values.
+#[allow(clippy::single_range_in_vec_init)]
 pub mod tests {
     use super::*;
     use crate::test_utils::ExtendedHeaderGeneratorExt;

--- a/node/src/store/redb_store.rs
+++ b/node/src/store/redb_store.rs
@@ -852,6 +852,8 @@ mod v2 {
 }
 
 #[cfg(test)]
+// One-element arrays here really are arrays of ranges, not a shorthand for a range of values.
+#[allow(clippy::single_range_in_vec_init)]
 pub mod tests {
     use super::*;
     use crate::test_utils::ExtendedHeaderGeneratorExt;

--- a/node/src/syncer.rs
+++ b/node/src/syncer.rs
@@ -768,6 +768,8 @@ async fn header_sub_recv(
 }
 
 #[cfg(test)]
+// One-element arrays here really are arrays of ranges, not a shorthand for a range of values.
+#[allow(clippy::single_range_in_vec_init)]
 mod tests {
     use std::ops::RangeInclusive;
 

--- a/node/tests/node.rs
+++ b/node/tests/node.rs
@@ -98,7 +98,10 @@ async fn peer_discovery() {
         .await
         .unwrap();
 
-    node1.wait_connected().await.unwrap();
+    timeout(Duration::from_secs(30), node1.wait_connected())
+        .await
+        .expect("node1 did not connect within 30s — is the devnet reachable? (docker compose -f ci/docker-compose.yml up)")
+        .unwrap();
 
     let node1_addrs = node1.listeners().await.unwrap();
 
@@ -111,7 +114,10 @@ async fn peer_discovery() {
         .await
         .unwrap();
 
-    node2.wait_connected().await.unwrap();
+    timeout(Duration::from_secs(30), node2.wait_connected())
+        .await
+        .expect("node2 did not connect to node1 within 30s")
+        .unwrap();
 
     // Node3
     //
@@ -122,7 +128,10 @@ async fn peer_discovery() {
         .await
         .unwrap();
 
-    node3.wait_connected().await.unwrap();
+    timeout(Duration::from_secs(30), node3.wait_connected())
+        .await
+        .expect("node3 did not connect to node1 within 30s")
+        .unwrap();
 
     let node1_peer_id = *node1.local_peer_id();
     let node2_peer_id = *node2.local_peer_id();

--- a/node/tests/utils/mod.rs
+++ b/node/tests/utils/mod.rs
@@ -86,21 +86,28 @@ where
         .await
         .unwrap();
 
-    node.wait_connected_trusted().await.unwrap();
+    timeout(Duration::from_secs(30), node.wait_connected_trusted())
+        .await
+        .expect("node did not connect within 30s — is the devnet reachable? (docker compose -f ci/docker-compose.yml up)")
+        .unwrap();
 
     // Wait until node reaches height 3
-    loop {
-        if node
-            .get_network_head_header()
-            .await
-            .unwrap()
-            .is_some_and(|head| head.height() >= 3)
-        {
-            break;
-        }
+    timeout(Duration::from_secs(60), async {
+        loop {
+            if node
+                .get_network_head_header()
+                .await
+                .unwrap()
+                .is_some_and(|head| head.height() >= 3)
+            {
+                break;
+            }
 
-        sleep(Duration::from_secs(1)).await;
-    }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .expect("node did not reach height 3 within 60s");
 
     (node, events)
 }

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -111,7 +111,8 @@ pub fn extend_rlcs(rlc_orig: &[GF128], k: usize, n: usize) -> Result<Vec<GF128>>
     }
 
     let mut shards = vec![0u8; k * 64];
-    for (dst_shard, rlc) in shards.chunks_exact_mut(64).zip(rlc_orig.iter()) {
+    let (dst_shards, _) = shards.as_chunks_mut::<64>();
+    for (dst_shard, rlc) in dst_shards.iter_mut().zip(rlc_orig.iter()) {
         let packed = pack_gf128_to_shard(rlc);
         dst_shard.copy_from_slice(&packed);
     }
@@ -121,9 +122,10 @@ pub fn extend_rlcs(rlc_orig: &[GF128], k: usize, n: usize) -> Result<Vec<GF128>>
     let (orig, parity) = extended_shards.split_at_mut(split_at);
     orig.copy_from_slice(&shards);
     fill_parity(orig, parity, k, n, 64)?;
-    Ok(extended_shards
-        .chunks_exact(64)
-        .map(unpack_shard_to_gf128)
+    let (extended, _) = extended_shards.as_chunks::<64>();
+    Ok(extended
+        .iter()
+        .map(|shard| unpack_shard_to_gf128(shard))
         .collect())
 }
 

--- a/types/src/blob/commitment.rs
+++ b/types/src/blob/commitment.rs
@@ -317,11 +317,7 @@ fn round_up_to_power_of_2(x: u64) -> Option<u64> {
         if po2 >= x {
             return Some(po2);
         }
-        if let Some(next_po2) = po2.checked_shl(1) {
-            po2 = next_po2;
-        } else {
-            return None;
-        }
+        po2 = po2.checked_shl(1)?;
     }
 }
 


### PR DESCRIPTION
## Overview

Use existing `Namespace`, `AccAddress`. Use `NonZeroU64` to have non-zero checks to be done at the conversion edge.
