### PR TITLE
perf(fibre): zero copy rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bech32",
+ "bytes",
  "celestia-grpc",
  "celestia-proto",
  "celestia-types",
@@ -763,6 +764,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "k256",
+ "libc",
  "lumina-utils",
  "prost",
  "rand 0.8.5",
@@ -4893,6 +4895,7 @@ dependencies = [
 name = "rsema1d"
 version = "1.1.0-rc.1"
 dependencies = [
+ "bytes",
  "criterion",
  "getrandom 0.2.17",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,6 @@ version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bech32",
- "bytes",
  "celestia-grpc",
  "celestia-proto",
  "celestia-types",
@@ -764,7 +763,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "k256",
- "libc",
  "lumina-utils",
  "prost",
  "rand 0.8.5",

--- a/fibre/Cargo.toml
+++ b/fibre/Cargo.toml
@@ -38,6 +38,7 @@ tonic = { workspace = true, features = ["codegen"] }
 tower = { version = "0.5.2", features = ["util"] }
 x509-parser = "0.17"
 prost.workspace = true
+bytes.workspace = true
 tendermint-proto.workspace = true
 
 # Error handling and utilities

--- a/fibre/Cargo.toml
+++ b/fibre/Cargo.toml
@@ -38,7 +38,6 @@ tonic = { workspace = true, features = ["codegen"] }
 tower = { version = "0.5.2", features = ["util"] }
 x509-parser = "0.17"
 prost.workspace = true
-bytes.workspace = true
 tendermint-proto.workspace = true
 
 # Error handling and utilities

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -308,6 +308,50 @@ fn bench_parse_download_response(c: &mut Criterion) {
     group.finish();
 }
 
+/// Upload path: building one validator's `UploadShardRequest` from row
+/// proofs and serialising it with prost, i.e. everything between `blob.row()`
+/// and the bytes handed to the HTTP/2 layer. Measured per shard of 148 rows
+/// on a 128MB blob (32 KiB rows), the production shape: the request body is
+/// ~4.7 MiB, so this is dominated by how many times the row data is copied.
+fn bench_upload_shard_encode(c: &mut Criterion) {
+    use prost::Message;
+
+    let mut group = c.benchmark_group("upload_shard_encode");
+    group.measurement_time(CHEAP_MEASUREMENT);
+    group.noise_threshold(0.03);
+
+    let blob = Blob::new(
+        &generate_data(BlobConfig::v0().max_data_size),
+        BlobConfig::v0(),
+    )
+    .unwrap();
+    let rlcs = blob.rlc_coeffs().unwrap().to_vec();
+    let shard = rows_per_shard();
+    let rows: Vec<usize> = (0..shard).collect();
+
+    let request = |proofs: &[rsema1d::RowInclusionProof]| proto::UploadShardRequest {
+        promise: None,
+        shard: Some(proto_conv::build_upload_shard(proofs, &rlcs)),
+    };
+    let wire_len = {
+        let proofs: Vec<_> = rows.iter().map(|&i| blob.row(i).unwrap()).collect();
+        request(&proofs).encoded_len()
+    };
+    group.throughput(Throughput::Bytes(wire_len as u64));
+
+    group.bench_function(
+        BenchmarkId::new("proofs_build_encode", "shard_148_rows_128MB"),
+        |b| {
+            b.iter(|| {
+                let proofs: Vec<_> = rows.iter().map(|&i| blob.row(i).unwrap()).collect();
+                request(black_box(&proofs)).encode_to_vec()
+            });
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_blob_new,
@@ -315,6 +359,7 @@ criterion_group!(
     bench_payment_promise,
     bench_signature_set,
     bench_validator_assign,
-    bench_parse_download_response
+    bench_parse_download_response,
+    bench_upload_shard_encode
 );
 criterion_main!(benches);

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -294,10 +294,7 @@ fn bench_parse_download_response(c: &mut Criterion) {
         .flat_map(|rlc| rlc.to_bytes())
         .collect();
     let response = proto::DownloadShardResponse {
-        shard: Some(proto::BlobShard {
-            rows,
-            rlcs: rlcs.into(),
-        }),
+        shard: Some(proto::BlobShard { rows, rlcs }),
     };
 
     group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {
@@ -311,11 +308,8 @@ fn bench_parse_download_response(c: &mut Criterion) {
     group.finish();
 }
 
-/// Upload path: building one validator's `UploadShardRequest` from row
-/// proofs and serialising it with prost, i.e. everything between `blob.row()`
-/// and the bytes handed to the HTTP/2 layer. Measured per shard of 148 rows
-/// on a 128MB blob (32 KiB rows), the production shape: the request body is
-/// ~4.7 MiB, so this is dominated by how many times the row data is copied.
+/// Upload path from row proof generation through protobuf encoding for one
+/// production-sized validator shard from a maximum-sized blob.
 fn bench_upload_shard_encode(c: &mut Criterion) {
     use prost::Message;
 
@@ -323,30 +317,41 @@ fn bench_upload_shard_encode(c: &mut Criterion) {
     group.measurement_time(CHEAP_MEASUREMENT);
     group.noise_threshold(0.03);
 
-    let blob = Blob::new(
+    let blob = EncodedBlob::new(
         &generate_data(BlobConfig::v0().max_data_size),
         BlobConfig::v0(),
     )
     .unwrap();
-    let rlcs = blob.rlc_coeffs().unwrap().to_vec();
+    let rlcs = blob.rlc_coeffs().to_vec();
     let shard = rows_per_shard();
-    let rows: Vec<usize> = (0..shard).collect();
 
-    let request = |proofs: &[rsema1d::RowInclusionProof]| proto::UploadShardRequest {
-        promise: None,
-        shard: Some(proto_conv::build_upload_shard(proofs, &rlcs)),
+    let request = |proofs: &[rsema1d::RowInclusionProof]| {
+        let rows = proofs
+            .iter()
+            .map(|proof| proto::BlobRow {
+                index: proof.index as u32,
+                data: proof.row.clone(),
+                proof: proof.row_proof.iter().map(|hash| hash.to_vec()).collect(),
+            })
+            .collect();
+        let rlcs = rlcs.iter().flat_map(|rlc| rlc.to_bytes()).collect();
+
+        proto::UploadShardRequest {
+            promise: None,
+            shard: Some(proto::BlobShard { rows, rlcs }),
+        }
     };
     let wire_len = {
-        let proofs: Vec<_> = rows.iter().map(|&i| blob.row(i).unwrap()).collect();
+        let proofs: Vec<_> = (0..shard).map(|i| blob.row(i).unwrap()).collect();
         request(&proofs).encoded_len()
     };
     group.throughput(Throughput::Bytes(wire_len as u64));
 
     group.bench_function(
-        BenchmarkId::new("proofs_build_encode", "shard_148_rows_128MB"),
+        BenchmarkId::new("proofs_build_encode", format!("shard_{shard}_rows_128MB")),
         |b| {
             b.iter(|| {
-                let proofs: Vec<_> = rows.iter().map(|&i| blob.row(i).unwrap()).collect();
+                let proofs: Vec<_> = (0..shard).map(|i| blob.row(i).unwrap()).collect();
                 request(black_box(&proofs)).encode_to_vec()
             });
         },

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -294,7 +294,10 @@ fn bench_parse_download_response(c: &mut Criterion) {
         .flat_map(|rlc| rlc.to_bytes())
         .collect();
     let response = proto::DownloadShardResponse {
-        shard: Some(proto::BlobShard { rows, rlcs }),
+        shard: Some(proto::BlobShard {
+            rows,
+            rlcs: rlcs.into(),
+        }),
     };
 
     group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -454,7 +454,9 @@ mod tests {
             for row in 0..total_rows {
                 let mut proof = blob.row(row).unwrap();
                 if i == 0 {
-                    proof.row[0] ^= 1;
+                    let mut corrupted = proof.row.to_vec();
+                    corrupted[0] ^= 1;
+                    proof.row = corrupted.into();
                 }
                 proofs.push(proof);
             }
@@ -509,7 +511,7 @@ mod tests {
                     let proof = blob.row(index).unwrap();
                     rsema1d::RowProof {
                         index: proof.index,
-                        row: std::borrow::Cow::Owned(proof.row),
+                        row: std::borrow::Cow::Owned(proof.row.to_vec()),
                         row_proof: proof.row_proof,
                     }
                 })

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -601,7 +601,7 @@ mod tests {
                     let proof = blob.row(i).unwrap();
                     rsema1d::RowProof {
                         index: proof.index,
-                        row: std::borrow::Cow::Owned(proof.row),
+                        row: std::borrow::Cow::Owned(proof.row.to_vec()),
                         row_proof: proof.row_proof,
                     }
                 })

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -103,7 +103,7 @@ impl MockValidatorConnection {
             .rows
             .extend(proofs.into_iter().map(|proof| rsema1d::RowProof {
                 index: proof.index,
-                row: Cow::Owned(proof.row),
+                row: Cow::Owned(proof.row.to_vec()),
                 row_proof: proof.row_proof,
             }));
         entry.rlcs = rlcs;

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -79,7 +79,8 @@ pub(crate) fn blob_row_to_row_proof(
 ///
 /// Shards carry the RLC vector of the K original rows (16 bytes per row) so
 /// the validator can verify each row without having enough rows to reconstruct.
-pub(crate) fn build_upload_shard(
+#[doc(hidden)]
+pub fn build_upload_shard(
     proofs: &[rsema1d::RowInclusionProof],
     rlc_vector: &[rsema1d::GF128],
 ) -> proto::BlobShard {

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -70,7 +70,7 @@ pub(crate) fn blob_row_to_row_proof(
 
     Ok(rsema1d::RowProof {
         index: row.index as usize,
-        row: std::borrow::Cow::Owned(row.data),
+        row: std::borrow::Cow::Owned(row.data.into()),
         row_proof,
     })
 }
@@ -92,7 +92,10 @@ pub fn build_upload_shard(
         rlcs.extend_from_slice(&rlc.to_bytes());
     }
 
-    proto::BlobShard { rows, rlcs }
+    proto::BlobShard {
+        rows,
+        rlcs: rlcs.into(),
+    }
 }
 
 /// Parse a proto [`proto::DownloadShardResponse`] into a [`DownloadResponse`].
@@ -216,7 +219,7 @@ mod tests {
     fn row_proof_blob_row_roundtrip() {
         let proof = rsema1d::RowInclusionProof {
             index: 5,
-            row: vec![42u8; 64],
+            row: vec![42u8; 64].into(),
             row_proof: vec![[1u8; 32], [2u8; 32]],
             rlc_root: [3u8; 32],
         };
@@ -236,7 +239,7 @@ mod tests {
     fn blob_row_to_row_proof_invalid_hash_length() {
         let row = proto::BlobRow {
             index: 0,
-            data: vec![0u8; 64],
+            data: vec![0u8; 64].into(),
             proof: vec![vec![0u8; 31]], // wrong length
         };
         let result = blob_row_to_row_proof(row);
@@ -247,7 +250,7 @@ mod tests {
     fn build_upload_shard_includes_rlc_vector() {
         let proofs = vec![rsema1d::RowInclusionProof {
             index: 0,
-            row: vec![0u8; 64],
+            row: vec![0u8; 64].into(),
             row_proof: vec![[0u8; 32]],
             rlc_root: [0u8; 32],
         }];
@@ -264,10 +267,10 @@ mod tests {
             shard: Some(proto::BlobShard {
                 rows: vec![proto::BlobRow {
                     index: 3,
-                    data: vec![1u8; 64],
+                    data: vec![1u8; 64].into(),
                     proof: vec![vec![2u8; 32]],
                 }],
-                rlcs: vec![9u8; 32], // 2 RLC values
+                rlcs: vec![9u8; 32].into(), // 2 RLC values
             }),
         };
 
@@ -288,7 +291,10 @@ mod tests {
     fn parse_download_response_invalid_rlc_length() {
         for rlcs in [vec![], vec![1u8; 15]] {
             let resp = proto::DownloadShardResponse {
-                shard: Some(proto::BlobShard { rows: vec![], rlcs }),
+                shard: Some(proto::BlobShard {
+                    rows: vec![],
+                    rlcs: rlcs.into(),
+                }),
             };
             assert!(parse_download_response(resp).is_err());
         }

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -79,8 +79,7 @@ pub(crate) fn blob_row_to_row_proof(
 ///
 /// Shards carry the RLC vector of the K original rows (16 bytes per row) so
 /// the validator can verify each row without having enough rows to reconstruct.
-#[doc(hidden)]
-pub fn build_upload_shard(
+pub(crate) fn build_upload_shard(
     proofs: &[rsema1d::RowInclusionProof],
     rlc_vector: &[rsema1d::GF128],
 ) -> proto::BlobShard {
@@ -92,10 +91,7 @@ pub fn build_upload_shard(
         rlcs.extend_from_slice(&rlc.to_bytes());
     }
 
-    proto::BlobShard {
-        rows,
-        rlcs: rlcs.into(),
-    }
+    proto::BlobShard { rows, rlcs }
 }
 
 /// Parse a proto [`proto::DownloadShardResponse`] into a [`DownloadResponse`].
@@ -270,7 +266,7 @@ mod tests {
                     data: vec![1u8; 64].into(),
                     proof: vec![vec![2u8; 32]],
                 }],
-                rlcs: vec![9u8; 32].into(), // 2 RLC values
+                rlcs: vec![9u8; 32], // 2 RLC values
             }),
         };
 
@@ -291,10 +287,7 @@ mod tests {
     fn parse_download_response_invalid_rlc_length() {
         for rlcs in [vec![], vec![1u8; 15]] {
             let resp = proto::DownloadShardResponse {
-                shard: Some(proto::BlobShard {
-                    rows: vec![],
-                    rlcs: rlcs.into(),
-                }),
+                shard: Some(proto::BlobShard { rows: vec![], rlcs }),
             };
             assert!(parse_download_response(resp).is_err());
         }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -280,7 +280,6 @@ fn prost_build(fds: FileDescriptorSet) {
         .bytes([
             ".tendermint_celestia_mods.abci",
             ".celestia.fibre.v1.BlobRow.data",
-            ".celestia.fibre.v1.BlobShard.rlcs",
         ])
         .compile_fds(fds)
         .expect("prost failed");
@@ -302,7 +301,6 @@ fn tonic_build(fds: FileDescriptorSet) {
         .bytes([
             ".tendermint_celestia_mods.abci",
             ".celestia.fibre.v1.BlobRow.data",
-            ".celestia.fibre.v1.BlobShard.rlcs",
         ]);
 
     for (type_path, attr) in CUSTOM_TYPE_ATTRIBUTES {

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -277,7 +277,11 @@ fn prost_build(fds: FileDescriptorSet) {
     config
         .include_file("mod.rs")
         .enable_type_names()
-        .bytes([".tendermint_celestia_mods.abci"])
+        .bytes([
+            ".tendermint_celestia_mods.abci",
+            ".celestia.fibre.v1.BlobRow.data",
+            ".celestia.fibre.v1.BlobShard.rlcs",
+        ])
         .compile_fds(fds)
         .expect("prost failed");
 }
@@ -295,7 +299,11 @@ fn tonic_build(fds: FileDescriptorSet) {
         .use_arc_self(true)
         .compile_well_known_types(true)
         .skip_protoc_run()
-        .bytes([".tendermint_celestia_mods.abci"]);
+        .bytes([
+            ".tendermint_celestia_mods.abci",
+            ".celestia.fibre.v1.BlobRow.data",
+            ".celestia.fibre.v1.BlobShard.rlcs",
+        ]);
 
     for (type_path, attr) in CUSTOM_TYPE_ATTRIBUTES {
         tonic_config = tonic_config.type_attribute(type_path, attr);

--- a/rsema1d/Cargo.toml
+++ b/rsema1d/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 reed-solomon-simd = "3.1.0"
+bytes.workspace = true
 sha2 = { version = "0.10.8", features = ["asm"] }
 thiserror = "1.0.69"
 rayon = "1.10"

--- a/rsema1d/src/codec/commitment.rs
+++ b/rsema1d/src/codec/commitment.rs
@@ -107,8 +107,7 @@ impl ExtendedData {
         params: &Parameters,
     ) -> Result<Self> {
         extended_rows.extended_view(params)?;
-        // Nothing below mutates the rows; freezing lets row proofs share the
-        // buffer instead of copying every row that goes on the wire.
+        // Share encoded rows with inclusion proofs.
         extended_rows.freeze();
 
         let row_tree = build_row_tree(&extended_rows, params);
@@ -263,5 +262,21 @@ mod tests {
         );
         assert_eq!(ext_data.rlc_orig.len(), params.k);
         assert_eq!(ext_data.rlc_extended.len(), params.k + params.n);
+    }
+
+    #[test]
+    fn row_inclusion_proof_shares_matrix_storage() {
+        let params = Parameters::new(4, 4, 64).unwrap();
+        let rows = RowMatrix::with_shape(
+            vec![0; params.total_rows() * params.row_size],
+            params.total_rows(),
+            params.row_size,
+        )
+        .unwrap();
+        let ext_data = ExtendedData::generate_from_extended_rows(rows, &params).unwrap();
+
+        let proof = ext_data.generate_row_inclusion_proof(3).unwrap();
+
+        assert_eq!(proof.row.as_ptr(), ext_data.row(3).unwrap().as_ptr());
     }
 }

--- a/rsema1d/src/codec/commitment.rs
+++ b/rsema1d/src/codec/commitment.rs
@@ -102,10 +102,13 @@ impl ExtendedData {
 
     /// Generate commitment from contiguous already-extended rows (K+N rows).
     pub fn generate_from_extended_rows(
-        extended_rows: RowMatrix,
+        mut extended_rows: RowMatrix,
         params: &Parameters,
     ) -> Result<Self> {
         extended_rows.extended_view(params)?;
+        // Nothing below mutates the rows; freezing lets row proofs share the
+        // buffer instead of copying every row that goes on the wire.
+        extended_rows.freeze();
 
         let row_tree = build_row_tree(&extended_rows, params);
         let row_root = row_tree.root();
@@ -219,11 +222,14 @@ impl ExtendedData {
 
     /// Generate row inclusion proof for any row.
     pub fn generate_row_inclusion_proof(&self, index: usize) -> Result<RowInclusionProof> {
-        let row_proof = self.generate_row_proof(index)?;
+        if index >= self.params.total_rows() {
+            return Err(Error::InvalidIndex(index, self.params.total_rows()));
+        }
+        let tree_pos = map_index_to_tree_position(index, self.params.k);
         Ok(RowInclusionProof {
-            index: row_proof.index,
-            row: row_proof.row.into_owned(),
-            row_proof: row_proof.row_proof,
+            index,
+            row: self.all_rows.row_bytes(index)?,
+            row_proof: self.row_tree.generate_proof(tree_pos),
             rlc_root: self.rlc_root,
         })
     }

--- a/rsema1d/src/codec/mod.rs
+++ b/rsema1d/src/codec/mod.rs
@@ -446,7 +446,7 @@ mod tests {
             let row_proof = ext_data.generate_row_proof(i).unwrap();
             let manual = RowInclusionProof {
                 index: row_proof.index,
-                row: row_proof.row.into_owned(),
+                row: row_proof.row.into_owned().into(),
                 row_proof: row_proof.row_proof,
                 rlc_root: ext_data.rlc_root(),
             };
@@ -460,7 +460,9 @@ mod tests {
         assert!(verify_row_inclusion(&proof, &bad_commitment, &params).is_err());
 
         let mut bad_row = proof.clone();
-        bad_row.row[0] ^= 0x01;
+        let mut corrupted = bad_row.row.to_vec();
+        corrupted[0] ^= 0x01;
+        bad_row.row = corrupted.into();
         assert!(verify_row_inclusion(&bad_row, &commitment, &params).is_err());
 
         assert!(ext_data

--- a/rsema1d/src/codec/proof.rs
+++ b/rsema1d/src/codec/proof.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::borrow::Cow;
 
 /// Lightweight row proof (works for both original and extended rows).
@@ -29,8 +30,9 @@ pub struct StandaloneProof {
 pub struct RowInclusionProof {
     /// Row index within the extended data (0..K+N).
     pub index: usize,
-    /// The row bytes.
-    pub row: Vec<u8>,
+    /// The row bytes; a reference-counted slice of the encoded matrix when
+    /// produced by [`ExtendedData`](crate::ExtendedData).
+    pub row: Bytes,
     /// Merkle proof siblings for the row tree.
     pub row_proof: Vec<[u8; 32]>,
     /// The RLC Merkle root used in the commitment.

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -1,13 +1,55 @@
 use crate::error::{Error, Result};
 use crate::params::Parameters;
+use bytes::Bytes;
+
+/// Backing store of a [`RowMatrix`].
+///
+/// A matrix starts out owned so it can be encoded in place. Once it is
+/// frozen, rows can be handed out as reference-counted [`Bytes`] slices
+/// without copying; mutating a frozen matrix converts it back to an owned
+/// buffer (a copy only if other `Bytes` still refer to it).
+#[derive(Debug, Clone)]
+enum Storage {
+    Owned(Vec<u8>),
+    Shared(Bytes),
+}
+
+impl Storage {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Storage::Owned(v) => v,
+            Storage::Shared(b) => b,
+        }
+    }
+
+    fn as_mut_vec(&mut self) -> &mut Vec<u8> {
+        if let Storage::Shared(b) = self {
+            *self = Storage::Owned(Vec::from(std::mem::take(b)));
+        }
+        match self {
+            Storage::Owned(v) => v,
+            Storage::Shared(_) => unreachable!("converted to owned above"),
+        }
+    }
+}
 
 /// Contiguous row-major byte matrix (rows × row_size).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct RowMatrix {
-    data: Vec<u8>,
+    data: Storage,
     row_size: usize,
     rows: usize,
 }
+
+impl PartialEq for RowMatrix {
+    fn eq(&self, other: &Self) -> bool {
+        self.rows == other.rows
+            && self.row_size == other.row_size
+            && self.as_row_major() == other.as_row_major()
+    }
+}
+
+impl Eq for RowMatrix {}
 
 impl RowMatrix {
     /// Create a matrix from a flat byte buffer with the given shape.
@@ -25,7 +67,7 @@ impl RowMatrix {
             )));
         }
         Ok(Self {
-            data,
+            data: Storage::Owned(data),
             row_size,
             rows,
         })
@@ -43,17 +85,36 @@ impl RowMatrix {
 
     /// Returns the underlying flat buffer as a byte slice.
     pub fn as_row_major(&self) -> &[u8] {
-        &self.data
+        self.data.as_slice()
     }
 
     /// Returns the underlying flat buffer as a mutable byte slice.
+    ///
+    /// If the matrix was frozen and rows are still shared, this copies the
+    /// buffer first.
     pub fn as_row_major_mut(&mut self) -> &mut [u8] {
-        &mut self.data
+        self.data.as_mut_vec()
     }
 
     /// Consumes the matrix and returns the underlying byte buffer.
     pub fn into_row_major(self) -> Vec<u8> {
-        self.data
+        match self.data {
+            Storage::Owned(v) => v,
+            Storage::Shared(b) => Vec::from(b),
+        }
+    }
+
+    /// Freeze the buffer so that [`row_bytes`](Self::row_bytes) can return
+    /// rows without copying. No-op if already frozen; never copies.
+    pub fn freeze(&mut self) {
+        if let Storage::Owned(v) = &mut self.data {
+            self.data = Storage::Shared(Bytes::from(std::mem::take(v)));
+        }
+    }
+
+    /// Returns `true` if the matrix has been frozen.
+    pub fn is_frozen(&self) -> bool {
+        matches!(self.data, Storage::Shared(_))
     }
 
     /// Returns the row at `index`, or an error if out of bounds.
@@ -62,6 +123,23 @@ impl RowMatrix {
             return Err(Error::InvalidIndex(index, self.rows));
         }
         Ok(self.row_unchecked(index))
+    }
+
+    /// Returns the row at `index` as a reference-counted slice of the
+    /// matrix buffer.
+    ///
+    /// Zero-copy once the matrix is [frozen](Self::freeze); copies the row
+    /// otherwise.
+    pub fn row_bytes(&self, index: usize) -> Result<Bytes> {
+        if index >= self.rows {
+            return Err(Error::InvalidIndex(index, self.rows));
+        }
+        let start = index * self.row_size;
+        let end = start + self.row_size;
+        Ok(match &self.data {
+            Storage::Shared(b) => b.slice(start..end),
+            Storage::Owned(v) => Bytes::copy_from_slice(&v[start..end]),
+        })
     }
 
     /// Returns a mutable reference to the row at `index`.
@@ -75,13 +153,13 @@ impl RowMatrix {
     pub(crate) fn row_unchecked(&self, index: usize) -> &[u8] {
         let start = index * self.row_size;
         let end = start + self.row_size;
-        &self.data[start..end]
+        &self.data.as_slice()[start..end]
     }
 
     pub(crate) fn row_mut_unchecked(&mut self, index: usize) -> &mut [u8] {
         let start = index * self.row_size;
         let end = start + self.row_size;
-        &mut self.data[start..end]
+        &mut self.data.as_mut_vec()[start..end]
     }
 
     /// Creates a new matrix containing only the rows at the given indices.

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -2,12 +2,6 @@ use crate::error::{Error, Result};
 use crate::params::Parameters;
 use bytes::Bytes;
 
-/// Backing store of a [`RowMatrix`].
-///
-/// A matrix starts out owned so it can be encoded in place. Once it is
-/// frozen, rows can be handed out as reference-counted [`Bytes`] slices
-/// without copying; mutating a frozen matrix converts it back to an owned
-/// buffer (a copy only if other `Bytes` still refer to it).
 #[derive(Debug, Clone)]
 enum Storage {
     Owned(Vec<u8>),
@@ -104,17 +98,10 @@ impl RowMatrix {
         }
     }
 
-    /// Freeze the buffer so that [`row_bytes`](Self::row_bytes) can return
-    /// rows without copying. No-op if already frozen; never copies.
-    pub fn freeze(&mut self) {
+    pub(crate) fn freeze(&mut self) {
         if let Storage::Owned(v) = &mut self.data {
             self.data = Storage::Shared(Bytes::from(std::mem::take(v)));
         }
-    }
-
-    /// Returns `true` if the matrix has been frozen.
-    pub fn is_frozen(&self) -> bool {
-        matches!(self.data, Storage::Shared(_))
     }
 
     /// Returns the row at `index`, or an error if out of bounds.
@@ -125,12 +112,7 @@ impl RowMatrix {
         Ok(self.row_unchecked(index))
     }
 
-    /// Returns the row at `index` as a reference-counted slice of the
-    /// matrix buffer.
-    ///
-    /// Zero-copy once the matrix is [frozen](Self::freeze); copies the row
-    /// otherwise.
-    pub fn row_bytes(&self, index: usize) -> Result<Bytes> {
+    pub(crate) fn row_bytes(&self, index: usize) -> Result<Bytes> {
         if index >= self.rows {
             return Err(Error::InvalidIndex(index, self.rows));
         }

--- a/rsema1d/tests/go_fuzzy_compat.rs
+++ b/rsema1d/tests/go_fuzzy_compat.rs
@@ -410,7 +410,7 @@ fn go_fuzzy_vectors_match_rust() {
 
             let inclusion = RowInclusionProof {
                 index: inclusion_test.index,
-                row: row.clone(),
+                row: row.clone().into(),
                 row_proof: row_proof.clone(),
                 rlc_root: inclusion_rlc_root,
             };
@@ -435,7 +435,7 @@ fn go_fuzzy_vectors_match_rust() {
                 case.name, inclusion_test.index
             );
             assert_eq!(
-                rust_inclusion.row.as_slice(),
+                rust_inclusion.row.as_ref(),
                 row.as_slice(),
                 "{}: row inclusion row mismatch for index {}",
                 case.name,


### PR DESCRIPTION
## Overview

Avoid copying encoded Fibre rows while building upload requests.

After encoding, row matrices are backed by shared `Bytes` storage. Row inclusion proofs and generated protobuf `BlobRow` messages retain slices of that storage instead of allocating and copying each row. Mutable `RowMatrix` access remains supported through copy-on-write, and the protobuf wire format is unchanged.

For a maximum-sized blob, the upload-shard build and encode benchmark improves from 501 µs to 211 µs (~58%).
