### PR TITLE
chore(ci): add retries to devnet

### DIFF
--- a/.github/actions/local-devnet-logs/action.yml
+++ b/.github/actions/local-devnet-logs/action.yml
@@ -1,0 +1,21 @@
+name: Dump local celestia devnet logs
+description: Prints the state of the devnet and uploads container logs as an artifact. Meant to be used on failure.
+inputs:
+  artifact-name:
+    description: Name of the artifact with the logs
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Dump devnet state
+      shell: bash
+      run: |
+        docker compose -f ci/docker-compose.yml ps --all || true
+        docker compose -f ci/docker-compose.yml logs --no-color --timestamps > "${{ runner.temp }}/devnet-logs.txt" || true
+
+    - name: Upload devnet logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/devnet-logs.txt
+        if-no-files-found: ignore

--- a/.github/actions/local-devnet/action.yml
+++ b/.github/actions/local-devnet/action.yml
@@ -5,41 +5,26 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Cache Docker layers
-      uses: actions/cache@v4
-      with:
-        path: ${{ runner.temp }}/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ hashFiles('./ci/Dockerfile*', './ci/*.yml', './ci/*.sh') }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
     - name: Build the docker-compose stack
       shell: bash
       run: |
-        mkdir -p ${{ runner.temp }}/.buildx-cache-new
         cd ci
         for image in "validator" "node" "grpcwebproxy"; do
           docker buildx build \
             --file "Dockerfile.$image" \
             --tag "$image" \
             --load \
-            --cache-from="type=local,src=${{ runner.temp }}/.buildx-cache/$image" \
-            --cache-to="type=local,dest=${{ runner.temp }}/.buildx-cache-new/$image" \
+            --cache-from="type=gha,scope=devnet-$image" \
+            --cache-to="type=gha,mode=max,scope=devnet-$image" \
             . &
         done
         wait $(jobs -p)
 
-    # Needed because otherwise cache would grow infinitely
-    # https://github.com/moby/buildkit/issues/1896
-    - name: Overwrite cache
-      shell: bash
-      run: |
-        rm -rf ${{ runner.temp }}/.buildx-cache
-        mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
-
     - name: Run the docker-compose stack
       shell: bash
-      run: docker compose -f ci/docker-compose.yml up --no-build -d
+      # --wait fails if any service exits or becomes unhealthy,
+      # instead of hanging until the job timeout
+      run: docker compose -f ci/docker-compose.yml up --no-build -d --wait --wait-timeout 180
 
     - name: Generate auth tokens
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `devnet: true` for crates whose tests talk to the local celestia devnet
         crate:
-          - celestia-proto
-          - celestia-types
-          - celestia-rpc
-          - celestia-grpc
-          - celestia-grpc-macros
-          - celestia-client
-          - lumina-node
-          - lumina-node-wasm
-          - lumina-utils
-          - lumina-cli
+          - name: celestia-proto
+          - name: celestia-types
+          - name: celestia-rpc
+            devnet: true
+          - name: celestia-grpc
+            devnet: true
+          - name: celestia-grpc-macros
+          - name: celestia-client
+            devnet: true
+          - name: lumina-node
+            devnet: true
+          - name: lumina-node-wasm
+            devnet: true
+          - name: lumina-utils
+          - name: lumina-cli
 
     steps:
     - uses: actions/checkout@v4
@@ -80,23 +86,30 @@ jobs:
     - name: Setup toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        cache-key: ${{ matrix.crate }}
+        cache-key: ${{ matrix.crate.name }}
 
     - name: Celestia devnet
+      if: matrix.crate.devnet
       uses: ./.github/actions/local-devnet
 
     - name: Run tests
       env:
-        LUMINA_TEST_LOG: ${{ github.workspace }}/test-${{ matrix.crate }}.log
-      run: cargo test --all-features -p ${{ matrix.crate }}
+        LUMINA_TEST_LOG: ${{ github.workspace }}/test-${{ matrix.crate.name }}.log
+      run: cargo test --all-features -p ${{ matrix.crate.name }}
 
     - name: Upload test logs
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-logs-${{ matrix.crate }}
-        path: test-${{ matrix.crate }}.log
+        name: test-logs-${{ matrix.crate.name }}
+        path: test-${{ matrix.crate.name }}.log
         if-no-files-found: ignore
+
+    - name: Dump devnet logs
+      if: failure() && matrix.crate.devnet
+      uses: ./.github/actions/local-devnet-logs
+      with:
+        artifact-name: devnet-logs-test-${{ matrix.crate.name }}
 
 
   test-wasm:
@@ -105,6 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `devnet: true` for crates whose tests talk to the local celestia devnet
         crate:
           - name: celestia-proto
             dir: proto
