### PR TITLE
chore(rsema1d): make codec benches statistically less noisy

### DIFF
--- a/rsema1d/benches/codec_bench.rs
+++ b/rsema1d/benches/codec_bench.rs
@@ -10,9 +10,6 @@ use rsema1d::{
     encode, encode_in_place, reconstruct, ExtendedData, Parameters, RowMatrix, VerificationContext,
 };
 
-/// Fixed seed so every run (and every config) encodes the same bytes. The RLC
-/// path skips zero symbols, so data content affects timing slightly; keeping it
-/// stable removes that as a source of run-to-run variance.
 const DATA_SEED: u64 = 0x5eed_5eed_5eed_5eed;
 
 fn generate_test_data(k: usize, row_size: usize) -> Vec<u8> {
@@ -22,82 +19,42 @@ fn generate_test_data(k: usize, row_size: usize) -> Vec<u8> {
     data
 }
 
-/// Sampling plan for one benchmark, chosen by how long a single iteration
-/// takes. Criterion's defaults (100 samples, 5 s, linear sampling) only work
-/// well for sub-millisecond routines; for the multi-millisecond and
-/// multi-second routines here they either emit "unable to complete 100
-/// samples" warnings or collapse to one iteration per sample.
-///
-/// * `Fast`  — iteration well under 1 ms (proof generation, verification).
-///   Linear sampling, 100 samples, 10 s. Plenty of iterations per sample, so
-///   scheduler jitter averages out.
-/// * `Small` — iteration in the 1–15 ms range (≤1 MB encodes, context build).
-///   Linear sampling needs 5050 iterations for 100 samples; 45 s covers that
-///   for iterations up to ~9 ms and degrades gracefully above.
-/// * `Medium` — iteration in the ~50–200 ms range (8 MB encodes/reconstruct).
-///   Flat sampling so every sample gets the same iteration count; 60 samples
-///   over 45 s gives several iterations per sample.
-/// * `Large` — iteration of one to a few seconds (128 MB encodes/reconstruct).
-///   Flat sampling, 30 samples over 75 s (one to three iterations per sample),
-///   with a longer warm-up so the allocator and rayon pool are steady before
-///   timing.
 #[derive(Clone, Copy)]
-enum Tier {
-    Fast,
-    Small,
-    Medium,
-    Large,
+enum SamplingProfile {
+    SubMillisecond,
+    Milliseconds,
+    Subsecond,
+    Seconds,
 }
 
-impl Tier {
-    /// Pick a tier for the data-parallel routines (`encode`, `encode_in_place`,
-    /// `reconstruct`) from the number of bytes they touch per iteration.
+impl SamplingProfile {
     fn for_bytes(bytes: usize) -> Self {
         const MIB: usize = 1024 * 1024;
         if bytes >= 64 * MIB {
-            Tier::Large
+            SamplingProfile::Seconds
         } else if bytes >= 4 * MIB {
-            Tier::Medium
+            SamplingProfile::Subsecond
         } else {
-            Tier::Small
+            SamplingProfile::Milliseconds
         }
     }
 
     fn apply(self, group: &mut BenchmarkGroup<'_, WallTime>) {
-        match self {
-            Tier::Fast => {
-                group
-                    .sampling_mode(SamplingMode::Linear)
-                    .sample_size(100)
-                    .warm_up_time(Duration::from_secs(3))
-                    .measurement_time(Duration::from_secs(10));
-            }
-            Tier::Small => {
-                group
-                    .sampling_mode(SamplingMode::Linear)
-                    .sample_size(100)
-                    .warm_up_time(Duration::from_secs(3))
-                    .measurement_time(Duration::from_secs(45));
-            }
-            Tier::Medium => {
-                group
-                    .sampling_mode(SamplingMode::Flat)
-                    .sample_size(60)
-                    .warm_up_time(Duration::from_secs(3))
-                    .measurement_time(Duration::from_secs(45));
-            }
-            Tier::Large => {
-                group
-                    .sampling_mode(SamplingMode::Flat)
-                    .sample_size(30)
-                    .warm_up_time(Duration::from_secs(5))
-                    .measurement_time(Duration::from_secs(75));
-            }
-        }
+        let (sampling_mode, sample_size, warm_up_secs, measurement_secs) = match self {
+            SamplingProfile::SubMillisecond => (SamplingMode::Linear, 100, 3, 10),
+            SamplingProfile::Milliseconds => (SamplingMode::Linear, 100, 3, 45),
+            SamplingProfile::Subsecond => (SamplingMode::Flat, 60, 3, 45),
+            SamplingProfile::Seconds => (SamplingMode::Flat, 30, 5, 75),
+        };
+
+        group
+            .sampling_mode(sampling_mode)
+            .sample_size(sample_size)
+            .warm_up_time(Duration::from_secs(warm_up_secs))
+            .measurement_time(Duration::from_secs(measurement_secs));
     }
 }
 
-// Test configurations: (data_size_name, k, n, row_size)
 const ENCODE_CONFIGS: &[(&str, usize, usize, usize)] = &[
     ("128KB_k1024_n3072", 1024, 3072, 128),
     ("1MB_k1024_n3072", 1024, 3072, 1024),
@@ -107,7 +64,7 @@ const ENCODE_CONFIGS: &[(&str, usize, usize, usize)] = &[
     ("128MB_k8192_n24576", 8192, 24576, 16384),
 ];
 
-const PROOF_CONFIGS: &[(&str, usize, usize, usize)] = &[
+const COMMON_CONFIGS: &[(&str, usize, usize, usize)] = &[
     ("1MB_k1024_n3072", 1024, 3072, 1024),
     ("8MB_k4096_n12288", 4096, 12288, 2048),
     ("128MB_k4096_n12288", 4096, 12288, 32768),
@@ -121,11 +78,7 @@ fn bench_encode(c: &mut Criterion) {
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let total_bytes = k * row_size;
 
-        // `encode` allocates and frees a fresh (k+n)*row_size buffer every
-        // iteration; that allocation (and the page faults on first touch) is
-        // part of what this benchmark measures. See `encode_in_place` for the
-        // buffer-reusing variant.
-        Tier::for_bytes(total_bytes).apply(&mut group);
+        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
         group.throughput(Throughput::Bytes(total_bytes as u64));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| encode(black_box(data), black_box(&params)).unwrap());
@@ -138,7 +91,6 @@ fn bench_encode(c: &mut Criterion) {
 fn bench_encode_in_place(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_in_place");
 
-    // Match the `encode` benchmark matrix exactly.
     for &(name, k, n, row_size) in ENCODE_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
@@ -147,7 +99,7 @@ fn bench_encode_in_place(c: &mut Criterion) {
         prefilled[..k * row_size].copy_from_slice(data.as_row_major());
         let mut extended = Some(RowMatrix::with_shape(prefilled, k + n, row_size).unwrap());
 
-        Tier::for_bytes(total_bytes).apply(&mut group);
+        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
         group.throughput(Throughput::Bytes(total_bytes as u64));
         group.bench_with_input(BenchmarkId::from_parameter(name), &params, |b, params| {
             b.iter(|| {
@@ -165,9 +117,9 @@ fn bench_encode_in_place(c: &mut Criterion) {
 
 fn bench_proof_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("proof_generation");
-    Tier::Fast.apply(&mut group);
+    SamplingProfile::SubMillisecond.apply(&mut group);
 
-    for &(name, k, n, row_size) in PROOF_CONFIGS {
+    for &(name, k, n, row_size) in COMMON_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
@@ -186,9 +138,9 @@ fn bench_proof_generation(c: &mut Criterion) {
 
 fn bench_verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("verification");
-    Tier::Fast.apply(&mut group);
+    SamplingProfile::SubMillisecond.apply(&mut group);
 
-    for &(name, k, n, row_size) in PROOF_CONFIGS {
+    for &(name, k, n, row_size) in COMMON_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
@@ -217,10 +169,9 @@ fn bench_verification(c: &mut Criterion) {
 
 fn bench_verification_context(c: &mut Criterion) {
     let mut group = c.benchmark_group("verification_context");
-    Tier::Small.apply(&mut group);
+    SamplingProfile::Milliseconds.apply(&mut group);
 
-    // The context build (RS extension of the RLC vector + Merkle build +
-    // row-derived coefficients) depends only on (k, n), not on row_size.
+    // Context construction depends on k and n, not row_size.
     let configs = [
         ("k1024_n3072", 1024, 3072, 1024),
         ("k4096_n12288", 4096, 12288, 256),
@@ -244,7 +195,7 @@ fn bench_verification_context(c: &mut Criterion) {
 fn bench_reconstruct(c: &mut Criterion) {
     let mut group = c.benchmark_group("reconstruct");
 
-    for &(name, k, n, row_size) in PROOF_CONFIGS {
+    for &(name, k, n, row_size) in COMMON_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let extended = ExtendedData::generate(&data, &params).unwrap();
@@ -255,7 +206,7 @@ fn bench_reconstruct(c: &mut Criterion) {
         let rows: Vec<&[u8]> = indices.iter().map(|&i| extended.row(i).unwrap()).collect();
         let total_bytes = k * row_size;
 
-        Tier::for_bytes(total_bytes).apply(&mut group);
+        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
         group.throughput(Throughput::Bytes(total_bytes as u64));
         group.bench_function(BenchmarkId::from_parameter(name), |b| {
             b.iter(|| {
@@ -267,20 +218,9 @@ fn bench_reconstruct(c: &mut Criterion) {
     group.finish();
 }
 
-fn criterion_config() -> Criterion {
-    Criterion::default()
-        // Everything here fans out over rayon (32 threads on a 16-core box),
-        // so run-to-run wobble of 1-2% is normal. Only flag a change once it
-        // clears that band; the raw estimates are still reported.
-        .noise_threshold(0.03)
-        // Let `-- --sample-size N` / `--measurement-time S` still override the
-        // *base* config. Per-tier settings above take precedence where set.
-        .configure_from_args()
-}
-
 criterion_group! {
     name = benches;
-    config = criterion_config();
+    config = Criterion::default().noise_threshold(0.03);
     targets =
         bench_encode,
         bench_encode_in_place,

--- a/rsema1d/benches/codec_bench.rs
+++ b/rsema1d/benches/codec_bench.rs
@@ -1,40 +1,131 @@
 use std::time::Duration;
 
 use criterion::{
-    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
+    Criterion, SamplingMode, Throughput,
 };
-use rand::Rng;
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use rsema1d::{
     encode, encode_in_place, reconstruct, ExtendedData, Parameters, RowMatrix, VerificationContext,
 };
 
+/// Fixed seed so every run (and every config) encodes the same bytes. The RLC
+/// path skips zero symbols, so data content affects timing slightly; keeping it
+/// stable removes that as a source of run-to-run variance.
+const DATA_SEED: u64 = 0x5eed_5eed_5eed_5eed;
+
 fn generate_test_data(k: usize, row_size: usize) -> Vec<u8> {
-    let mut rng = rand::thread_rng();
+    let mut rng = ChaCha8Rng::seed_from_u64(DATA_SEED);
     let mut data = vec![0u8; k * row_size];
-    for b in &mut data {
-        *b = rng.gen::<u8>();
-    }
+    rng.fill_bytes(&mut data);
     data
 }
+
+/// Sampling plan for one benchmark, chosen by how long a single iteration
+/// takes. Criterion's defaults (100 samples, 5 s, linear sampling) only work
+/// well for sub-millisecond routines; for the multi-millisecond and
+/// multi-second routines here they either emit "unable to complete 100
+/// samples" warnings or collapse to one iteration per sample.
+///
+/// * `Fast`  — iteration well under 1 ms (proof generation, verification).
+///   Linear sampling, 100 samples, 10 s. Plenty of iterations per sample, so
+///   scheduler jitter averages out.
+/// * `Small` — iteration in the 1–15 ms range (≤1 MB encodes, context build).
+///   Linear sampling needs 5050 iterations for 100 samples; 45 s covers that
+///   for iterations up to ~9 ms and degrades gracefully above.
+/// * `Medium` — iteration in the ~50–200 ms range (8 MB encodes/reconstruct).
+///   Flat sampling so every sample gets the same iteration count; 60 samples
+///   over 45 s gives several iterations per sample.
+/// * `Large` — iteration of one to a few seconds (128 MB encodes/reconstruct).
+///   Flat sampling, 30 samples over 75 s (one to three iterations per sample),
+///   with a longer warm-up so the allocator and rayon pool are steady before
+///   timing.
+#[derive(Clone, Copy)]
+enum Tier {
+    Fast,
+    Small,
+    Medium,
+    Large,
+}
+
+impl Tier {
+    /// Pick a tier for the data-parallel routines (`encode`, `encode_in_place`,
+    /// `reconstruct`) from the number of bytes they touch per iteration.
+    fn for_bytes(bytes: usize) -> Self {
+        const MIB: usize = 1024 * 1024;
+        if bytes >= 64 * MIB {
+            Tier::Large
+        } else if bytes >= 4 * MIB {
+            Tier::Medium
+        } else {
+            Tier::Small
+        }
+    }
+
+    fn apply(self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        match self {
+            Tier::Fast => {
+                group
+                    .sampling_mode(SamplingMode::Linear)
+                    .sample_size(100)
+                    .warm_up_time(Duration::from_secs(3))
+                    .measurement_time(Duration::from_secs(10));
+            }
+            Tier::Small => {
+                group
+                    .sampling_mode(SamplingMode::Linear)
+                    .sample_size(100)
+                    .warm_up_time(Duration::from_secs(3))
+                    .measurement_time(Duration::from_secs(45));
+            }
+            Tier::Medium => {
+                group
+                    .sampling_mode(SamplingMode::Flat)
+                    .sample_size(60)
+                    .warm_up_time(Duration::from_secs(3))
+                    .measurement_time(Duration::from_secs(45));
+            }
+            Tier::Large => {
+                group
+                    .sampling_mode(SamplingMode::Flat)
+                    .sample_size(30)
+                    .warm_up_time(Duration::from_secs(5))
+                    .measurement_time(Duration::from_secs(75));
+            }
+        }
+    }
+}
+
+// Test configurations: (data_size_name, k, n, row_size)
+const ENCODE_CONFIGS: &[(&str, usize, usize, usize)] = &[
+    ("128KB_k1024_n3072", 1024, 3072, 128),
+    ("1MB_k1024_n3072", 1024, 3072, 1024),
+    ("1MB_k4096_n12288", 4096, 12288, 256),
+    ("8MB_k4096_n12288", 4096, 12288, 2048),
+    ("128MB_k4096_n12288", 4096, 12288, 32768),
+    ("128MB_k8192_n24576", 8192, 24576, 16384),
+];
+
+const PROOF_CONFIGS: &[(&str, usize, usize, usize)] = &[
+    ("1MB_k1024_n3072", 1024, 3072, 1024),
+    ("8MB_k4096_n12288", 4096, 12288, 2048),
+    ("128MB_k4096_n12288", 4096, 12288, 32768),
+];
 
 fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode");
 
-    // Test configurations: (data_size_name, k, n, row_size)
-    let configs = vec![
-        ("128KB_k1024_n3072", 1024, 3072, 128),
-        ("1MB_k1024_n3072", 1024, 3072, 1024),
-        ("1MB_k4096_n12288", 4096, 12288, 256),
-        ("8MB_k4096_n12288", 4096, 12288, 2048),
-        ("128MB_k4096_n12288", 4096, 12288, 32768),
-        ("128MB_k8192_n24576", 8192, 24576, 16384),
-    ];
-
-    for (name, k, n, row_size) in configs {
+    for &(name, k, n, row_size) in ENCODE_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let total_bytes = k * row_size;
 
+        // `encode` allocates and frees a fresh (k+n)*row_size buffer every
+        // iteration; that allocation (and the page faults on first touch) is
+        // part of what this benchmark measures. See `encode_in_place` for the
+        // buffer-reusing variant.
+        Tier::for_bytes(total_bytes).apply(&mut group);
         group.throughput(Throughput::Bytes(total_bytes as u64));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
             b.iter(|| encode(black_box(data), black_box(&params)).unwrap());
@@ -48,16 +139,7 @@ fn bench_encode_in_place(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode_in_place");
 
     // Match the `encode` benchmark matrix exactly.
-    let configs = vec![
-        ("128KB_k1024_n3072", 1024, 3072, 128),
-        ("1MB_k1024_n3072", 1024, 3072, 1024),
-        ("1MB_k4096_n12288", 4096, 12288, 256),
-        ("8MB_k4096_n12288", 4096, 12288, 2048),
-        ("128MB_k4096_n12288", 4096, 12288, 32768),
-        ("128MB_k8192_n24576", 8192, 24576, 16384),
-    ];
-
-    for (name, k, n, row_size) in configs {
+    for &(name, k, n, row_size) in ENCODE_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let total_bytes = k * row_size;
@@ -65,6 +147,7 @@ fn bench_encode_in_place(c: &mut Criterion) {
         prefilled[..k * row_size].copy_from_slice(data.as_row_major());
         let mut extended = Some(RowMatrix::with_shape(prefilled, k + n, row_size).unwrap());
 
+        Tier::for_bytes(total_bytes).apply(&mut group);
         group.throughput(Throughput::Bytes(total_bytes as u64));
         group.bench_with_input(BenchmarkId::from_parameter(name), &params, |b, params| {
             b.iter(|| {
@@ -82,14 +165,9 @@ fn bench_encode_in_place(c: &mut Criterion) {
 
 fn bench_proof_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("proof_generation");
+    Tier::Fast.apply(&mut group);
 
-    let configs = vec![
-        ("1MB_k1024_n3072", 1024, 3072, 1024),
-        ("8MB_k4096_n12288", 4096, 12288, 2048),
-        ("128MB_k4096_n12288", 4096, 12288, 32768),
-    ];
-
-    for (name, k, n, row_size) in configs {
+    for &(name, k, n, row_size) in PROOF_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
@@ -108,23 +186,19 @@ fn bench_proof_generation(c: &mut Criterion) {
 
 fn bench_verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("verification");
+    Tier::Fast.apply(&mut group);
 
-    let configs = vec![
-        ("1MB_k1024_n3072", 1024, 3072, 1024),
-        ("8MB_k4096_n12288", 4096, 12288, 2048),
-        ("128MB_k4096_n12288", 4096, 12288, 32768),
-    ];
-
-    for (name, k, n, row_size) in configs {
+    for &(name, k, n, row_size) in PROOF_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
         let proof = commitment.generate_row_proof(0).unwrap();
         let context = VerificationContext::new(commitment.rlc_original(), &params).unwrap();
+        let commitment_bytes = commitment.commitment();
 
         group.bench_with_input(
             BenchmarkId::from_parameter(name),
-            &(&proof, &commitment.commitment(), &context),
+            &(&proof, &commitment_bytes, &context),
             |b, (proof, commitment_bytes, context)| {
                 b.iter(|| {
                     rsema1d::codec::verify_proof(
@@ -143,10 +217,11 @@ fn bench_verification(c: &mut Criterion) {
 
 fn bench_verification_context(c: &mut Criterion) {
     let mut group = c.benchmark_group("verification_context");
+    Tier::Small.apply(&mut group);
 
     // The context build (RS extension of the RLC vector + Merkle build +
     // row-derived coefficients) depends only on (k, n), not on row_size.
-    let configs = vec![
+    let configs = [
         ("k1024_n3072", 1024, 3072, 1024),
         ("k4096_n12288", 4096, 12288, 256),
         ("k8192_n24576", 8192, 24576, 128),
@@ -168,18 +243,8 @@ fn bench_verification_context(c: &mut Criterion) {
 
 fn bench_reconstruct(c: &mut Criterion) {
     let mut group = c.benchmark_group("reconstruct");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(30));
-    group.warm_up_time(Duration::from_secs(5));
-    group.sampling_mode(SamplingMode::Flat);
 
-    let configs = vec![
-        ("1MB_k1024_n3072", 1024, 3072, 1024),
-        ("8MB_k4096_n12288", 4096, 12288, 2048),
-        ("128MB_k4096_n12288", 4096, 12288, 32768),
-    ];
-
-    for (name, k, n, row_size) in configs {
+    for &(name, k, n, row_size) in PROOF_CONFIGS {
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let extended = ExtendedData::generate(&data, &params).unwrap();
@@ -188,8 +253,10 @@ fn bench_reconstruct(c: &mut Criterion) {
         // actual Reed-Solomon decode instead of copying originals through.
         let indices: Vec<usize> = (k..2 * k).collect();
         let rows: Vec<&[u8]> = indices.iter().map(|&i| extended.row(i).unwrap()).collect();
+        let total_bytes = k * row_size;
 
-        group.throughput(Throughput::Bytes((k * row_size) as u64));
+        Tier::for_bytes(total_bytes).apply(&mut group);
+        group.throughput(Throughput::Bytes(total_bytes as u64));
         group.bench_function(BenchmarkId::from_parameter(name), |b| {
             b.iter(|| {
                 reconstruct(black_box(&rows), black_box(&indices), black_box(&params)).unwrap()
@@ -200,13 +267,26 @@ fn bench_reconstruct(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_encode,
-    bench_encode_in_place,
-    bench_proof_generation,
-    bench_verification,
-    bench_verification_context,
-    bench_reconstruct
-);
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        // Everything here fans out over rayon (32 threads on a 16-core box),
+        // so run-to-run wobble of 1-2% is normal. Only flag a change once it
+        // clears that band; the raw estimates are still reported.
+        .noise_threshold(0.03)
+        // Let `-- --sample-size N` / `--measurement-time S` still override the
+        // *base* config. Per-tier settings above take precedence where set.
+        .configure_from_args()
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets =
+        bench_encode,
+        bench_encode_in_place,
+        bench_proof_generation,
+        bench_verification,
+        bench_verification_context,
+        bench_reconstruct
+}
 criterion_main!(benches);


### PR DESCRIPTION
## Overview

Criterion defaults (100 samples, 5 s, linear sampling) collapsed to one iteration per sample for every config above ~10 ms, so the 128MB encode benches reported ±3-8% confidence intervals with ~10% outliers, and every heavy config printed an "unable to complete 100 samples" warning.

- Pick a sampling plan per config from bytes touched: linear 10 s / 45 s for sub-10 ms routines, flat 60x45 s for ~100 ms routines, flat 30x75 s with a 5 s warm-up for the second-scale 128MB configs.
- Share the config tables between `encode` and `encode_in_place` so the two matrices cannot drift apart.
- Seed the input data with ChaCha8 so runs encode identical bytes.
- Raise the noise threshold to 3% so normal rayon wobble on a 32-thread box is not reported as a regression.

On the same machine the 128MB encode intervals went from ±3.1% / ±8.0% to ±0.25% with no outliers, and a confirmation re-run reproduced the 128MB k8192 encode within 1%. Total runtime is ~15 min instead of ~8.
