### PR TITLE
perf(rsema1d): (safe) encode parity in cache-resident column stripes in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4896,6 +4896,7 @@ dependencies = [
  "criterion",
  "getrandom 0.2.17",
  "hex",
+ "num_cpus",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -6,6 +6,7 @@
 //! - `Blob`: encoded data with Reed-Solomon erasure coding
 
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use crate::blob_header::BlobHeaderV0;
@@ -128,6 +129,15 @@ impl Blob {
     /// Returns `FibreError::EmptyBlobData` if data is empty.
     /// Returns `FibreError::BlobTooLarge` if the data exceeds `cfg.max_data_size`.
     pub fn new(data: &[u8], cfg: BlobConfig) -> Result<Self, FibreError> {
+        Self::new_with_work_budget(data, cfg, rsema1d::default_work_budget())
+    }
+
+    /// Encode data with an explicit combined Reed-Solomon work-buffer budget.
+    pub fn new_with_work_budget(
+        data: &[u8],
+        cfg: BlobConfig,
+        work_budget: NonZeroUsize,
+    ) -> Result<Self, FibreError> {
         if data.is_empty() {
             return Err(FibreError::EmptyBlobData);
         }
@@ -149,7 +159,8 @@ impl Blob {
         header.encode_into_buffer(data, &mut flat);
         let extended = rsema1d::RowMatrix::with_shape(flat, total_rows, row_size)?;
         let params = rsema1d::Parameters::new(cfg.original_rows, cfg.parity_rows, row_size)?;
-        let (ext_data, commitment, rlc_orig) = rsema1d::encode_in_place(extended, &params)?;
+        let (ext_data, commitment, rlc_orig) =
+            rsema1d::encode_in_place_with_work_budget(extended, &params, work_budget)?;
 
         let id = BlobID::new(cfg.blob_version, commitment);
 

--- a/rsema1d/Cargo.toml
+++ b/rsema1d/Cargo.toml
@@ -17,6 +17,7 @@ rayon = "1.10"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 hex.workspace = true
+num_cpus = "1.17"
 
 [dev-dependencies]
 rand.workspace = true

--- a/rsema1d/src/codec/commitment.rs
+++ b/rsema1d/src/codec/commitment.rs
@@ -1,8 +1,8 @@
+use crate::codec::extend_rlcs;
 use crate::codec::padding::map_index_to_tree_position;
 use crate::codec::proof::{RowInclusionProof, RowProof, StandaloneProof};
 use crate::codec::rows::RowMatrix;
 use crate::codec::symbols::RlcCoefficientLogs;
-use crate::codec::{extend_data, extend_rlcs};
 use crate::crypto::{derive_coefficients, hash_leaf, sha256, MerkleTree};
 use crate::error::{Error, Result};
 use crate::field::GF128;
@@ -96,8 +96,17 @@ pub struct ExtendedData {
 impl ExtendedData {
     /// Generate commitment from contiguous original rows.
     pub fn generate(original_rows: &RowMatrix, params: &Parameters) -> Result<Self> {
+        Self::generate_with_work_budget(original_rows, params, super::default_work_budget())
+    }
+
+    /// Generate commitment using an explicit combined Leopard work-buffer budget.
+    pub fn generate_with_work_budget(
+        original_rows: &RowMatrix,
+        params: &Parameters,
+        work_budget: std::num::NonZeroUsize,
+    ) -> Result<Self> {
         let original_view = original_rows.original_view(params)?;
-        let all_rows = extend_data(original_view, params)?;
+        let all_rows = super::rs::extend_data_with_work_budget(original_view, params, work_budget)?;
         Self::generate_from_extended_rows(all_rows, params)
     }
 

--- a/rsema1d/src/codec/mod.rs
+++ b/rsema1d/src/codec/mod.rs
@@ -12,6 +12,7 @@ mod verification;
 use crate::error::Result;
 use crate::field::GF128;
 use crate::params::Parameters;
+use std::num::NonZeroUsize;
 
 pub use commitment::ExtendedData;
 pub use padding::map_index_to_tree_position;
@@ -19,7 +20,8 @@ pub use proof::{RowInclusionProof, RowProof, StandaloneProof};
 pub use reconstruct::reconstruct_data;
 pub use rows::{ExtendedRowsView, OriginalRowsView, RowMatrix};
 pub use rs::{
-    encode_parity_in_place, extend_data, extend_rlcs, pack_gf128_to_shard, unpack_shard_to_gf128,
+    encode_parity_in_place, encode_parity_in_place_with_work_budget, extend_data,
+    extend_data_with_work_budget, extend_rlcs, pack_gf128_to_shard, unpack_shard_to_gf128,
 };
 pub use symbols::{compute_rlc, extract_symbols};
 pub use verification::{
@@ -31,12 +33,44 @@ pub use verification::{
 /// A 32-byte SHA-256 commitment hash.
 pub type Commitment = [u8; 32];
 
+const DEFAULT_WORK_BUDGET_PER_PHYSICAL_CORE: NonZeroUsize = NonZeroUsize::new(2 << 20).unwrap();
+const MIN_DEFAULT_WORK_BUDGET: NonZeroUsize = NonZeroUsize::new(8 << 20).unwrap();
+
+fn work_budget_for_parallelism(
+    threads: NonZeroUsize,
+    physical_cores: NonZeroUsize,
+) -> NonZeroUsize {
+    DEFAULT_WORK_BUDGET_PER_PHYSICAL_CORE
+        .saturating_mul(threads.min(physical_cores))
+        .max(MIN_DEFAULT_WORK_BUDGET)
+}
+
+/// Return the default combined Leopard work-buffer budget for the current pool.
+///
+/// The default has an 8 MiB floor to avoid excessively narrow serial stripes,
+/// then scales at 2 MiB per active physical core. Rayon workers above the
+/// detected physical-core count are treated as SMT siblings, not extra cache.
+pub fn default_work_budget() -> NonZeroUsize {
+    let threads = NonZeroUsize::new(rayon::current_num_threads()).unwrap_or(NonZeroUsize::MIN);
+    let physical_cores = NonZeroUsize::new(num_cpus::get_physical()).unwrap_or(NonZeroUsize::MIN);
+    work_budget_for_parallelism(threads, physical_cores)
+}
+
 /// Encode original rows and return extended data, commitment, and original RLCs.
 pub fn encode(
     data: &RowMatrix,
     params: &Parameters,
 ) -> Result<(ExtendedData, Commitment, Vec<GF128>)> {
-    let ext_data = ExtendedData::generate(data, params)?;
+    encode_with_work_budget(data, params, default_work_budget())
+}
+
+/// Encode original rows with an explicit combined Leopard work-buffer budget.
+pub fn encode_with_work_budget(
+    data: &RowMatrix,
+    params: &Parameters,
+    work_budget: NonZeroUsize,
+) -> Result<(ExtendedData, Commitment, Vec<GF128>)> {
+    let ext_data = ExtendedData::generate_with_work_budget(data, params, work_budget)?;
     let commitment = ext_data.commitment();
     let rlc_orig = ext_data.rlc_original().to_vec();
     Ok((ext_data, commitment, rlc_orig))
@@ -49,11 +83,20 @@ pub fn encode(
 /// 2. computes parity rows in place
 /// 3. builds commitment, trees, and RLCs from the extended rows
 pub fn encode_in_place(
-    mut extended_rows: RowMatrix,
+    extended_rows: RowMatrix,
     params: &Parameters,
 ) -> Result<(ExtendedData, Commitment, Vec<GF128>)> {
+    encode_in_place_with_work_budget(extended_rows, params, default_work_budget())
+}
+
+/// Encode from a caller-provided buffer with an explicit Leopard work-buffer budget.
+pub fn encode_in_place_with_work_budget(
+    mut extended_rows: RowMatrix,
+    params: &Parameters,
+    work_budget: NonZeroUsize,
+) -> Result<(ExtendedData, Commitment, Vec<GF128>)> {
     extended_rows.extended_view(params)?;
-    encode_parity_in_place(&mut extended_rows, params)?;
+    encode_parity_in_place_with_work_budget(&mut extended_rows, params, work_budget)?;
 
     let ext_data = ExtendedData::generate_from_extended_rows(extended_rows, params)?;
     let commitment = ext_data.commitment();
@@ -180,6 +223,49 @@ mod tests {
             seed: 14,
         },
     ];
+
+    #[test]
+    fn default_work_budget_scales_with_physical_parallelism() {
+        for (threads, physical_cores, expected_mib) in [
+            (1, 16, 8),
+            (2, 16, 8),
+            (4, 16, 8),
+            (8, 16, 16),
+            (16, 16, 32),
+            (32, 16, 32),
+            (192, 192, 384),
+        ] {
+            let threads = NonZeroUsize::new(threads).unwrap();
+            let physical_cores = NonZeroUsize::new(physical_cores).unwrap();
+
+            assert_eq!(
+                work_budget_for_parallelism(threads, physical_cores).get(),
+                expected_mib << 20
+            );
+        }
+    }
+
+    #[test]
+    fn work_budget_does_not_change_encoded_output() {
+        let case = Case {
+            k: 16,
+            n: 48,
+            row_size: 4096,
+            seed: 42,
+        };
+        let (params, rows) = make_original_rows(case);
+        let small_budget = NonZeroUsize::new(64 << 10).unwrap();
+        let large_budget = NonZeroUsize::new(8 << 20).unwrap();
+
+        let (small, small_commitment, small_rlcs) =
+            encode_with_work_budget(&rows, &params, small_budget).unwrap();
+        let (large, large_commitment, large_rlcs) =
+            encode_with_work_budget(&rows, &params, large_budget).unwrap();
+
+        assert_eq!(small.rows().as_row_major(), large.rows().as_row_major());
+        assert_eq!(small_commitment, large_commitment);
+        assert_eq!(small_rlcs, large_rlcs);
+    }
 
     fn make_original_rows(case: Case) -> (Parameters, RowMatrix) {
         let params = Parameters::new(case.k, case.n, case.row_size).unwrap();

--- a/rsema1d/src/codec/mod.rs
+++ b/rsema1d/src/codec/mod.rs
@@ -13,6 +13,7 @@ use crate::error::Result;
 use crate::field::GF128;
 use crate::params::Parameters;
 use std::num::NonZeroUsize;
+use std::sync::OnceLock;
 
 pub use commitment::ExtendedData;
 pub use padding::map_index_to_tree_position;
@@ -51,8 +52,13 @@ fn work_budget_for_parallelism(
 /// then scales at 2 MiB per active physical core. Rayon workers above the
 /// detected physical-core count are treated as SMT siblings, not extra cache.
 pub fn default_work_budget() -> NonZeroUsize {
+    // `num_cpus::get_physical` parses /proc/cpuinfo on Linux (~0.4 ms), and
+    // this runs on every encode and every verification-context build.
+    static PHYSICAL_CORES: OnceLock<NonZeroUsize> = OnceLock::new();
+
     let threads = NonZeroUsize::new(rayon::current_num_threads()).unwrap_or(NonZeroUsize::MIN);
-    let physical_cores = NonZeroUsize::new(num_cpus::get_physical()).unwrap_or(NonZeroUsize::MIN);
+    let physical_cores = *PHYSICAL_CORES
+        .get_or_init(|| NonZeroUsize::new(num_cpus::get_physical()).unwrap_or(NonZeroUsize::MIN));
     work_budget_for_parallelism(threads, physical_cores)
 }
 

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -2,8 +2,142 @@ use crate::codec::rows::{OriginalRowsView, RowMatrix};
 use crate::error::{Error, Result};
 use crate::field::GF128;
 use crate::params::Parameters;
+use rayon::prelude::*;
 use reed_solomon_simd::engine::DefaultEngine;
 use reed_solomon_simd::rate::{HighRateEncoder, RateEncoder};
+use std::cell::RefCell;
+
+/// Upper bound on the combined Leopard work set of all stripe encoders that
+/// run concurrently, in bytes.
+///
+/// Leopard's high-rate transform keeps `k.next_multiple_of(n.next_power_of_two())`
+/// shards in a work buffer and sweeps it several times, so throughput is set by
+/// whether that buffer sits in cache or in DRAM. Encoding every row as a single
+/// shard (32 KiB rows at K=4096/N=12288) makes the buffer 512 MiB and the whole
+/// encode DRAM-bound on one core. Splitting rows into column stripes gives
+/// `row_size / stripe` independent encoders whose buffers are
+/// `work_shards * stripe` bytes each; keeping all concurrently running buffers
+/// within this budget keeps the transforms cache-resident. 32 MiB is half the
+/// L3 of a 16-core Zen 2 part and was the best value measured there (16 threads
+/// x 2 MiB or 32 threads x 1 MiB gave the same ~58 ms per 128 MiB blob).
+const STRIPE_WORK_BUDGET: usize = 32 << 20;
+
+/// Smallest stripe worth encoding separately. Below one 64-byte Leopard block
+/// per shard the per-shard overhead dominates.
+const MIN_STRIPE: usize = 64;
+
+thread_local! {
+    /// One encoder per rayon worker, reused across calls so the Leopard work
+    /// buffer is allocated and page-faulted once per thread, not once per blob.
+    static ENCODER: RefCell<Option<HighRateEncoder<DefaultEngine>>> = const { RefCell::new(None) };
+}
+
+/// Raw pointer to the parity region that can be shared across rayon tasks.
+///
+/// Each stripe task writes only the byte ranges
+/// `[row * row_size + offset, row * row_size + offset + len)` of its own stripe,
+/// which are disjoint between tasks, so concurrent writes never alias.
+#[derive(Clone, Copy)]
+struct ParityOut(*mut u8);
+
+// SAFETY: see the type documentation; the pointer is only dereferenced for
+// disjoint byte ranges, and the underlying `&mut [u8]` outlives the parallel
+// section that uses it.
+unsafe impl Send for ParityOut {}
+unsafe impl Sync for ParityOut {}
+
+/// Page size assumed when faulting in freshly allocated parity memory.
+const TOUCH_PAGE: usize = 4096;
+/// Contiguous span each rayon worker faults in at a time.
+const TOUCH_CHUNK: usize = 2 << 20;
+
+/// Write one byte per page of `buf`, contiguous chunks per worker.
+///
+/// The striped scatter below has every worker writing 64-byte pieces all
+/// over the parity region at once. When that region is freshly allocated,
+/// the first touch of each page is a page fault, and many threads faulting
+/// interleaved pages of one mapping serialize in the kernel: measured 105 ms
+/// versus 6 ms for a 24 MiB parity region with 32 threads. Faulting the pages
+/// in sequentially first takes the fast path; on already-resident memory this
+/// pass costs one cached store per page.
+fn touch_pages(buf: &mut [u8]) {
+    buf.par_chunks_mut(TOUCH_CHUNK).for_each(|chunk| {
+        for page in chunk.chunks_mut(TOUCH_PAGE) {
+            // SAFETY: `page` is a non-empty, valid, writable slice.
+            unsafe { std::ptr::write_volatile(page.as_mut_ptr(), page[0]) };
+        }
+    });
+}
+
+/// Number of shards in the Leopard high-rate work buffer for `(k, n)`.
+fn work_shards(k: usize, n: usize) -> usize {
+    let chunk = n.next_power_of_two();
+    k.div_ceil(chunk) * chunk
+}
+
+/// Stripe width in bytes for encoding `row_size`-byte rows with `(k, n)`.
+///
+/// Returns the largest multiple of 64 such that all rayon workers' work
+/// buffers fit in [`STRIPE_WORK_BUDGET`], clamped to `[MIN_STRIPE, row_size]`.
+fn stripe_size(k: usize, n: usize, row_size: usize) -> usize {
+    let threads = rayon::current_num_threads().max(1);
+    let per_encoder = STRIPE_WORK_BUDGET / (threads * work_shards(k, n));
+    let stripe = (per_encoder / MIN_STRIPE) * MIN_STRIPE;
+    stripe.clamp(MIN_STRIPE, row_size)
+}
+
+/// Encode one column stripe of `original_rows` into the matching stripe of
+/// the parity rows, using this thread's cached encoder.
+fn encode_stripe(
+    original_rows: &[u8],
+    parity: ParityOut,
+    k: usize,
+    n: usize,
+    row_size: usize,
+    offset: usize,
+    len: usize,
+) -> Result<()> {
+    ENCODER.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let encoder = match slot.as_mut() {
+            Some(encoder) => {
+                encoder
+                    .reset(k, n, len)
+                    .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+                encoder
+            }
+            None => slot.insert(
+                RateEncoder::new(k, n, len, DefaultEngine::new(), None)
+                    .map_err(|e| Error::ReedSolomon(e.to_string()))?,
+            ),
+        };
+
+        for row in original_rows.chunks_exact(row_size) {
+            encoder
+                .add_original_shard(&row[offset..offset + len])
+                .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+        }
+
+        let result = encoder
+            .encode()
+            .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+
+        for (i, recovery) in result.recovery_iter().enumerate() {
+            debug_assert_eq!(recovery.len(), len);
+            // SAFETY: `parity` points to `n * row_size` writable bytes that no
+            // other task touches in this stripe's byte ranges (see `ParityOut`),
+            // and `i < n`, `offset + len <= row_size`.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    recovery.as_ptr(),
+                    parity.0.add(i * row_size + offset),
+                    len,
+                );
+            }
+        }
+        Ok(())
+    })
+}
 
 fn fill_parity(
     original_rows: &[u8],
@@ -33,32 +167,28 @@ fn fill_parity(
             k, n, row_size
         )));
     }
-
-    let engine = DefaultEngine::new();
-    let mut encoder: HighRateEncoder<DefaultEngine> =
-        RateEncoder::new(k, n, row_size, engine, None)
-            .map_err(|e| Error::ReedSolomon(e.to_string()))?;
-
-    // Add all original rows
-    for row in original_rows.chunks_exact(row_size) {
-        encoder
-            .add_original_shard(row)
-            .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+    if !row_size.is_multiple_of(MIN_STRIPE) {
+        return Err(Error::InvalidParameters(format!(
+            "row_size {} is not a multiple of {}",
+            row_size, MIN_STRIPE
+        )));
     }
 
-    // Generate parity rows
-    let result = encoder
-        .encode()
-        .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+    // Leopard applies the same transform independently to every 64-byte
+    // block position of a shard, so encoding column stripes of the rows
+    // separately yields exactly the parity that one encoder over whole rows
+    // would, byte for byte. The last stripe may be shorter.
+    let stripe = stripe_size(k, n, row_size);
+    touch_pages(parity_rows);
+    let parity = ParityOut(parity_rows.as_mut_ptr());
 
-    for (dst_row, src_row) in parity_rows
-        .chunks_exact_mut(row_size)
-        .zip(result.recovery_iter())
-    {
-        dst_row.copy_from_slice(src_row);
-    }
-
-    Ok(())
+    (0..row_size.div_ceil(stripe))
+        .into_par_iter()
+        .try_for_each(|s| {
+            let offset = s * stripe;
+            let len = stripe.min(row_size - offset);
+            encode_stripe(original_rows, parity, k, n, row_size, offset, len)
+        })
 }
 
 /// Extend data using Reed-Solomon encoding.
@@ -217,5 +347,48 @@ mod tests {
             assert_eq!(extended[i], rlc_orig[i]);
         }
         assert!(extended[k..(k + n)].iter().any(|rlc| *rlc != GF128::zero()));
+    }
+
+    /// Striped, parallel parity must be byte-identical to a single Leopard
+    /// encoder over whole rows (what validators recompute on the Go side).
+    #[test]
+    fn striped_parity_matches_single_encoder() {
+        use rand::{RngCore, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+
+        // Production shape (K=4096, N=12288) with a row size that splits into
+        // several stripes under any thread count, plus a row size that is not
+        // a multiple of the stripe (last stripe shorter) and a tiny case.
+        for (k, n, row_size, seed) in [
+            (4096usize, 12288usize, 512usize, 1u64),
+            (4096, 12288, 64 * 21, 2),
+            (16, 48, 4096, 3),
+            (4, 4, 64, 4),
+        ] {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut original = vec![0u8; k * row_size];
+            rng.fill_bytes(&mut original);
+
+            let mut expected = vec![0u8; n * row_size];
+            let mut encoder: HighRateEncoder<DefaultEngine> =
+                RateEncoder::new(k, n, row_size, DefaultEngine::new(), None).unwrap();
+            for row in original.chunks_exact(row_size) {
+                encoder.add_original_shard(row).unwrap();
+            }
+            let result = encoder.encode().unwrap();
+            for (dst, src) in expected
+                .chunks_exact_mut(row_size)
+                .zip(result.recovery_iter())
+            {
+                dst.copy_from_slice(src);
+            }
+
+            let mut parity = vec![0u8; n * row_size];
+            fill_parity(&original, &mut parity, k, n, row_size).unwrap();
+            assert!(
+                parity == expected,
+                "striped parity differs for k={k} n={n} row_size={row_size}"
+            );
+        }
     }
 }

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -5,6 +5,7 @@ use crate::params::Parameters;
 use rayon::prelude::*;
 use reed_solomon_simd::engine::DefaultEngine;
 use reed_solomon_simd::rate::{HighRateEncoder, RateEncoder};
+use std::num::NonZeroUsize;
 
 /// Maximum combined Leopard work-buffer size for concurrently encoded stripes.
 /// This is a performance-tuning target; it does not include parity scratch space.
@@ -15,16 +16,24 @@ const MIN_STRIPE: usize = 64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct StripePlan {
-    stripe_size: usize,
-    parallelism: usize,
+    stripe_size: NonZeroUsize,
+    parallelism: NonZeroUsize,
 }
 
 impl StripePlan {
-    const fn new(stripe_size: usize, parallelism: usize) -> Self {
+    fn new(stripe_size: usize, parallelism: usize) -> Self {
         Self {
-            stripe_size,
-            parallelism,
+            stripe_size: NonZeroUsize::new(stripe_size).expect("stripe size must be non-zero"),
+            parallelism: NonZeroUsize::new(parallelism).expect("parallelism must be non-zero"),
         }
+    }
+
+    const fn stripe_size(self) -> usize {
+        self.stripe_size.get()
+    }
+
+    const fn parallelism(self) -> usize {
+        self.parallelism.get()
     }
 }
 
@@ -51,14 +60,23 @@ fn stripe_plan(k: usize, n: usize, row_size: usize, threads: usize) -> StripePla
     StripePlan::new(stripe.clamp(MIN_STRIPE, row_size), parallelism)
 }
 
-#[derive(Default)]
-struct EncoderSlot {
-    encoder: Option<HighRateEncoder<DefaultEngine>>,
+struct StripeEncoder {
+    encoder: HighRateEncoder<DefaultEngine>,
     recovery: Vec<u8>,
 }
 
-impl EncoderSlot {
-    fn encode(
+impl StripeEncoder {
+    fn new(k: usize, n: usize, stripe_size: usize) -> Result<Self> {
+        let encoder = RateEncoder::new(k, n, stripe_size, DefaultEngine::new(), None)
+            .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+
+        Ok(Self {
+            encoder,
+            recovery: Vec::with_capacity(n * stripe_size),
+        })
+    }
+
+    fn encode_stripe(
         &mut self,
         original_rows: &[u8],
         k: usize,
@@ -66,26 +84,18 @@ impl EncoderSlot {
         row_size: usize,
         stripe: Stripe,
     ) -> Result<()> {
-        let encoder = match self.encoder.as_mut() {
-            Some(encoder) => {
-                encoder
-                    .reset(k, n, stripe.len)
-                    .map_err(|e| Error::ReedSolomon(e.to_string()))?;
-                encoder
-            }
-            None => self.encoder.insert(
-                RateEncoder::new(k, n, stripe.len, DefaultEngine::new(), None)
-                    .map_err(|e| Error::ReedSolomon(e.to_string()))?,
-            ),
-        };
+        self.encoder
+            .reset(k, n, stripe.len)
+            .map_err(|e| Error::ReedSolomon(e.to_string()))?;
 
         for row in original_rows.chunks_exact(row_size) {
-            encoder
+            self.encoder
                 .add_original_shard(&row[stripe.offset..stripe.offset + stripe.len])
                 .map_err(|e| Error::ReedSolomon(e.to_string()))?;
         }
 
-        let result = encoder
+        let result = self
+            .encoder
             .encode()
             .map_err(|e| Error::ReedSolomon(e.to_string()))?;
 
@@ -150,32 +160,37 @@ fn fill_parity_with_plan(
     row_size: usize,
     plan: StripePlan,
 ) -> Result<()> {
-    assert!(plan.stripe_size > 0 && plan.stripe_size.is_multiple_of(MIN_STRIPE));
-    assert!(plan.parallelism > 0);
+    let stripe_size = plan.stripe_size();
+    let parallelism = plan.parallelism();
+    assert!(stripe_size.is_multiple_of(MIN_STRIPE));
 
     let stripes: Vec<_> = (0..row_size)
-        .step_by(plan.stripe_size)
+        .step_by(stripe_size)
         .map(|offset| Stripe {
             offset,
-            len: plan.stripe_size.min(row_size - offset),
+            len: stripe_size.min(row_size - offset),
         })
         .collect();
-    let mut slots: Vec<_> = (0..plan.parallelism.min(stripes.len()))
-        .map(|_| EncoderSlot::default())
-        .collect();
+    let slot_count = parallelism.min(stripes.len());
+    let mut encoders = (0..slot_count)
+        .into_par_iter()
+        .map(|_| StripeEncoder::new(k, n, stripe_size))
+        .collect::<Result<Vec<_>>>()?;
 
     // Leopard transforms each 64-byte block position independently. Encode a
     // cache-sized batch of column stripes, then scatter it by parity row so all
     // writes use ordinary disjoint mutable slices.
-    for batch in stripes.chunks(plan.parallelism) {
-        slots[..batch.len()]
+    for batch in stripes.chunks(parallelism) {
+        encoders[..batch.len()]
             .par_iter_mut()
             .zip(batch.par_iter())
-            .try_for_each(|(slot, &stripe)| slot.encode(original_rows, k, n, row_size, stripe))?;
+            .try_for_each(|(encoder, &stripe)| {
+                encoder.encode_stripe(original_rows, k, n, row_size, stripe)
+            })?;
 
-        let recovery: Vec<_> = slots[..batch.len()]
+        let recovery: Vec<_> = encoders[..batch.len()]
             .iter()
-            .map(|slot| slot.recovery.as_slice())
+            .map(|encoder| encoder.recovery.as_slice())
             .collect();
         parity_rows
             .par_chunks_mut(row_size)
@@ -361,7 +376,8 @@ mod tests {
 
             assert_eq!(plan, expected);
             assert!(
-                plan.parallelism * work_shards(k, n) * plan.stripe_size <= STRIPE_WORK_BUDGET_BYTES
+                plan.parallelism() * work_shards(k, n) * plan.stripe_size()
+                    <= STRIPE_WORK_BUDGET_BYTES
             );
         }
     }

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -5,68 +5,33 @@ use crate::params::Parameters;
 use rayon::prelude::*;
 use reed_solomon_simd::engine::DefaultEngine;
 use reed_solomon_simd::rate::{HighRateEncoder, RateEncoder};
-use std::cell::RefCell;
 
-/// Upper bound on the combined Leopard work set of all stripe encoders that
-/// run concurrently, in bytes.
-///
-/// Leopard's high-rate transform keeps `k.next_multiple_of(n.next_power_of_two())`
-/// shards in a work buffer and sweeps it several times, so throughput is set by
-/// whether that buffer sits in cache or in DRAM. Encoding every row as a single
-/// shard (32 KiB rows at K=4096/N=12288) makes the buffer 512 MiB and the whole
-/// encode DRAM-bound on one core. Splitting rows into column stripes gives
-/// `row_size / stripe` independent encoders whose buffers are
-/// `work_shards * stripe` bytes each; keeping all concurrently running buffers
-/// within this budget keeps the transforms cache-resident. 32 MiB is half the
-/// L3 of a 16-core Zen 2 part and was the best value measured there (16 threads
-/// x 2 MiB or 32 threads x 1 MiB gave the same ~58 ms per 128 MiB blob).
-const STRIPE_WORK_BUDGET: usize = 32 << 20;
+/// Maximum combined Leopard work-buffer size for concurrently encoded stripes.
+/// This is a performance-tuning target; it does not include parity scratch space.
+const STRIPE_WORK_BUDGET_BYTES: usize = 32 << 20;
 
-/// Smallest stripe worth encoding separately. Below one 64-byte Leopard block
-/// per shard the per-shard overhead dominates.
+/// Leopard operates on 64-byte blocks, so stripes stay block-aligned.
 const MIN_STRIPE: usize = 64;
 
-thread_local! {
-    /// One encoder per rayon worker, reused across calls so the Leopard work
-    /// buffer is allocated and page-faulted once per thread, not once per blob.
-    static ENCODER: RefCell<Option<HighRateEncoder<DefaultEngine>>> = const { RefCell::new(None) };
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StripePlan {
+    stripe_size: usize,
+    parallelism: usize,
 }
 
-/// Raw pointer to the parity region that can be shared across rayon tasks.
-///
-/// Each stripe task writes only the byte ranges
-/// `[row * row_size + offset, row * row_size + offset + len)` of its own stripe,
-/// which are disjoint between tasks, so concurrent writes never alias.
-#[derive(Clone, Copy)]
-struct ParityOut(*mut u8);
-
-// SAFETY: see the type documentation; the pointer is only dereferenced for
-// disjoint byte ranges, and the underlying `&mut [u8]` outlives the parallel
-// section that uses it.
-unsafe impl Send for ParityOut {}
-unsafe impl Sync for ParityOut {}
-
-/// Page size assumed when faulting in freshly allocated parity memory.
-const TOUCH_PAGE: usize = 4096;
-/// Contiguous span each rayon worker faults in at a time.
-const TOUCH_CHUNK: usize = 2 << 20;
-
-/// Write one byte per page of `buf`, contiguous chunks per worker.
-///
-/// The striped scatter below has every worker writing 64-byte pieces all
-/// over the parity region at once. When that region is freshly allocated,
-/// the first touch of each page is a page fault, and many threads faulting
-/// interleaved pages of one mapping serialize in the kernel: measured 105 ms
-/// versus 6 ms for a 24 MiB parity region with 32 threads. Faulting the pages
-/// in sequentially first takes the fast path; on already-resident memory this
-/// pass costs one cached store per page.
-fn touch_pages(buf: &mut [u8]) {
-    buf.par_chunks_mut(TOUCH_CHUNK).for_each(|chunk| {
-        for page in chunk.chunks_mut(TOUCH_PAGE) {
-            // SAFETY: `page` is a non-empty, valid, writable slice.
-            unsafe { std::ptr::write_volatile(page.as_mut_ptr(), page[0]) };
+impl StripePlan {
+    const fn new(stripe_size: usize, parallelism: usize) -> Self {
+        Self {
+            stripe_size,
+            parallelism,
         }
-    });
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Stripe {
+    offset: usize,
+    len: usize,
 }
 
 /// Number of shards in the Leopard high-rate work buffer for `(k, n)`.
@@ -75,46 +40,48 @@ fn work_shards(k: usize, n: usize) -> usize {
     k.div_ceil(chunk) * chunk
 }
 
-/// Stripe width in bytes for encoding `row_size`-byte rows with `(k, n)`.
-///
-/// Returns the largest multiple of 64 such that all rayon workers' work
-/// buffers fit in [`STRIPE_WORK_BUDGET`], clamped to `[MIN_STRIPE, row_size]`.
-fn stripe_size(k: usize, n: usize, row_size: usize) -> usize {
-    let threads = rayon::current_num_threads().max(1);
-    let per_encoder = STRIPE_WORK_BUDGET / (threads * work_shards(k, n));
+/// Choose a block-aligned stripe width and bound the number encoded at once.
+fn stripe_plan(k: usize, n: usize, row_size: usize, threads: usize) -> StripePlan {
+    let work_shards = work_shards(k, n);
+    let max_parallelism = (STRIPE_WORK_BUDGET_BYTES / (work_shards * MIN_STRIPE)).max(1);
+    let parallelism = threads.max(1).min(max_parallelism);
+    let per_encoder = STRIPE_WORK_BUDGET_BYTES / parallelism / work_shards;
     let stripe = (per_encoder / MIN_STRIPE) * MIN_STRIPE;
-    stripe.clamp(MIN_STRIPE, row_size)
+
+    StripePlan::new(stripe.clamp(MIN_STRIPE, row_size), parallelism)
 }
 
-/// Encode one column stripe of `original_rows` into the matching stripe of
-/// the parity rows, using this thread's cached encoder.
-fn encode_stripe(
-    original_rows: &[u8],
-    parity: ParityOut,
-    k: usize,
-    n: usize,
-    row_size: usize,
-    offset: usize,
-    len: usize,
-) -> Result<()> {
-    ENCODER.with(|cell| {
-        let mut slot = cell.borrow_mut();
-        let encoder = match slot.as_mut() {
+#[derive(Default)]
+struct EncoderSlot {
+    encoder: Option<HighRateEncoder<DefaultEngine>>,
+    recovery: Vec<u8>,
+}
+
+impl EncoderSlot {
+    fn encode(
+        &mut self,
+        original_rows: &[u8],
+        k: usize,
+        n: usize,
+        row_size: usize,
+        stripe: Stripe,
+    ) -> Result<()> {
+        let encoder = match self.encoder.as_mut() {
             Some(encoder) => {
                 encoder
-                    .reset(k, n, len)
+                    .reset(k, n, stripe.len)
                     .map_err(|e| Error::ReedSolomon(e.to_string()))?;
                 encoder
             }
-            None => slot.insert(
-                RateEncoder::new(k, n, len, DefaultEngine::new(), None)
+            None => self.encoder.insert(
+                RateEncoder::new(k, n, stripe.len, DefaultEngine::new(), None)
                     .map_err(|e| Error::ReedSolomon(e.to_string()))?,
             ),
         };
 
         for row in original_rows.chunks_exact(row_size) {
             encoder
-                .add_original_shard(&row[offset..offset + len])
+                .add_original_shard(&row[stripe.offset..stripe.offset + stripe.len])
                 .map_err(|e| Error::ReedSolomon(e.to_string()))?;
         }
 
@@ -122,21 +89,15 @@ fn encode_stripe(
             .encode()
             .map_err(|e| Error::ReedSolomon(e.to_string()))?;
 
-        for (i, recovery) in result.recovery_iter().enumerate() {
-            debug_assert_eq!(recovery.len(), len);
-            // SAFETY: `parity` points to `n * row_size` writable bytes that no
-            // other task touches in this stripe's byte ranges (see `ParityOut`),
-            // and `i < n`, `offset + len <= row_size`.
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    recovery.as_ptr(),
-                    parity.0.add(i * row_size + offset),
-                    len,
-                );
-            }
+        self.recovery.clear();
+        self.recovery.reserve(n * stripe.len);
+        for recovery in result.recovery_iter() {
+            self.recovery.extend_from_slice(recovery);
         }
+        debug_assert_eq!(self.recovery.len(), n * stripe.len);
+
         Ok(())
-    })
+    }
 }
 
 fn fill_parity(
@@ -174,21 +135,61 @@ fn fill_parity(
         )));
     }
 
-    // Leopard applies the same transform independently to every 64-byte
-    // block position of a shard, so encoding column stripes of the rows
-    // separately yields exactly the parity that one encoder over whole rows
-    // would, byte for byte. The last stripe may be shorter.
-    let stripe = stripe_size(k, n, row_size);
-    touch_pages(parity_rows);
-    let parity = ParityOut(parity_rows.as_mut_ptr());
+    HighRateEncoder::<DefaultEngine>::validate(k, n, MIN_STRIPE)
+        .map_err(|e| Error::ReedSolomon(e.to_string()))?;
 
-    (0..row_size.div_ceil(stripe))
-        .into_par_iter()
-        .try_for_each(|s| {
-            let offset = s * stripe;
-            let len = stripe.min(row_size - offset);
-            encode_stripe(original_rows, parity, k, n, row_size, offset, len)
+    let plan = stripe_plan(k, n, row_size, rayon::current_num_threads());
+    fill_parity_with_plan(original_rows, parity_rows, k, n, row_size, plan)
+}
+
+fn fill_parity_with_plan(
+    original_rows: &[u8],
+    parity_rows: &mut [u8],
+    k: usize,
+    n: usize,
+    row_size: usize,
+    plan: StripePlan,
+) -> Result<()> {
+    assert!(plan.stripe_size > 0 && plan.stripe_size.is_multiple_of(MIN_STRIPE));
+    assert!(plan.parallelism > 0);
+
+    let stripes: Vec<_> = (0..row_size)
+        .step_by(plan.stripe_size)
+        .map(|offset| Stripe {
+            offset,
+            len: plan.stripe_size.min(row_size - offset),
         })
+        .collect();
+    let mut slots: Vec<_> = (0..plan.parallelism.min(stripes.len()))
+        .map(|_| EncoderSlot::default())
+        .collect();
+
+    // Leopard transforms each 64-byte block position independently. Encode a
+    // cache-sized batch of column stripes, then scatter it by parity row so all
+    // writes use ordinary disjoint mutable slices.
+    for batch in stripes.chunks(plan.parallelism) {
+        slots[..batch.len()]
+            .par_iter_mut()
+            .zip(batch.par_iter())
+            .try_for_each(|(slot, &stripe)| slot.encode(original_rows, k, n, row_size, stripe))?;
+
+        let recovery: Vec<_> = slots[..batch.len()]
+            .iter()
+            .map(|slot| slot.recovery.as_slice())
+            .collect();
+        parity_rows
+            .par_chunks_mut(row_size)
+            .enumerate()
+            .for_each(|(parity_index, row)| {
+                for (&stripe, recovery) in batch.iter().zip(&recovery) {
+                    let recovery_start = parity_index * stripe.len;
+                    row[stripe.offset..stripe.offset + stripe.len]
+                        .copy_from_slice(&recovery[recovery_start..recovery_start + stripe.len]);
+                }
+            });
+    }
+
+    Ok(())
 }
 
 /// Extend data using Reed-Solomon encoding.
@@ -349,6 +350,22 @@ mod tests {
         assert!(extended[k..(k + n)].iter().any(|rlc| *rlc != GF128::zero()));
     }
 
+    #[test]
+    fn stripe_plan_respects_work_budget() {
+        for (k, n, row_size, threads, expected) in [
+            (4096, 12288, 32768, 32, StripePlan::new(64, 32)),
+            (4096, 12288, 32768, 1, StripePlan::new(2048, 1)),
+            (32768, 32768, 32768, 32, StripePlan::new(64, 16)),
+        ] {
+            let plan = stripe_plan(k, n, row_size, threads);
+
+            assert_eq!(plan, expected);
+            assert!(
+                plan.parallelism * work_shards(k, n) * plan.stripe_size <= STRIPE_WORK_BUDGET_BYTES
+            );
+        }
+    }
+
     /// Striped, parallel parity must be byte-identical to a single Leopard
     /// encoder over whole rows (what validators recompute on the Go side).
     #[test]
@@ -356,14 +373,19 @@ mod tests {
         use rand::{RngCore, SeedableRng};
         use rand_chacha::ChaCha8Rng;
 
-        // Production shape (K=4096, N=12288) with a row size that splits into
-        // several stripes under any thread count, plus a row size that is not
-        // a multiple of the stripe (last stripe shorter) and a tiny case.
-        for (k, n, row_size, seed) in [
-            (4096usize, 12288usize, 512usize, 1u64),
-            (4096, 12288, 64 * 21, 2),
-            (16, 48, 4096, 3),
-            (4, 4, 64, 4),
+        // Plans are explicit so coverage does not depend on the CI machine's
+        // rayon pool. The second case also reuses a slot for a shorter stripe.
+        for (k, n, row_size, seed, plan) in [
+            (
+                4096usize,
+                12288usize,
+                512usize,
+                1u64,
+                StripePlan::new(128, 2),
+            ),
+            (4096, 12288, 64 * 21, 2, StripePlan::new(512, 2)),
+            (16, 48, 4096, 3, StripePlan::new(1024, 4)),
+            (4, 4, 64, 4, StripePlan::new(64, 1)),
         ] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let mut original = vec![0u8; k * row_size];
@@ -384,7 +406,7 @@ mod tests {
             }
 
             let mut parity = vec![0u8; n * row_size];
-            fill_parity(&original, &mut parity, k, n, row_size).unwrap();
+            fill_parity_with_plan(&original, &mut parity, k, n, row_size, plan).unwrap();
             assert!(
                 parity == expected,
                 "striped parity differs for k={k} n={n} row_size={row_size}"

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -1,3 +1,4 @@
+use super::default_work_budget;
 use crate::codec::rows::{OriginalRowsView, RowMatrix};
 use crate::error::{Error, Result};
 use crate::field::GF128;
@@ -6,10 +7,6 @@ use rayon::prelude::*;
 use reed_solomon_simd::engine::DefaultEngine;
 use reed_solomon_simd::rate::{HighRateEncoder, RateEncoder};
 use std::num::NonZeroUsize;
-
-/// Maximum combined Leopard work-buffer size for concurrently encoded stripes.
-/// This is a performance-tuning target; it does not include parity scratch space.
-const STRIPE_WORK_BUDGET_BYTES: usize = 32 << 20;
 
 /// Leopard operates on 64-byte blocks, so stripes stay block-aligned.
 const MIN_STRIPE: usize = 64;
@@ -50,11 +47,18 @@ fn work_shards(k: usize, n: usize) -> usize {
 }
 
 /// Choose a block-aligned stripe width and bound the number encoded at once.
-fn stripe_plan(k: usize, n: usize, row_size: usize, threads: usize) -> Result<StripePlan> {
+fn stripe_plan(
+    k: usize,
+    n: usize,
+    row_size: usize,
+    threads: usize,
+    work_budget: NonZeroUsize,
+) -> Result<StripePlan> {
     let work_shards = work_shards(k, n);
-    let max_parallelism = (STRIPE_WORK_BUDGET_BYTES / (work_shards * MIN_STRIPE)).max(1);
+    let work_budget = work_budget.get();
+    let max_parallelism = (work_budget / (work_shards * MIN_STRIPE)).max(1);
     let parallelism = threads.max(1).min(max_parallelism);
-    let per_encoder = STRIPE_WORK_BUDGET_BYTES / parallelism / work_shards;
+    let per_encoder = work_budget / parallelism / work_shards;
     let stripe = (per_encoder / MIN_STRIPE) * MIN_STRIPE;
     let stripe_size = NonZeroUsize::new(stripe.max(MIN_STRIPE).min(row_size)).ok_or_else(|| {
         Error::InvalidParameters("stripe planner produced a zero stripe size".into())
@@ -123,6 +127,24 @@ fn fill_parity(
     n: usize,
     row_size: usize,
 ) -> Result<()> {
+    fill_parity_with_work_budget(
+        original_rows,
+        parity_rows,
+        k,
+        n,
+        row_size,
+        default_work_budget(),
+    )
+}
+
+fn fill_parity_with_work_budget(
+    original_rows: &[u8],
+    parity_rows: &mut [u8],
+    k: usize,
+    n: usize,
+    row_size: usize,
+    work_budget: NonZeroUsize,
+) -> Result<()> {
     if original_rows.len() != k * row_size {
         return Err(Error::InvalidParameters(format!(
             "expected {} bytes of original rows, got {}",
@@ -154,7 +176,7 @@ fn fill_parity(
     HighRateEncoder::<DefaultEngine>::validate(k, n, MIN_STRIPE)
         .map_err(|e| Error::ReedSolomon(e.to_string()))?;
 
-    let plan = stripe_plan(k, n, row_size, rayon::current_num_threads())?;
+    let plan = stripe_plan(k, n, row_size, rayon::current_num_threads(), work_budget)?;
     fill_parity_with_plan(original_rows, parity_rows, k, n, row_size, plan)
 }
 
@@ -215,11 +237,27 @@ fn fill_parity_with_plan(
 
 /// Extend data using Reed-Solomon encoding.
 pub fn extend_data(original_rows: OriginalRowsView<'_>, params: &Parameters) -> Result<RowMatrix> {
+    extend_data_with_work_budget(original_rows, params, default_work_budget())
+}
+
+/// Extend data with an explicit combined Leopard work-buffer budget.
+pub fn extend_data_with_work_budget(
+    original_rows: OriginalRowsView<'_>,
+    params: &Parameters,
+    work_budget: NonZeroUsize,
+) -> Result<RowMatrix> {
     let mut all_rows = vec![0u8; (params.k + params.n) * params.row_size];
     let split_at = params.k * params.row_size;
     let (orig, parity) = all_rows.split_at_mut(split_at);
     orig.copy_from_slice(original_rows.as_row_major());
-    fill_parity(orig, parity, params.k, params.n, params.row_size)?;
+    fill_parity_with_work_budget(
+        orig,
+        parity,
+        params.k,
+        params.n,
+        params.row_size,
+        work_budget,
+    )?;
     RowMatrix::with_shape(all_rows, params.total_rows(), params.row_size)
 }
 
@@ -227,9 +265,25 @@ pub fn extend_data(original_rows: OriginalRowsView<'_>, params: &Parameters) -> 
 ///
 /// The first K rows must already contain original data.
 pub fn encode_parity_in_place(extended_rows: &mut RowMatrix, params: &Parameters) -> Result<()> {
+    encode_parity_in_place_with_work_budget(extended_rows, params, default_work_budget())
+}
+
+/// Encode parity rows in place with an explicit Leopard work-buffer budget.
+pub fn encode_parity_in_place_with_work_budget(
+    extended_rows: &mut RowMatrix,
+    params: &Parameters,
+    work_budget: NonZeroUsize,
+) -> Result<()> {
     let mut view = extended_rows.extended_view_mut(params)?;
     let (orig, parity) = view.split_original_parity();
-    fill_parity(orig, parity, params.k, params.n, params.row_size)
+    fill_parity_with_work_budget(
+        orig,
+        parity,
+        params.k,
+        params.n,
+        params.row_size,
+        work_budget,
+    )
 }
 
 /// Pack GF128 value into a 64-byte Leopard shard.
@@ -380,23 +434,24 @@ mod tests {
 
     #[test]
     fn stripe_plan_respects_work_budget() {
-        for (k, n, row_size, threads, expected_stripe_size, expected_parallelism) in [
-            (4096, 12288, 32768, 32, 64, 32),
-            (4096, 12288, 32768, 1, 2048, 1),
-            (4096, 12288, 32768, 0, 2048, 1),
-            (32768, 32768, 32768, 32, 64, 16),
+        for (k, n, row_size, threads, budget_mib, expected_stripe, expected_parallelism) in [
+            (4096, 12288, 32768, 32, 32, 64, 32),
+            (4096, 12288, 32768, 1, 1, 64, 1),
+            (4096, 12288, 32768, 4, 4, 64, 4),
+            (4096, 12288, 32768, 1, 32, 2048, 1),
+            (32768, 32768, 32768, 32, 32, 64, 16),
         ] {
-            let plan = stripe_plan(k, n, row_size, threads).unwrap();
+            let work_budget = NonZeroUsize::new(budget_mib << 20).unwrap();
+            let plan = stripe_plan(k, n, row_size, threads, work_budget).unwrap();
 
-            assert_eq!(plan.stripe_size(), expected_stripe_size);
+            assert_eq!(plan.stripe_size(), expected_stripe);
             assert_eq!(plan.parallelism(), expected_parallelism);
             assert!(
-                plan.parallelism() * work_shards(k, n) * plan.stripe_size()
-                    <= STRIPE_WORK_BUDGET_BYTES
+                plan.parallelism() * work_shards(k, n) * plan.stripe_size() <= work_budget.get()
             );
         }
 
-        assert!(stripe_plan(4, 4, 0, 1).is_err());
+        assert!(stripe_plan(4, 4, 0, 1, NonZeroUsize::MIN).is_err());
     }
 
     /// Striped, parallel parity must be byte-identical to a single Leopard

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -192,6 +192,30 @@ fn fill_parity_with_plan(
     let parallelism = plan.parallelism();
     assert!(stripe_size.is_multiple_of(MIN_STRIPE));
 
+    // A single stripe (always the case for the 64-byte RLC rows in
+    // `extend_rlcs`) gains nothing from the rayon fan-out and staging copy
+    // below; encode whole rows on the calling thread instead.
+    if stripe_size >= row_size {
+        let mut encoder: HighRateEncoder<DefaultEngine> =
+            RateEncoder::new(k, n, row_size, DefaultEngine::new(), None)
+                .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+        for row in original_rows.chunks_exact(row_size) {
+            encoder
+                .add_original_shard(row)
+                .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+        }
+        let result = encoder
+            .encode()
+            .map_err(|e| Error::ReedSolomon(e.to_string()))?;
+        for (dst_row, src_row) in parity_rows
+            .chunks_exact_mut(row_size)
+            .zip(result.recovery_iter())
+        {
+            dst_row.copy_from_slice(src_row);
+        }
+        return Ok(());
+    }
+
     let stripes: Vec<_> = (0..row_size)
         .step_by(stripe_size)
         .map(|offset| Stripe {
@@ -462,7 +486,8 @@ mod tests {
         use rand_chacha::ChaCha8Rng;
 
         // Plans are explicit so coverage does not depend on the CI machine's
-        // rayon pool. The second case also reuses a slot for a shorter stripe.
+        // rayon pool. The second case also reuses a slot for a shorter stripe;
+        // the last two take the single-stripe path.
         for (k, n, row_size, seed, plan) in [
             (
                 4096usize,
@@ -473,6 +498,7 @@ mod tests {
             ),
             (4096, 12288, 64 * 21, 2, test_stripe_plan(512, 2)),
             (16, 48, 4096, 3, test_stripe_plan(1024, 4)),
+            (16, 48, 256, 5, test_stripe_plan(256, 4)),
             (4, 4, 64, 4, test_stripe_plan(64, 1)),
         ] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -14,17 +14,17 @@ const STRIPE_WORK_BUDGET_BYTES: usize = 32 << 20;
 /// Leopard operates on 64-byte blocks, so stripes stay block-aligned.
 const MIN_STRIPE: usize = 64;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 struct StripePlan {
     stripe_size: NonZeroUsize,
     parallelism: NonZeroUsize,
 }
 
 impl StripePlan {
-    fn new(stripe_size: usize, parallelism: usize) -> Self {
+    const fn new(stripe_size: NonZeroUsize, parallelism: NonZeroUsize) -> Self {
         Self {
-            stripe_size: NonZeroUsize::new(stripe_size).expect("stripe size must be non-zero"),
-            parallelism: NonZeroUsize::new(parallelism).expect("parallelism must be non-zero"),
+            stripe_size,
+            parallelism,
         }
     }
 
@@ -50,14 +50,20 @@ fn work_shards(k: usize, n: usize) -> usize {
 }
 
 /// Choose a block-aligned stripe width and bound the number encoded at once.
-fn stripe_plan(k: usize, n: usize, row_size: usize, threads: usize) -> StripePlan {
+fn stripe_plan(k: usize, n: usize, row_size: usize, threads: usize) -> Result<StripePlan> {
     let work_shards = work_shards(k, n);
     let max_parallelism = (STRIPE_WORK_BUDGET_BYTES / (work_shards * MIN_STRIPE)).max(1);
     let parallelism = threads.max(1).min(max_parallelism);
     let per_encoder = STRIPE_WORK_BUDGET_BYTES / parallelism / work_shards;
     let stripe = (per_encoder / MIN_STRIPE) * MIN_STRIPE;
+    let stripe_size = NonZeroUsize::new(stripe.max(MIN_STRIPE).min(row_size)).ok_or_else(|| {
+        Error::InvalidParameters("stripe planner produced a zero stripe size".into())
+    })?;
+    let parallelism = NonZeroUsize::new(parallelism).ok_or_else(|| {
+        Error::InvalidParameters("stripe planner produced zero parallelism".into())
+    })?;
 
-    StripePlan::new(stripe.clamp(MIN_STRIPE, row_size), parallelism)
+    Ok(StripePlan::new(stripe_size, parallelism))
 }
 
 struct StripeEncoder {
@@ -148,7 +154,7 @@ fn fill_parity(
     HighRateEncoder::<DefaultEngine>::validate(k, n, MIN_STRIPE)
         .map_err(|e| Error::ReedSolomon(e.to_string()))?;
 
-    let plan = stripe_plan(k, n, row_size, rayon::current_num_threads());
+    let plan = stripe_plan(k, n, row_size, rayon::current_num_threads())?;
     fill_parity_with_plan(original_rows, parity_rows, k, n, row_size, plan)
 }
 
@@ -279,6 +285,13 @@ pub fn extend_rlcs(rlc_orig: &[GF128], k: usize, n: usize) -> Result<Vec<GF128>>
 mod tests {
     use super::*;
 
+    fn test_stripe_plan(stripe_size: usize, parallelism: usize) -> StripePlan {
+        StripePlan::new(
+            NonZeroUsize::new(stripe_size).expect("test stripe size must be non-zero"),
+            NonZeroUsize::new(parallelism).expect("test parallelism must be non-zero"),
+        )
+    }
+
     #[test]
     fn test_extend_data() {
         let k = 4;
@@ -367,19 +380,23 @@ mod tests {
 
     #[test]
     fn stripe_plan_respects_work_budget() {
-        for (k, n, row_size, threads, expected) in [
-            (4096, 12288, 32768, 32, StripePlan::new(64, 32)),
-            (4096, 12288, 32768, 1, StripePlan::new(2048, 1)),
-            (32768, 32768, 32768, 32, StripePlan::new(64, 16)),
+        for (k, n, row_size, threads, expected_stripe_size, expected_parallelism) in [
+            (4096, 12288, 32768, 32, 64, 32),
+            (4096, 12288, 32768, 1, 2048, 1),
+            (4096, 12288, 32768, 0, 2048, 1),
+            (32768, 32768, 32768, 32, 64, 16),
         ] {
-            let plan = stripe_plan(k, n, row_size, threads);
+            let plan = stripe_plan(k, n, row_size, threads).unwrap();
 
-            assert_eq!(plan, expected);
+            assert_eq!(plan.stripe_size(), expected_stripe_size);
+            assert_eq!(plan.parallelism(), expected_parallelism);
             assert!(
                 plan.parallelism() * work_shards(k, n) * plan.stripe_size()
                     <= STRIPE_WORK_BUDGET_BYTES
             );
         }
+
+        assert!(stripe_plan(4, 4, 0, 1).is_err());
     }
 
     /// Striped, parallel parity must be byte-identical to a single Leopard
@@ -397,11 +414,11 @@ mod tests {
                 12288usize,
                 512usize,
                 1u64,
-                StripePlan::new(128, 2),
+                test_stripe_plan(128, 2),
             ),
-            (4096, 12288, 64 * 21, 2, StripePlan::new(512, 2)),
-            (16, 48, 4096, 3, StripePlan::new(1024, 4)),
-            (4, 4, 64, 4, StripePlan::new(64, 1)),
+            (4096, 12288, 64 * 21, 2, test_stripe_plan(512, 2)),
+            (16, 48, 4096, 3, test_stripe_plan(1024, 4)),
+            (4, 4, 64, 4, test_stripe_plan(64, 1)),
         ] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let mut original = vec![0u8; k * row_size];

--- a/rsema1d/src/lib.rs
+++ b/rsema1d/src/lib.rs
@@ -21,7 +21,8 @@ pub use codec::{
 pub use codec::Commitment;
 
 pub use codec::{
-    create_verification_context, encode, encode_in_place, encode_parity, reconstruct,
+    create_verification_context, default_work_budget, encode, encode_in_place,
+    encode_in_place_with_work_budget, encode_parity, encode_with_work_budget, reconstruct,
     verify_row_inclusion, verify_row_inclusion_proof, verify_row_with_context, verify_standalone,
     verify_standalone_proof, verify_with_context,
 };


### PR DESCRIPTION
## Overview

Successor of  https://github.com/celestiaorg/lumina/pull/1003 but **without unsafe blocks**

The code on main was correct, but it organized the Reed–Solomon work in a way that was very unfriendly to the CPU cache and could only use one core for parity generation.


## What main did

Fibre v0 divides a maximum-size blob into:

- 4,096 original rows
- 12,288 parity rows
- 32 KiB per row

Conceptually:

```
Original row 0:  [---------------- 32 KiB ----------------]
Original row 1:  [---------------- 32 KiB ----------------]
...
Original row 4095
```

main gave all 4,096 complete rows to one HighRateEncoder:

```
one encoder
    ├── original row 0, all 32 KiB
    ├── original row 1, all 32 KiB
    └── ...
```

The Leopard encoder needs an internal work buffer. For this production shape, that buffer was approximately:

```
16,384 work shards × 32 KiB = 512 MiB
```

That is much larger than the CPU’s cache. Leopard repeatedly walks this buffer while performing its transforms, so it continually fetches data from RAM.

There was also only one encoder running on the calling thread. Rayon could not parallelize the expensive Reed–Solomon calculation.

## Short Summary of Branch changes

So the essence of the change is:

main:
one huge, serial, RAM-bound Reed–Solomon operation

branch:
many small, independent, cache-friendly operations
→ encode concurrently
→ safely assemble identical parity rows

## What the branch does


The branch divides every row into vertical stripes and encodes several stripes concurrently.

For the 128 MiB production case with 32 Rayon workers:

```
row size:                 32 KiB
stripe size:              64 bytes
number of stripes:        32 KiB / 64 = 512
parallel encoders:        32
stripes per batch:        32
number of batches:        512 / 32 = 16
```

One 64-byte stripe requires roughly:

```
16,384 work shards × 64 bytes = 1 MiB
```

Therefore, 32 concurrent encoders need approximately:

```
32 × 1 MiB = 32 MiB
```

That is the purpose of the **work budget**: a performance target for the combined Leopard work buffers, not a total memory limit. `default_work_budget()` allows 2 MiB per physical core, capped by the number of rayon workers (SMT siblings share cache, so they add no budget), with an 8 MiB floor. On the 16-core / 32-thread bench box that is 32 MiB. `stripe_plan` then narrows the stripe (down to 64 bytes) and/or lowers the parallelism until the buffers fit.

Instead of one 512 MiB working set, we now have 32 independent 1 MiB working sets that can run concurrently and fit much better in CPU cache.

### What `StripePlan` does

`stripe_plan` chooses two values:

```rust
struct StripePlan {
    stripe_size: NonZeroUsize,
    parallelism: NonZeroUsize,
}
```

It adapts them to the number of Rayon workers while targeting the same combined work budget.

### What `StripeEncoder` does

Each `StripeEncoder` owns:

```rust
struct StripeEncoder {
    encoder: HighRateEncoder<DefaultEngine>,
    recovery: Vec<u8>,
}
```

The `HighRateEncoder` contains reusable Leopard working state. The recovery vector temporarily stores the parity generated for one stripe.

At the start of fill_parity, the required encoders are constructed in parallel. They are then reused for every batch:

```
  batch 1 → reset encoders → encode stripes
  batch 2 → reset same encoders → encode next stripes
```



### API changes

Every encode entry point gains a `*_with_work_budget` variant that takes the budget explicitly: `encode`, `encode_in_place`, `encode_parity_in_place`, `extend_data`, `ExtendedData::generate`, and `fibre::Blob::new`. `rsema1d::default_work_budget()` is public as well. Existing signatures are unchanged and use the default budget. New dependency: `num_cpus` (physical core count, read once and cached).

### Why parity is written in two phases

Writing stripes directly into the final matrix concurrently is awkward in safe Rust. (that's what has been done in original PR). The unsafe PR used raw pointers and relied on a manually maintained disjointness argument.

The safe implementation instead performs two phases:

1. Encode each stripe into an encoder-owned recovery buffer.
2. Split the final output into disjoint mutable parity rows and copy the completed stripes into each row.

```
temporary stripe results
          │
          ▼
parity row 0: [stripe 0][stripe 1][stripe 2]...
parity row 1: [stripe 0][stripe 1][stripe 2]...
```


`par_chunks_mut(row_size)` guarantees that each Rayon task owns a different parity row. Consequently, all final writes use ordinary safe slices—no raw pointers and no unsafe aliasing argument.

The cost is an additional intermediate copy and batch synchronization.

### Note on SIMD

SIMD instructions remain fully utilized, but striping introduces orchestration overhead around them.

### Small-row regression and fix

The raw `blob_new/128KB` runs below show a +13–17% regression. 128 KB blobs have 64-byte rows, i.e. a single stripe, and that case still went through the rayon encoder fan-out and the batch/scatter copy. On top of that, `default_work_budget()` re-parsed `/proc/cpuinfo` through `num_cpus::get_physical()` (~0.4 ms) on every call. The same path is hit by `extend_rlcs` on every `VerificationContext::new`, which showed up as `verification_context/k4096_n12288` going from 1.55 ms to 2.48 ms.

Fixed in 0b7422869957253d49a5440d5946f599a9f8339c: rows that fit in one stripe take the original single-encoder path on the calling thread, and the physical core count is cached in a `OnceLock`. After the fix, `verification_context/k4096_n12288` is back to 1.55 ms (same as main), `encode_in_place/8MB_k4096_n12288` is 18.6 ms, and `blob_new/128KB` is within the ±4–5% band that identical-code 128 KB rsema1d benches also swing in between runs.

**All benchmark output below was collected before this fix.**

## Correctness

- `striped_parity_matches_single_encoder` compares the striped output against a single whole-row `HighRateEncoder` (what validators recompute on the Go side) with explicit plans: the production K/N, a row size whose last stripe is shorter, slot reuse across batches, and the single-stripe path.
- `work_budget_does_not_change_encoded_output`: extended rows, commitment and RLCs are identical across budgets.
- Go cross-implementation vectors (`go_fuzzy_vectors_match_rust`, 254 cases including K=4096/N=12288) pass.

## Benchmarks

**rsema1d**

```
encode_in_place/8MB_k4096_n12288
                        time:   [48.230 ms 48.345 ms 48.463 ms]
                        time:   [48.228 ms 48.327 ms 48.426 ms]
                        time:   [48.676 ms 48.775 ms 48.880 ms]
                        thrpt:  [165.07 MiB/s 165.48 MiB/s 165.87 MiB/s]
                        thrpt:  [165.20 MiB/s 165.54 MiB/s 165.88 MiB/s]
                        thrpt:  [163.67 MiB/s 164.02 MiB/s 164.35 MiB/s]
encode_in_place/128MB_k4096_n12288
                        time:   [752.72 ms 753.45 ms 754.20 ms]
                        time:   [753.49 ms 754.37 ms 755.27 ms]
                        time:   [758.95 ms 760.13 ms 761.32 ms]
                        thrpt:  [169.72 MiB/s 169.89 MiB/s 170.05 MiB/s]
                        thrpt:  [169.48 MiB/s 169.68 MiB/s 169.88 MiB/s]
                        thrpt:  [168.13 MiB/s 168.39 MiB/s 168.65 MiB/s]



## Branch (3 runs)

encode_in_place/8MB_k4096_n12288
                        time:   [19.025 ms 19.113 ms 19.201 ms]
                        thrpt:  [416.66 MiB/s 418.57 MiB/s 420.50 MiB/s]
                 change:
                        time:   [-61.024% -60.815% -60.606%] (p = 0.00 < 0.05)
                        thrpt:  [+153.85% +155.20% +156.57%]
                        Performance has improved.

encode_in_place/128MB_k4096_n12288
                        time:   [232.58 ms 232.89 ms 233.20 ms]
                        thrpt:  [548.89 MiB/s 549.63 MiB/s 550.36 MiB/s]
                 change:
                        time:   [-69.427% -69.362% -69.298%] (p = 0.00 < 0.05)
                        thrpt:  [+225.72% +226.40% +227.09%]
                        Performance has improved.

encode_in_place/8MB_k4096_n12288
                        time:   [18.888 ms 18.967 ms 19.044 ms]
                        thrpt:  [420.07 MiB/s 421.79 MiB/s 423.54 MiB/s]
                 change:
                        time:   [-61.278% -61.114% -60.945%] (p = 0.00 < 0.05)
                        thrpt:  [+156.05% +157.16% +158.25%]
                        Performance has improved.

encode_in_place/128MB_k4096_n12288
                        time:   [232.31 ms 232.60 ms 232.90 ms]
                        thrpt:  [549.60 MiB/s 550.30 MiB/s 550.98 MiB/s]
                 change:
                        time:   [-69.461% -69.400% -69.337%] (p = 0.00 < 0.05)
                        thrpt:  [+226.13% +226.80% +227.45%]
                        Performance has improved.

encode_in_place/8MB_k4096_n12288
                        time:   [18.667 ms 18.746 ms 18.829 ms]
                        thrpt:  [424.88 MiB/s 426.75 MiB/s 428.56 MiB/s]
                 change:
                        time:   [-61.739% -61.566% -61.383%] (p = 0.00 < 0.05)
                        thrpt:  [+158.96% +160.19% +161.36%]
                        Performance has improved.

encode_in_place/128MB_k4096_n12288
                        time:   [232.50 ms 232.88 ms 233.30 ms]
                        thrpt:  [548.65 MiB/s 549.64 MiB/s 550.55 MiB/s]
                 change:
                        time:   [-69.434% -69.363% -69.284%] (p = 0.00 < 0.05)
                        thrpt:  [+225.57% +226.40% +227.16%]
                        Performance has improved.
```

**fibre_bench blob::new**

```
# Main baseline
blob_new/128KB          time:   [3.7608 ms 3.7807 ms 3.8019 ms]
                        time:   [3.7928 ms 3.8162 ms 3.8410 ms]
                        time:   [3.8141 ms 3.8346 ms 3.8555 ms]
                        thrpt:  [32.878 MiB/s 33.063 MiB/s 33.238 MiB/s]
                        thrpt:  [32.544 MiB/s 32.755 MiB/s 32.957 MiB/s]
                        thrpt:  [32.421 MiB/s 32.598 MiB/s 32.773 MiB/s]

blob_new/1MB            time:   [8.6042 ms 8.6250 ms 8.6427 ms]
                        time:   [8.5250 ms 8.5669 ms 8.6102 ms]
                        time:   [8.5048 ms 8.5373 ms 8.5708 ms]
                        thrpt:  [115.70 MiB/s 115.94 MiB/s 116.22 MiB/s]
                        thrpt:  [116.14 MiB/s 116.73 MiB/s 117.30 MiB/s]
                        thrpt:  [116.68 MiB/s 117.13 MiB/s 117.58 MiB/s]

blob_new/8MB            time:   [60.247 ms 60.297 ms 60.342 ms]
                        time:   [60.054 ms 60.096 ms 60.138 ms]
                        time:   [60.134 ms 60.182 ms 60.232 ms]
                        thrpt:  [132.58 MiB/s 132.68 MiB/s 132.79 MiB/s]
                        thrpt:  [133.03 MiB/s 133.12 MiB/s 133.21 MiB/s]
                        thrpt:  [132.82 MiB/s 132.93 MiB/s 133.04 MiB/s]

blob_new/32MB           time:   [237.25 ms 237.79 ms 238.28 ms]
                        time:   [237.89 ms 238.34 ms 238.75 ms]
                        time:   [237.06 ms 237.40 ms 237.74 ms]
                        thrpt:  [134.29 MiB/s 134.57 MiB/s 134.88 MiB/s]
                        thrpt:  [134.03 MiB/s 134.26 MiB/s 134.51 MiB/s]
                        thrpt:  [134.60 MiB/s 134.80 MiB/s 134.99 MiB/s]

blob_new/128MB          time:   [932.75 ms 935.25 ms 937.80 ms]
                        time:   [927.01 ms 935.06 ms 945.37 ms]
                        time:   [929.09 ms 931.53 ms 933.89 ms]
                        thrpt:  [136.49 MiB/s 136.86 MiB/s 137.23 MiB/s]
                        thrpt:  [135.40 MiB/s 136.89 MiB/s 138.08 MiB/s]
                        thrpt:  [137.06 MiB/s 137.41 MiB/s 137.77 MiB/s]


## Branch (2 runs)

blob_new/128KB          time:   [4.3011 ms 4.3232 ms 4.3482 ms]
                        thrpt:  [28.748 MiB/s 28.914 MiB/s 29.062 MiB/s]
                 change:
                        time:   [+12.379% +13.180% +14.049%] (p = 0.00 < 0.05)
                        thrpt:  [-12.319% -11.645% -11.016%]
                        Performance has regressed.

blob_new/1MB            time:   [6.5756 ms 6.6229 ms 6.6642 ms]
                        thrpt:  [150.05 MiB/s 150.99 MiB/s 152.08 MiB/s]
                 change:
                        time:   [-24.705% -24.071% -23.491%] (p = 0.00 < 0.05)
                        thrpt:  [+30.703% +31.702% +32.811%]
                        Performance has improved.

blob_new/8MB            time:   [29.413 ms 38.834 ms 52.840 ms]
                        thrpt:  [151.40 MiB/s 206.00 MiB/s 271.98 MiB/s]
                 change:
                        time:   [-51.963% -35.513% -13.060%] (p = 0.01 < 0.05)
                        thrpt:  [+15.022% +55.070% +108.17%]
                        Performance has improved.

blob_new/32MB           time:   [106.61 ms 107.80 ms 109.35 ms]
                        thrpt:  [292.65 MiB/s 296.84 MiB/s 300.17 MiB/s]
                 change:
                        time:   [-55.144% -54.644% -53.972%] (p = 0.00 < 0.05)
                        thrpt:  [+117.26% +120.48% +122.93%]
                        Performance has improved.

blob_new/128MB          time:   [391.32 ms 401.97 ms 415.32 ms]
                        thrpt:  [308.20 MiB/s 318.43 MiB/s 327.10 MiB/s]
                 change:
                        time:   [-58.050% -56.855% -55.251%] (p = 0.00 < 0.05)
                        thrpt:  [+123.47% +131.78% +138.38%]
                        Performance has improved.
blob_new/128KB          time:   [4.3862 ms 4.4602 ms 4.5838 ms]
                        thrpt:  [27.270 MiB/s 28.026 MiB/s 28.499 MiB/s]
                 change:
                        time:   [+14.670% +16.767% +19.962%] (p = 0.00 < 0.05)
                        thrpt:  [-16.640% -14.359% -12.793%]
                        Performance has regressed.

blob_new/1MB            time:   [6.6606 ms 6.7139 ms 6.7603 ms]
                        thrpt:  [147.92 MiB/s 148.94 MiB/s 150.14 MiB/s]
                 change:
                        time:   [-23.776% -23.028% -22.411%] (p = 0.00 < 0.05)
                        thrpt:  [+28.884% +29.917% +31.193%]
                        Performance has improved.

blob_new/8MB            time:   [26.357 ms 26.452 ms 26.556 ms]
                        thrpt:  [301.25 MiB/s 302.43 MiB/s 303.52 MiB/s]
                 change:
                        time:   [-56.238% -56.075% -55.890%] (p = 0.00 < 0.05)
                        thrpt:  [+126.70% +127.66% +128.51%]
                        Performance has improved.
blob_new/32MB           time:   [101.78 ms 101.90 ms 102.00 ms]
                        thrpt:  [313.72 MiB/s 314.04 MiB/s 314.39 MiB/s]
                 change:
                        time:   [-57.221% -57.129% -57.034%] (p = 0.00 < 0.05)
                        thrpt:  [+132.74% +133.26% +133.76%]
                        Performance has improved.
blob_new/128MB          time:   [383.65 ms 384.48 ms 385.32 ms]
                        thrpt:  [332.19 MiB/s 332.92 MiB/s 333.64 MiB/s]
                 change:
                        time:   [-58.876% -58.733% -58.587%] (p = 0.00 < 0.05)
                        thrpt:  [+141.47% +142.32% +143.17%]
                        Performance has improved.
```