@@ -114,17 +128,22 @@ jobs:
           - name: celestia-rpc
             dir: rpc
             wasm-pack-test-flags: --features=wasm-bindgen
+            devnet: true
           - name: celestia-grpc
             dir: grpc
+            devnet: true
           - name: celestia-client
             dir: client
+            devnet: true
           - name: lumina-node
             dir: node
+            devnet: true
           - name: lumina-node-wasm
             dir: node-wasm
             # We're running node-wasm tests in release mode to get around a failing debug assertion
             # https://github.com/libp2p/rust-libp2p/issues/5618
             wasm-pack-test-flags: --release
+            devnet: true
           - name: lumina-utils
             dir: utils
 
@@ -149,10 +168,17 @@ jobs:
       uses: nanasess/setup-chromedriver@v2
 
     - name: Celestia devnet
+      if: matrix.crate.devnet
       uses: ./.github/actions/local-devnet
 
     - name: Run wasm-pack tests
       run: wasm-pack test --headless --chrome ${{ matrix.crate.dir }}  ${{ matrix.crate.wasm-pack-test-flags }}
+
+    - name: Dump devnet logs
+      if: failure() && matrix.crate.devnet
+      uses: ./.github/actions/local-devnet-logs
+      with:
+        artifact-name: devnet-logs-test-wasm-${{ matrix.crate.name }}
 
 
   build-wasm:
@@ -208,6 +234,12 @@ jobs:
 
     - name: Run javascript tests
       run: npm test
+
+    - name: Dump devnet logs
+      if: failure()
+      uses: ./.github/actions/local-devnet-logs
+      with:
+        artifact-name: devnet-logs-test-js
 
 
   fmt:

--- a/ci/Dockerfile.grpcwebproxy
+++ b/ci/Dockerfile.grpcwebproxy
@@ -1,8 +1,9 @@
-FROM docker.io/alpine:3.19.1
+FROM docker.io/alpine:3.20
 
 RUN apk update && apk add --no-cache wget unzip
 
-RUN wget -O grpcwebproxy.zip https://github.com/improbable-eng/grpc-web/releases/download/v0.15.0/grpcwebproxy-v0.15.0-linux-x86_64.zip && \
+# retry the download, github release assets are occasionally flaky in CI
+RUN wget --tries=5 --waitretry=5 --retry-connrefused -O grpcwebproxy.zip https://github.com/improbable-eng/grpc-web/releases/download/v0.15.0/grpcwebproxy-v0.15.0-linux-x86_64.zip && \
   unzip grpcwebproxy.zip && \
   mv dist/grpcwebproxy* /usr/local/bin/grpcwebproxy && \
   rm grpcwebproxy.zip

--- a/ci/Dockerfile.node
+++ b/ci/Dockerfile.node
@@ -10,6 +10,7 @@ COPY --from=ghcr.io/celestiaorg/celestia-node:v0.30.2 /bin/celestia /bin/celesti
 COPY --from=ghcr.io/celestiaorg/celestia-node:v0.30.2 /bin/cel-key /bin/cel-key
 
 COPY ./run-node.sh /opt/entrypoint.sh
+COPY ./healthcheck-node.sh /opt/healthcheck.sh
 
 #  2121 is the default node port for p2p connectivity
 # 26658 is the port used by RPC

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -6,12 +6,13 @@ services:
       context: .
       dockerfile: Dockerfile.validator
     environment:
+      - NO_COLOR=1
       # amount of DA nodes to provision (default: 3)
       - NODE_COUNT=3
     ports:
-      - 19090:9090 # grpc
+      - 127.0.0.1:19090:9090 # grpc
       # TODO: uncomment and remove grpcwebproxy below, once CORS works with built-in grpc-web
-      #- 18080:1317 # grpc-web
+      #- 127.0.0.1:18080:1317 # grpc-web
     volumes: &vols
       - credentials:/credentials
       - genesis:/genesis
@@ -19,7 +20,8 @@ services:
       # wait for validator to fund all keys
       test: celestia-appd query block --type height 5
       interval: 1s
-      timeout: 60s
+      timeout: 10s
+      start_period: 10s
       retries: 60
 
   grpcwebproxy:
@@ -30,7 +32,10 @@ services:
       dockerfile: Dockerfile.grpcwebproxy
     command: --backend_addr=validator:9090 --run_tls_server=false --allow_all_origins
     ports:
-      - 18080:8080
+      - 127.0.0.1:18080:8080
+    depends_on:
+      validator:
+        condition: service_healthy
     # just so we can count it as healthy
     healthcheck:
       test: "true"
