### PR TITLE
chore: pin rust toolchain to make PRs stable across toolchain updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Setup toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: rustfmt
+        # this disables default behavior of `setup-rust-toolchain` to put `-D warnings` which overwrites `.cargo/config.toml`
+        rustflags: ""
+
     - name: Run fmt
       run: cargo fmt -- --check
 
@@ -229,11 +237,13 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         components: clippy
-        # TODO: pinned due to https://gitlab.com/ijackson/rust-shellexpand/-/issues/13
-        toolchain: nightly-2026-02-01, stable
         target: wasm32-unknown-unknown
         # this disables default behavior of `setup-rust-toolchain` to put `-D warnings` which overwrites `.cargo/config.toml`
         rustflags: ""
+
+    # TODO: pinned due to https://gitlab.com/ijackson/rust-shellexpand/-/issues/13
+    - name: Install nightly for rustdoc
+      run: rustup toolchain install --profile minimal nightly-2026-02-01
 
     - name: Missing docs for native
       run: cargo clippy --workspace --all-features -- -D missing-docs

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -15,11 +15,16 @@ let
     "aarch64-apple-ios-sim"
   ];
 
+  # keep the devshell on the same rustc as CI
+  channel = (lib.importTOML ../rust-toolchain.toml).toolchain.channel;
+  # hash of the rust dist manifest for `channel`; nix prints the correct value on mismatch
+  channelSha256 = "sha256-P30Tm3O7vQAE725YtDCDHGjNrSsfZO4us11UwJGZSJo=";
+
   rustToolchain =
     with pkgs;
     fenix.combine [
       # components
-      (fenix.stable.withComponents [
+      ((fenix.toolchainOf { inherit channel; sha256 = channelSha256; }).withComponents [
         "cargo"
         "clippy"
         "rustc"
@@ -27,14 +32,16 @@ let
         "rust-analyzer"
       ])
       # extra targets
-      (lib.lists.map (target: fenix.targets."${target}".stable.rust-std) extraTargets)
+      (lib.lists.map (
+        target: (fenix.targets."${target}".toolchainOf { inherit channel; sha256 = channelSha256; }).rust-std
+      ) extraTargets)
     ];
 
   # rustup-like-ish wrapper for cargo to allow `+nightly` syntax
   cargoWrapper =
     with pkgs;
     writeShellScriptBin "cargo" ''
-      if [ "$1" == "+nightly" ]; then
+      if [[ "$1" == +nightly* ]]; then
           shift
           exec env PATH="${fenix.minimal.toolchain}/bin:$PATH" cargo "$@"
       fi

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Overview

Toolchain updates become deliberate. This can be automated with simple claude/codex command and be done quickly. But it will be done **at our cadence**, so no PRs will randomly start getting failed CI, because stable rust toolchain has been updated and now new clippy errors are surfaced. 