@@ -43,6 +48,7 @@ services:
       context: .
       dockerfile: Dockerfile.node
     environment:
+      - NO_COLOR=1
       # id of the DA node (default: 0)
       # each node should have a next natural number starting from 0
       - NODE_ID=0
@@ -52,14 +58,19 @@ services:
       # setting SKIP_AUTH to true disables the use of JWT for authentication
       - SKIP_AUTH=true
     ports:
-      - 26658:26658
+      - 127.0.0.1:26658:26658
     volumes: *vols
+    depends_on:
+      validator:
+        condition: service_healthy
     healthcheck: &healthcheck-node
-      # wait for the node to start json-rpc server
-      test: celestia header local-head
+      # wait for the node to start json-rpc server and sync a few headers.
+      # tests wait for height >= 3 anyway, so don't report healthy before that.
+      test: /opt/healthcheck.sh 3
       interval: 1s
-      timeout: 60s
-      retries: 60
+      timeout: 10s
+      start_period: 20s
+      retries: 90
 
   node-1:
     image: node
@@ -68,10 +79,16 @@ services:
       context: .
       dockerfile: Dockerfile.node
     environment:
+      - NO_COLOR=1
       - NODE_ID=1
     ports:
-      - 36658:26658
+      - 127.0.0.1:36658:26658
     volumes: *vols
+    depends_on: &depends-on-node-0
+      validator:
+        condition: service_healthy
+      node-0:
+        condition: service_healthy
     healthcheck: *healthcheck-node
 
   node-2:
@@ -81,12 +98,14 @@ services:
       context: .
       dockerfile: Dockerfile.node
     environment:
+      - NO_COLOR=1
       - NODE_ID=2
       - NODE_TYPE=light
       - SKIP_AUTH=true
     ports:
-      - 46658:26658
+      - 127.0.0.1:46658:26658
     volumes: *vols
+    depends_on: *depends-on-node-0
     healthcheck: *healthcheck-node
 
   # Uncomment for another nodes
@@ -98,10 +117,12 @@ services:
   #     context: .
   #     dockerfile: Dockerfile.node
   #   environment:
+  #     - NO_COLOR=1
   #     - NODE_ID=3
   #   ports:
-  #     - 46658:26658
+  #     - 127.0.0.1:56658:26658
   #   volumes: *vols
+  #   depends_on: *depends-on-node-0
   #   healthcheck: *healthcheck-node
 
   # This validator is started as a separate network, only to be able to test
@@ -114,6 +135,7 @@ services:
       context: .
       dockerfile: Dockerfile.validator
     environment:
+      - NO_COLOR=1
       - P2P_NETWORK=private-eviction-testing
       # amount of DA nodes to provision (default: 3)
       - NODE_COUNT=3
@@ -123,8 +145,12 @@ services:
       - SQUARE_SIZE=64
       - MEMPOOL_TX_TTL=1
     ports:
-      - 29090:9090
+      - 127.0.0.1:29090:9090
     volumes: *vols
+    # it reuses the keys created by the main validator
+    depends_on:
+      validator:
+        condition: service_healthy
     healthcheck: *healthcheck-validator
 
 volumes:

--- a/ci/healthcheck-node.sh
+++ b/ci/healthcheck-node.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Healthcheck for a DA node: reports healthy only once the node's RPC is up
+# and it has synced at least the given number of headers (default: 3).
+set -euo pipefail
+
+target_height="${1:-3}"
+# admin token written by the entrypoint before the node starts.
+# nodes with skip-auth accept it as well.
+token="$(tail -n 1 "/credentials/node-${NODE_ID:-0}.jwt")"
+url="http://localhost:26658"
+
+height="$(celestia header network-head --token "$token" --url "$url" 2>/dev/null \
+  | jq -r '.result.header.height // empty')"
+
+if [[ -z "$height" ]]; then
+  echo "rpc not ready" >&2
+  exit 1
+fi
+
+if (( height < target_height )); then
+  echo "network head is $height, waiting for $target_height" >&2
+  exit 1
+fi
+
+# the header at the target height must be retrievable, not just announced
+celestia header get-by-height "$target_height" --token "$token" --url "$url" >/dev/null

--- a/ci/run-node.sh
+++ b/ci/run-node.sh
@@ -57,16 +57,39 @@ whitelist_localhost_nodes() {
 
 write_jwt_token() {
   echo "Saving jwt token to $NODE_JWT_FILE"
-  celestia "$NODE_TYPE" auth admin --p2p.network "$P2P_NETWORK" > "$NODE_JWT_FILE"
+  # `CELESTIA_CUSTOM` makes the cli print a warning to stdout, keep only the token
+  celestia "$NODE_TYPE" auth admin --p2p.network "$P2P_NETWORK" | tail -n 1 > "$NODE_JWT_FILE"
+}
+
+# Retries the given command until it succeeds or the attempts run out
+retry() {
+  local attempts="$1"
+  shift
+
+  for (( i = 1; i <= attempts; i++ )); do
+    if "$@"; then
+      return 0
+    fi
+    echo "Attempt $i/$attempts of '$*' failed, retrying" >&2
+    sleep 1
+  done
+
+  echo "'$*' did not succeed after $attempts attempts" >&2
+  return 1
 }
 
 common_node_addr() {
   local peer_id
 
-  # wait for node to spin up
-  sleep 4
-  # get PeerId of the common node
-  celestia p2p info --token skip-auth --url 'ws://node-0:26658' | jq -r '.result.id'
+  # get PeerId of the common node. `depends_on` in docker-compose ensures
+  # node-0 is healthy before we start, but keep retrying just in case
+  peer_id="$(retry 30 celestia p2p info --token skip-auth --url 'ws://node-0:26658' | jq -r '.result.id')"
+  if [[ -z "$peer_id" || "$peer_id" == null ]]; then
+    echo "Could not get the peer id of node-0" >&2
+    return 1
+  fi
+
+  echo "$peer_id"
 }
 
 main() {
@@ -96,9 +119,10 @@ main() {
     if [ "$NODE_TYPE" == bridge ]; then
       # this should run in background after node is started
       (
+        # wait for our own node to start its rpc, then connect
         sleep 4
         echo "Connecting to common $peer_id node"
-        celestia p2p connect "$peer_id" /dns/node-0/tcp/2121
+        retry 30 celestia p2p connect "$peer_id" /dns/node-0/tcp/2121
       )&
     else
       extra_flags+=( --headers.trusted-peers "/dns/node-0/tcp/2121/p2p/$peer_id" )

--- a/tools/gen_auth_tokens.sh
+++ b/tools/gen_auth_tokens.sh
@@ -5,13 +5,16 @@ DOTENV=".env"
 DOTENV_SAMPLE=".env.sample"
 DOCKER_COMPOSE_FILE="./ci/docker-compose.yml"
 
+# how long to wait for all services to become healthy, in seconds
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-180}"
+
 wait_for_docker_setup() {
   local services_expected
   services_expected="$(docker compose -f "$DOCKER_COMPOSE_FILE" config --services | wc -l)"
 
   printf "Waiting for docker compose services"
 
-  while :; do
+  for (( elapsed = 0; elapsed <= WAIT_TIMEOUT; elapsed++ )); do
     local status
     local healthy
     local starting
@@ -27,12 +30,21 @@ wait_for_docker_setup() {
       echo ""
       echo "Some services crashed or are unhealthy" >&2
       docker compose -f "$DOCKER_COMPOSE_FILE" ps --all
+      docker compose -f "$DOCKER_COMPOSE_FILE" logs --tail 100
       exit 1
     fi
 
     printf "."
     sleep 1
   done
+
+  if (( healthy != services_expected )); then
+    echo ""
+    echo "Services did not become healthy within ${WAIT_TIMEOUT}s" >&2
+    docker compose -f "$DOCKER_COMPOSE_FILE" ps --all
+    docker compose -f "$DOCKER_COMPOSE_FILE" logs --tail 100
+    exit 1
+  fi
 
   echo ""
   echo "All services healthy"


### PR DESCRIPTION
## Overview

Make devnet containers start to be more robust.

0. change caching to use `--cache-to="type=gha` as docker arguments.
1. Start containers in the right order. rely on container healthchecks for that.
2. "Healthy" now means "actually working". Before, a node was healthy as soon as its RPC port answered. Now it is healthy only after it has synced 3 blocks. Same we did at soveregin-sdk
3. Fail fast instead of hanging. Before, if a container crashed during setup, the wait script could loop forever until the job timed out. Now docker compose up --wait stops with an error within seconds.
4. Save logs when something breaks. On any failure (during setup or during tests) CI now uploads the container logs as an artifact. This is the change that would have let us understand the main failure from the report.
5. Don't start the devnet where it isn't needed. Five crates (proto, types, grpc-macros, utils, cli) have no tests that talk to the devnet, but CI still built and started it for them. Now it's skipped there.
6. Small hardening. Retry the grpcwebproxy download (it failed once on a TLS hiccup), bind ports to 127.0.0.1 only, retry instead of sleep when nodes connect to each other, simpler buildx caching.
7. A bug found on the way. The node-N.jwt files contained a warning line before the token. Nothing read them before, so nobody noticed.

Also created follow up issue: https://github.com/celestiaorg/lumina/issues/987