### PR TITLE
refactor(fibre): split blob lifecycle states

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [**breaking**] change Fibre uploads to accept `EncodedFibreBlob` and make downloaded `FibreBlob` data always present
+
 ## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-client-v1.0.0...celestia-client-v1.1.0-rc.1) - 2026-06-24
 
 ### Added

--- a/client/src/fibre.rs
+++ b/client/src/fibre.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use celestia_fibre::{
-    Blob, BlobID, DownloadOptions, FibreClient, FibreError, SignedPaymentPromise,
+    Blob, BlobID, DownloadOptions, EncodedBlob, FibreClient, FibreError, SignedPaymentPromise,
 };
 use celestia_grpc::{SubmittedTx, TxConfig};
 use celestia_types::nmt::Namespace;
@@ -32,7 +32,7 @@ impl FibreApi {
         }
     }
 
-    /// Upload a pre-encoded [`Blob`] and collect validator signatures.
+    /// Upload an [`EncodedBlob`] and collect validator signatures.
     ///
     /// Returns a [`SignedPaymentPromise`] once enough validator signatures
     /// have been collected to meet the safety threshold.
@@ -40,7 +40,7 @@ impl FibreApi {
         &self,
         signing_key: &SigningKey,
         namespace: Namespace,
-        blob: Blob,
+        blob: EncodedBlob,
     ) -> Result<SignedPaymentPromise, FibreError> {
         self.fibre_client.upload(signing_key, namespace, blob).await
     }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -39,9 +39,9 @@ pub mod api {
         pub use celestia_fibre::NativeTcpConnector;
         #[doc(inline)]
         pub use celestia_fibre::{
-            Blob as FibreBlob, BlobID, BoxedFibreIo, DownloadOptions, FibreClient,
-            FibreClientConfig, FibreError, FibreIo, FibreIoConnector, PaymentPromise,
-            SignedPaymentPromise,
+            Blob as FibreBlob, BlobConfig, BlobID, BoxedFibreIo, DownloadOptions,
+            EncodedBlob as EncodedFibreBlob, FibreClient, FibreClientConfig, FibreError, FibreIo,
+            FibreIoConnector, PaymentPromise, SignedPaymentPromise,
         };
     }
 

--- a/fibre/CHANGELOG.md
+++ b/fibre/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- split the Fibre blob lifecycle into upload-ready `EncodedBlob`, private reconstruction state, and decoded `Blob`
+- [**breaking**] split the Fibre blob lifecycle into upload-ready `EncodedBlob`, private reconstruction state, and decoded `Blob`
 - remove the public manual-reconstruction API (`Blob::empty` and `Blob::set_row`); use `FibreClient::download` instead
 
 ## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-fibre-v1.0.0...celestia-fibre-v1.1.0-rc.1) - 2026-06-24

--- a/fibre/CHANGELOG.md
+++ b/fibre/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- split the Fibre blob lifecycle into upload-ready `EncodedBlob`, private reconstruction state, and decoded `Blob`
 - remove the public manual-reconstruction API (`Blob::empty` and `Blob::set_row`); use `FibreClient::download` instead
 
 ## [1.1.0-rc.1](https://github.com/celestiaorg/lumina/compare/celestia-fibre-v1.0.0...celestia-fibre-v1.1.0-rc.1) - 2026-06-24

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -48,7 +48,8 @@ use rand::rngs::OsRng;
 
 use celestia_fibre::transport::proto_conv;
 use celestia_fibre::{
-    Blob, BlobConfig, FibreClientConfig, Fraction, PaymentPromise, ValidatorInfo, ValidatorSet,
+    BlobConfig, EncodedBlob, FibreClientConfig, Fraction, PaymentPromise, ValidatorInfo,
+    ValidatorSet,
 };
 use celestia_proto::celestia::fibre::v1 as proto;
 use celestia_types::nmt::Namespace;
@@ -121,7 +122,7 @@ fn bench_blob_new(c: &mut Criterion) {
         let data = generate_data(len);
         group.throughput(Throughput::Bytes(len as u64));
         group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
-            b.iter(|| Blob::new(black_box(data), BlobConfig::v0()).unwrap());
+            b.iter(|| EncodedBlob::new(black_box(data), BlobConfig::v0()).unwrap());
         });
     }
 
@@ -142,7 +143,7 @@ fn bench_blob_row_proofs(c: &mut Criterion) {
     group.noise_threshold(0.03);
 
     for &(name, len) in &[("1MB", 1 << 20), ("8MB", 8 << 20)] {
-        let blob = Blob::new(&generate_data(len), BlobConfig::v0()).unwrap();
+        let blob = EncodedBlob::new(&generate_data(len), BlobConfig::v0()).unwrap();
 
         let shard = rows_per_shard();
         group.bench_function(BenchmarkId::new(format!("shard_{shard}_rows"), name), |b| {
@@ -275,7 +276,7 @@ fn bench_parse_download_response(c: &mut Criterion) {
     group.noise_threshold(0.03);
 
     let shard = rows_per_shard();
-    let blob = Blob::new(&generate_data(1 << 20), BlobConfig::v0()).unwrap();
+    let blob = EncodedBlob::new(&generate_data(1 << 20), BlobConfig::v0()).unwrap();
 
     let rows: Vec<proto::BlobRow> = (0..shard)
         .map(|i| {
@@ -289,7 +290,6 @@ fn bench_parse_download_response(c: &mut Criterion) {
         .collect();
     let rlcs: Vec<u8> = blob
         .rlc_coeffs()
-        .unwrap()
         .iter()
         .flat_map(|rlc| rlc.to_bytes())
         .collect();

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 use crate::client::task::{TaskSet, spawn_task};
 
 use crate::ValidatorInfo;
-use crate::blob::{Blob, BlobID, ShardVerifier, VerifiedRows};
+use crate::blob::{Blob, BlobID, BlobReconstruction, ShardVerifier, VerifiedRows};
 use crate::client::FibreClient;
 #[cfg(test)]
 use crate::config::BlobConfig;
@@ -34,7 +34,7 @@ impl FibreClient {
     /// 3. Downloads row inclusion proofs from validators using adaptive fan-out.
     /// 4. Reconstructs the original data from collected proofs.
     ///
-    /// Returns the reconstructed [`Blob`] whose `data()` contains the original payload.
+    /// Returns a [`Blob`] containing the original payload.
     ///
     /// # Errors
     ///
@@ -51,16 +51,16 @@ impl FibreClient {
             Some(h) => self.set_getter.get_by_height(h).await?,
             None => self.set_getter.head().await?,
         };
-        let mut blob = Blob::empty(id.clone())?;
-        self.select_and_download(&val_set, &mut blob).await?;
-        blob.reconstruct()?;
-        Ok(blob)
+        let mut reconstruction = BlobReconstruction::new(id.clone())?;
+        self.select_and_download(&val_set, &mut reconstruction)
+            .await?;
+        reconstruction.reconstruct()
     }
 
     /// Internal download with a custom [`BlobConfig`].
     ///
     /// This allows tests to use small K/N parameters without going through
-    /// the production `Blob::empty()` path which hardcodes production params.
+    /// the production `BlobReconstruction::new()` path which uses production params.
     #[cfg(test)]
     pub(crate) async fn download_with_config(
         &self,
@@ -72,16 +72,16 @@ impl FibreClient {
         }
 
         let val_set = self.set_getter.head().await?;
-        let mut blob = Blob::empty_with_config(id.clone(), blob_cfg);
-        self.select_and_download(&val_set, &mut blob).await?;
-        blob.reconstruct()?;
-        Ok(blob)
+        let mut reconstruction = BlobReconstruction::with_config(id.clone(), blob_cfg);
+        self.select_and_download(&val_set, &mut reconstruction)
+            .await?;
+        reconstruction.reconstruct()
     }
 
     async fn select_and_download(
         &self,
         val_set: &ValidatorSet,
-        blob: &mut Blob,
+        blob: &mut BlobReconstruction,
     ) -> Result<(), FibreError> {
         let selected = val_set.select(
             blob.config().original_rows,
@@ -108,7 +108,7 @@ impl FibreClient {
         &self,
         selected: &[(usize, &ValidatorInfo)],
         original_rows: usize,
-        blob: &mut Blob,
+        blob: &mut BlobReconstruction,
         cancel_token: &CancellationToken,
     ) -> Result<(), FibreError> {
         if selected.is_empty() {
@@ -175,7 +175,7 @@ impl FibreClient {
                         Some((val_idx, Some(Ok(verified)))) => {
                             let (rows, info) = selected[val_idx];
                             inflight_rows = inflight_rows.saturating_sub(rows);
-                            let applied = blob.store_rows(verified)?;
+                            let applied = blob.store_rows(verified);
                             // Shards are never empty here, so zero
                             // applied means all rows were duplicates.
                             if applied == 0 {
@@ -242,7 +242,7 @@ mod tests {
     use tokio::sync::Barrier;
     use tokio_util::sync::CancellationToken;
 
-    use crate::blob::{Blob, BlobID};
+    use crate::blob::{BlobID, BlobReconstruction, EncodedBlob};
     use crate::config::BlobConfig;
     use crate::error::FibreError;
     use crate::payment_promise::PaymentPromise;
@@ -316,7 +316,7 @@ mod tests {
         connections: &[Arc<MockValidatorConnection>],
         cfg: &BlobConfig,
     ) -> BlobID {
-        let blob = Blob::new(data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
         let total_rows = cfg.total_rows();
 
@@ -325,11 +325,7 @@ mod tests {
             for i in 0..total_rows {
                 proofs.push(blob.row(i).unwrap());
             }
-            conn.store_proofs(
-                blob_id.commitment(),
-                proofs,
-                blob.rlc_coeffs().unwrap().to_vec(),
-            );
+            conn.store_proofs(blob_id.commitment(), proofs, blob.rlc_coeffs().to_vec());
         }
 
         blob_id
@@ -366,7 +362,7 @@ mod tests {
         let client = build_test_client(val_set, connector, "test-chain");
         let blob = client.download_with_config(&blob_id, cfg).await.unwrap();
 
-        assert_eq!(blob.data().unwrap(), &data);
+        assert_eq!(blob.data(), &data);
     }
 
     #[tokio::test]
@@ -399,7 +395,7 @@ mod tests {
             .map(|(k, _)| Arc::new(MockValidatorConnection::new(k.clone())))
             .collect();
 
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
         let total_rows = cfg.total_rows();
 
@@ -408,11 +404,7 @@ mod tests {
             for i in 0..total_rows {
                 proofs.push(blob.row(i).unwrap());
             }
-            conn.store_proofs(
-                blob_id.commitment(),
-                proofs,
-                blob.rlc_coeffs().unwrap().to_vec(),
-            );
+            conn.store_proofs(blob_id.commitment(), proofs, blob.rlc_coeffs().to_vec());
         }
 
         let mut connector = MockConnector::new();
@@ -425,7 +417,7 @@ mod tests {
         let client = build_test_client(val_set, connector, "test-chain");
         let result = client.download_with_config(&blob_id, cfg).await.unwrap();
 
-        assert_eq!(result.data().unwrap(), &data);
+        assert_eq!(result.data(), &data);
     }
 
     #[tokio::test]
@@ -445,7 +437,7 @@ mod tests {
             .map(|(k, _)| Arc::new(MockValidatorConnection::new(k.clone())))
             .collect();
 
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
         let total_rows = cfg.total_rows();
 
@@ -458,11 +450,7 @@ mod tests {
                 }
                 proofs.push(proof);
             }
-            conn.store_proofs(
-                blob_id.commitment(),
-                proofs,
-                blob.rlc_coeffs().unwrap().to_vec(),
-            );
+            conn.store_proofs(blob_id.commitment(), proofs, blob.rlc_coeffs().to_vec());
         }
 
         let mut connector = MockConnector::new();
@@ -471,7 +459,7 @@ mod tests {
         }
 
         let client = build_test_client(val_set, connector, "test-chain");
-        let mut result = Blob::empty_with_config(blob_id, cfg.clone());
+        let mut reconstruction = BlobReconstruction::with_config(blob_id, cfg.clone());
         let selected = [
             (cfg.original_rows, &val_infos[0]),
             (cfg.original_rows, &val_infos[1]),
@@ -481,21 +469,21 @@ mod tests {
             .download_blob(
                 &selected,
                 cfg.original_rows,
-                &mut result,
+                &mut reconstruction,
                 &CancellationToken::new(),
             )
             .await
             .unwrap();
-        result.reconstruct().unwrap();
+        let result = reconstruction.reconstruct().unwrap();
 
-        assert_eq!(result.data().unwrap(), &data);
+        assert_eq!(result.data(), &data);
     }
 
     #[tokio::test]
     async fn download_cancels_inflight_tasks_after_reaching_threshold() {
         let cfg = test_blob_config();
         let data: Vec<u8> = (0u8..=199).collect();
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
         let validators = [make_validator(100, 1), make_validator(100, 2)];
         let val_infos: Vec<_> = validators.iter().map(|(_, info)| info.clone()).collect();
@@ -514,7 +502,7 @@ mod tests {
                     }
                 })
                 .collect(),
-            rlcs: blob.rlc_coeffs().unwrap().to_vec(),
+            rlcs: blob.rlc_coeffs().to_vec(),
         };
         let connector = CoordinatedConnector {
             fast_address: val_infos[0].address,
@@ -523,14 +511,14 @@ mod tests {
             barrier: Arc::new(Barrier::new(2)),
         };
         let client = build_test_client(val_set, connector, "test-chain");
-        let mut result = Blob::empty_with_config(blob_id, cfg.clone());
+        let mut reconstruction = BlobReconstruction::with_config(blob_id, cfg.clone());
         let selected = [(2, &val_infos[0]), (2, &val_infos[1])];
 
         client
             .download_blob(
                 &selected,
                 cfg.original_rows,
-                &mut result,
+                &mut reconstruction,
                 &CancellationToken::new(),
             )
             .await
@@ -561,7 +549,7 @@ mod tests {
         let mut connector = MockConnector::new();
         connector.add(val_infos[0].address, failing_conn);
 
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
 
         let client = build_test_client(val_set, connector, "test-chain");
@@ -614,7 +602,7 @@ mod tests {
             height: 42,
         };
 
-        let blob = Blob::new(&original_data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&original_data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
         let total_rows = cfg.total_rows();
 
@@ -628,11 +616,7 @@ mod tests {
             for i in 0..total_rows {
                 proofs.push(blob.row(i).unwrap());
             }
-            conn.store_proofs(
-                blob_id.commitment(),
-                proofs,
-                blob.rlc_coeffs().unwrap().to_vec(),
-            );
+            conn.store_proofs(blob_id.commitment(), proofs, blob.rlc_coeffs().to_vec());
         }
 
         let mut connector = MockConnector::new();
@@ -643,7 +627,7 @@ mod tests {
         let client = build_test_client(val_set, connector, "test-chain");
         let downloaded = client.download_with_config(&blob_id, cfg).await.unwrap();
 
-        assert_eq!(downloaded.data().unwrap(), &original_data);
+        assert_eq!(downloaded.data(), &original_data);
         assert_eq!(downloaded.id(), &blob_id);
     }
 
@@ -664,7 +648,7 @@ mod tests {
             height: 1,
         };
 
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
         let total_rows = cfg.total_rows();
 
@@ -680,11 +664,7 @@ mod tests {
                 for i in 0..total_rows {
                     proofs.push(blob.row(i).unwrap());
                 }
-                conn.store_proofs(
-                    blob_id.commitment(),
-                    proofs,
-                    blob.rlc_coeffs().unwrap().to_vec(),
-                );
+                conn.store_proofs(blob_id.commitment(), proofs, blob.rlc_coeffs().to_vec());
                 conn
             })
             .collect();
@@ -697,6 +677,6 @@ mod tests {
         let client = build_test_client(val_set, connector, "test-chain");
         let downloaded = client.download_with_config(&blob_id, cfg).await.unwrap();
 
-        assert_eq!(downloaded.data().unwrap(), &data);
+        assert_eq!(downloaded.data(), &data);
     }
 }

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -1,6 +1,6 @@
 //! Upload flow orchestration.
 //!
-//! Distributes a pre-encoded [`Blob`] to validators, collecting ed25519
+//! Distributes an [`EncodedBlob`] to validators, collecting ed25519
 //! signatures until the safety threshold is met, then returns a
 //! [`SignedPaymentPromise`].
 //!
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::client::task::{TaskSet, spawn_task};
 
-use crate::blob::Blob;
+use crate::blob::EncodedBlob;
 use crate::client::FibreClient;
 use crate::config::BlobConfig;
 use crate::error::FibreError;
@@ -26,7 +26,7 @@ use crate::validator::signature_set::SignatureSet;
 use crate::validator::{ShardMap, ValidatorSet};
 
 impl FibreClient {
-    /// Upload a pre-encoded [`Blob`] and collect validator signatures.
+    /// Upload an [`EncodedBlob`] and collect validator signatures.
     ///
     /// Returns a [`SignedPaymentPromise`] once enough validator signatures
     /// have been collected to meet the safety threshold.
@@ -34,7 +34,7 @@ impl FibreClient {
         &self,
         signing_key: &k256::ecdsa::SigningKey,
         namespace: Namespace,
-        blob: Blob,
+        blob: EncodedBlob,
     ) -> Result<SignedPaymentPromise, FibreError> {
         if self.cancel_token.is_cancelled() {
             return Err(FibreError::ClientClosed);
@@ -44,9 +44,7 @@ impl FibreClient {
         let val_set = self.set_getter.head().await?;
 
         // 2. Create and sign payment promise
-        let upload_size = blob
-            .upload_size()
-            .ok_or_else(|| FibreError::Other("blob has no data to upload".into()))?;
+        let upload_size = blob.upload_size();
         let upload_size_u32 = u32::try_from(upload_size).map_err(|_| FibreError::BlobTooLarge {
             size: upload_size,
             max: u32::MAX as usize,
@@ -118,8 +116,8 @@ impl FibreClient {
             return Err(FibreError::ClientClosed);
         }
 
-        // 1. Encode data into a Blob.
-        let blob = Blob::new(data, BlobConfig::for_version(0)?)?;
+        // 1. Encode data into an EncodedBlob.
+        let blob = EncodedBlob::new(data, BlobConfig::for_version(0)?)?;
 
         // 2. Upload to validators and collect signatures.
         let signed_promise = self.upload(signing_key, namespace, blob).await?;
@@ -153,7 +151,7 @@ impl FibreClient {
         val_set: &ValidatorSet,
         shard_map: &ShardMap,
         promise: &PaymentPromise,
-        blob: &Arc<Blob>,
+        blob: &Arc<EncodedBlob>,
         sig_set: &Arc<SignatureSet>,
         cancel_token: &CancellationToken,
     ) -> Result<(), FibreError> {
@@ -163,12 +161,6 @@ impl FibreClient {
             .iter()
             .map(|(&val_idx, row_indices)| (val_idx, row_indices.clone()))
             .collect();
-
-        let rlc_coeffs = Arc::new(
-            blob.rlc_coeffs()
-                .ok_or_else(|| FibreError::Other("blob has no RLC coefficients to upload".into()))?
-                .to_vec(),
-        );
 
         let mut futures: TaskSet<usize, Result<Vec<u8>, FibreError>> = TaskSet::new();
 
@@ -185,7 +177,6 @@ impl FibreClient {
             let connector = Arc::clone(&self.connector);
             let validator = val_set.validators[val_idx].clone();
             let promise = promise.clone();
-            let rlc_coeffs = Arc::clone(&rlc_coeffs);
             let blob = Arc::clone(blob);
 
             spawn_task(&mut futures, val_idx, async move {
@@ -198,7 +189,9 @@ impl FibreClient {
                 }
 
                 let conn = connector.connect(&validator).await?;
-                let resp = conn.upload_shard(&promise, &proofs, &rlc_coeffs).await?;
+                let resp = conn
+                    .upload_shard(&promise, &proofs, blob.rlc_coeffs())
+                    .await?;
                 Ok(resp.validator_signature)
             });
         }
@@ -267,7 +260,7 @@ mod tests {
     use k256::ecdsa::SigningKey;
     use rand::rngs::OsRng;
 
-    use crate::blob::Blob;
+    use crate::blob::EncodedBlob;
     use crate::config::BlobConfig;
     use crate::error::FibreError;
     use crate::test_utils::{
@@ -276,10 +269,10 @@ mod tests {
     };
     use crate::validator::{ValidatorInfo, ValidatorSet};
 
-    fn make_test_blob() -> Blob {
+    fn make_test_blob() -> EncodedBlob {
         let cfg = BlobConfig::new_test(0, 4, 4, 4096, 4, 64);
         let data: Vec<u8> = (0u8..200).collect();
-        Blob::new(&data, cfg).unwrap()
+        EncodedBlob::new(&data, cfg).unwrap()
     }
 
     fn test_signing_key() -> SigningKey {

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -244,6 +244,9 @@ impl BlobReconstruction {
     ///
     /// Rows whose index is already filled are skipped. Returns the number of
     /// genuinely new rows stored.
+    ///
+    /// Row indexes are not re-checked here: [`ShardVerifier::new`] copies this
+    /// reconstruction's config, so `verify` already bounds them by `total_rows`.
     pub(crate) fn store_rows(&mut self, rows: VerifiedRows) -> usize {
         let mut applied = 0;
         for proof in rows.0 {
@@ -571,10 +574,13 @@ mod tests {
         Ok(blob.store_rows(verified))
     }
 
+    fn test_data() -> Vec<u8> {
+        (0u8..=249).collect()
+    }
+
     fn test_blob_and_reconstruction() -> (EncodedBlob, BlobReconstruction) {
         let cfg = BlobConfig::new_test(0, 4, 4, 4096, 4, 64);
-        let data: Vec<u8> = (0u8..=249).collect();
-        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&test_data(), cfg.clone()).unwrap();
         let reconstruction = BlobReconstruction::with_config(blob.id().clone(), cfg);
         (blob, reconstruction)
     }
@@ -591,7 +597,8 @@ mod tests {
                 .unwrap();
 
         assert_eq!(unique, 4);
-        reconstruction.reconstruct().unwrap();
+        let reconstructed = reconstruction.reconstruct().unwrap();
+        assert_eq!(reconstructed.data(), &test_data());
     }
 
     #[tokio::test]

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -3,7 +3,8 @@
 //! This module implements the core blob data structures for the Fibre protocol:
 //! - `Commitment`: a 32-byte SHA-256 commitment hash
 //! - `BlobID`: version byte + commitment that uniquely identifies a blob
-//! - `Blob`: encoded data with Reed-Solomon erasure coding
+//! - `EncodedBlob`: encoded data ready for upload
+//! - `Blob`: decoded data returned by download
 
 use std::fmt;
 use std::sync::Arc;
@@ -101,26 +102,35 @@ impl fmt::Debug for BlobID {
     }
 }
 
-/// Encoded blob with Reed-Solomon erasure coding.
-///
-/// A `Blob` can be created in two ways:
-/// - `Blob::new()` encodes data into a new blob (for upload)
-/// - [`FibreClient::download`](crate::FibreClient::download) reconstructs blobs from downloaded shards
+/// Decoded blob returned by [`FibreClient::download`](crate::FibreClient::download).
+#[derive(Debug)]
 pub struct Blob {
-    cfg: BlobConfig,
-    extended_data: Option<rsema1d::ExtendedData>,
     id: BlobID,
-    rlc_coeffs: Option<Vec<rsema1d::GF128>>,
-    header: BlobHeaderV0,
-    /// The decoded original data (without header). `None` until encoded or reconstructed.
-    data: Option<Vec<u8>>,
-    /// Rows buffer for reconstruction (indexed by row number).
-    /// `None` entries indicate missing rows.
-    rows: Option<Vec<Option<Vec<u8>>>>,
+    data: Vec<u8>,
 }
 
 impl Blob {
-    /// Encode data into a new Blob.
+    /// Returns the BlobID of this blob.
+    pub fn id(&self) -> &BlobID {
+        &self.id
+    }
+
+    /// Returns the original data without the header.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+/// Encoded blob ready for upload.
+pub struct EncodedBlob {
+    cfg: BlobConfig,
+    extended_data: rsema1d::ExtendedData,
+    id: BlobID,
+    data_size: usize,
+}
+
+impl EncodedBlob {
+    /// Encode data into a new upload-ready blob.
     ///
     /// The data is prefixed with a header containing the blob version and data size,
     /// then split into rows and erasure-coded using rsema1d.
@@ -149,56 +159,16 @@ impl Blob {
         header.encode_into_buffer(data, &mut flat);
         let extended = rsema1d::RowMatrix::with_shape(flat, total_rows, row_size)?;
         let params = rsema1d::Parameters::new(cfg.original_rows, cfg.parity_rows, row_size)?;
-        let (ext_data, commitment, rlc_orig) = rsema1d::encode_in_place(extended, &params)?;
+        let (extended_data, commitment, _) = rsema1d::encode_in_place(extended, &params)?;
 
         let id = BlobID::new(cfg.blob_version, commitment);
 
         Ok(Self {
             cfg,
-            extended_data: Some(ext_data),
+            extended_data,
             id,
-            rlc_coeffs: Some(rlc_orig),
-            header,
-            data: Some(data.to_vec()),
-            rows: None,
+            data_size: data.len(),
         })
-    }
-
-    /// Create an empty blob for internal reconstruction from downloaded shards.
-    ///
-    /// Returns an error if the BlobID is invalid or the blob version is not supported.
-    pub(crate) fn empty(id: BlobID) -> Result<Self, FibreError> {
-        id.validate()?;
-        let cfg = BlobConfig::for_version(id.version())?;
-        let total_rows = cfg.total_rows();
-
-        Ok(Self {
-            cfg,
-            extended_data: None,
-            id,
-            rlc_coeffs: None,
-            header: BlobHeaderV0::default(),
-            data: None,
-            rows: Some(vec![None; total_rows]),
-        })
-    }
-
-    /// Create an empty blob with a custom [`BlobConfig`] for reconstruction.
-    ///
-    /// This is like [`Blob::empty()`] but uses a caller-supplied config instead of
-    /// deriving it from the blob version. Useful for tests that use small K/N parameters.
-    #[cfg(test)]
-    pub(crate) fn empty_with_config(id: BlobID, cfg: BlobConfig) -> Self {
-        let total_rows = cfg.total_rows();
-        Self {
-            cfg,
-            extended_data: None,
-            id,
-            rlc_coeffs: None,
-            header: BlobHeaderV0::default(),
-            data: None,
-            rows: Some(vec![None; total_rows]),
-        }
     }
 
     /// Returns the BlobID of this blob.
@@ -211,115 +181,94 @@ impl Blob {
         &self.cfg
     }
 
-    /// Returns the RLC coefficients of the original data, if available.
-    pub fn rlc_coeffs(&self) -> Option<&[rsema1d::GF128]> {
-        self.rlc_coeffs.as_deref()
+    /// Returns the RLC coefficients of the original data.
+    pub fn rlc_coeffs(&self) -> &[rsema1d::GF128] {
+        self.extended_data.rlc_original()
     }
 
-    /// Returns the size of each row in bytes, or `None` if no data is available.
-    pub fn row_size(&self) -> Option<usize> {
-        self.data.as_ref().map(|d| self.cfg.row_size(d.len()))
+    /// Returns the size of each row in bytes.
+    pub fn row_size(&self) -> usize {
+        self.extended_data.rows().row_size()
     }
 
-    /// Returns the size of the original data (without header), or `None` if
-    /// no data is available.
-    pub fn data_size(&self) -> Option<usize> {
-        self.data.as_ref().map(|d| d.len())
+    /// Returns the size of the original data without the header.
+    pub fn data_size(&self) -> usize {
+        self.data_size
     }
 
-    /// Returns the upload size (data with padding, without parity), or `None`
-    /// if no data is available.
-    ///
-    /// This is the size included in the `PaymentPromise` and the one actually paid for.
-    pub fn upload_size(&self) -> Option<usize> {
-        self.data_size().map(|s| self.cfg.upload_size(s))
-    }
-
-    /// Returns the original data (without header), if available.
-    ///
-    /// Returns `None` if the data has not been decoded yet
-    /// (call `reconstruct()` first for received blobs).
-    pub fn data(&self) -> Option<&[u8]> {
-        self.data.as_deref()
+    /// Returns the upload size: data with padding and without parity.
+    pub fn upload_size(&self) -> usize {
+        self.row_size() * self.cfg.original_rows
     }
 
     /// Generate a `RowInclusionProof` for the given row index from the extended data.
     pub fn row(&self, index: usize) -> Result<rsema1d::RowInclusionProof, FibreError> {
-        let ext = self
-            .extended_data
-            .as_ref()
-            .ok_or_else(|| FibreError::Other("no extended data available".into()))?;
-        ext.generate_row_inclusion_proof(index)
+        self.extended_data
+            .generate_row_inclusion_proof(index)
             .map_err(|e| e.into())
+    }
+}
+
+/// Incomplete blob used while collecting rows for reconstruction.
+pub(crate) struct BlobReconstruction {
+    cfg: BlobConfig,
+    id: BlobID,
+    rows: Vec<Option<Vec<u8>>>,
+}
+
+impl BlobReconstruction {
+    /// Create a reconstruction buffer for the blob ID.
+    pub(crate) fn new(id: BlobID) -> Result<Self, FibreError> {
+        let cfg = BlobConfig::for_version(id.version())?;
+        let rows = vec![None; cfg.total_rows()];
+
+        Ok(Self { cfg, id, rows })
+    }
+
+    /// Create a reconstruction buffer with a custom configuration for tests.
+    #[cfg(test)]
+    pub(crate) fn with_config(id: BlobID, cfg: BlobConfig) -> Self {
+        let rows = vec![None; cfg.total_rows()];
+        Self { cfg, id, rows }
+    }
+
+    pub(crate) fn id(&self) -> &BlobID {
+        &self.id
+    }
+
+    pub(crate) fn config(&self) -> &BlobConfig {
+        &self.cfg
     }
 
     /// Store rows that passed [`ShardVerifier::verify`].
     ///
     /// Rows whose index is already filled are skipped. Returns the number of
     /// genuinely new rows stored.
-    pub(crate) fn store_rows(&mut self, rows: VerifiedRows) -> Result<usize, FibreError> {
+    pub(crate) fn store_rows(&mut self, rows: VerifiedRows) -> usize {
         let mut applied = 0;
         for proof in rows.0 {
-            if self.store_row(proof.index, proof.row.into_owned())? {
+            let row = &mut self.rows[proof.index];
+            if row.is_none() {
+                *row = Some(proof.row.into_owned());
                 applied += 1;
             }
         }
-        Ok(applied)
+        applied
     }
 
     /// Returns which row indices are already stored, for pre-filtering
     /// downloaded shards before verification.
     pub(crate) fn stored_rows_bitmap(&self) -> Vec<bool> {
-        match &self.rows {
-            Some(rows) => rows.iter().map(Option::is_some).collect(),
-            None => Vec::new(),
-        }
-    }
-
-    fn store_row(&mut self, index: usize, row: Vec<u8>) -> Result<bool, FibreError> {
-        if let Some(ref mut rows) = self.rows {
-            if index < rows.len() {
-                if rows[index].is_some() {
-                    return Ok(false);
-                }
-                rows[index] = Some(row);
-            } else {
-                return Err(FibreError::Other(format!(
-                    "row index {} out of bounds (total rows: {})",
-                    index,
-                    rows.len()
-                )));
-            }
-        } else {
-            return Err(FibreError::Other(
-                "blob not initialized for reconstruction".into(),
-            ));
-        }
-
-        Ok(true)
+        self.rows.iter().map(Option::is_some).collect()
     }
 
     /// Reconstruct the original data from accumulated rows.
     ///
     /// Requires at least `original_rows` (K) rows to have been set via `store_rows()`.
-    /// After reconstruction, `data()` will return the original data.
-    ///
-    /// This method is NOT safe for concurrent calls.
-    pub fn reconstruct(&mut self) -> Result<(), FibreError> {
-        let rows_buffer = self
-            .rows
-            .as_ref()
-            .ok_or_else(|| FibreError::Other("no rows available for reconstruction".into()))?;
-
-        // Collect available row indices and data
+    pub(crate) fn reconstruct(self) -> Result<Blob, FibreError> {
         let mut indices = Vec::new();
-        let mut row_size = 0usize;
-
-        for (i, row_opt) in rows_buffer.iter().enumerate() {
-            if let Some(row) = row_opt {
-                if row_size == 0 {
-                    row_size = row.len();
-                }
+        for (i, row_opt) in self.rows.iter().enumerate() {
+            if row_opt.is_some() {
                 indices.push(i);
             }
         }
@@ -331,36 +280,28 @@ impl Blob {
             });
         }
 
-        if row_size == 0 {
-            return Err(FibreError::Other("no rows with data available".into()));
-        }
-
-        let params =
-            rsema1d::Parameters::new(self.cfg.original_rows, self.cfg.parity_rows, row_size)?;
-
-        // Take exactly K rows for reconstruction
         let k = self.cfg.original_rows;
         let selected_indices: Vec<usize> = indices[..k].to_vec();
         let selected_rows: Vec<&[u8]> = selected_indices
             .iter()
-            .map(|&i| rows_buffer[i].as_ref().unwrap().as_slice())
+            .map(|&i| self.rows[i].as_ref().unwrap().as_slice())
             .collect();
+        let params = rsema1d::Parameters::new(
+            self.cfg.original_rows,
+            self.cfg.parity_rows,
+            selected_rows[0].len(),
+        )?;
 
-        // Reconstruct original rows
         let reconstructed = rsema1d::reconstruct(&selected_rows, &selected_indices, &params)?;
 
-        // Decode header and extract original data from the first K rows
         let original_rows: Vec<&[u8]> = (0..k).map(|i| reconstructed.row(i).unwrap()).collect();
-        let (header, original_data) = BlobHeaderV0::decode_from_rows(&original_rows, &self.cfg)?;
+        let (_, data) = BlobHeaderV0::decode_from_rows(&original_rows, &self.cfg)?;
 
-        self.header = header;
-        self.data = Some(original_data);
-
-        Ok(())
+        Ok(Blob { id: self.id, data })
     }
 }
 
-/// Rows that passed shard verification, accepted by [`Blob::store_rows`].
+/// Rows that passed shard verification, accepted by [`BlobReconstruction::store_rows`].
 ///
 /// Only [`ShardVerifier::verify`] can construct this, so unverified rows
 /// cannot reach the blob's row buffer.
@@ -386,7 +327,7 @@ pub(crate) struct ShardVerifier {
 }
 
 impl ShardVerifier {
-    pub(crate) fn new(blob: &Blob) -> Self {
+    pub(crate) fn new(blob: &BlobReconstruction) -> Self {
         Self {
             commitment: blob.id.commitment(),
             cfg: blob.cfg.clone(),
@@ -535,25 +476,23 @@ mod tests {
     }
 
     #[test]
-    fn blob_new_and_accessors() {
+    fn encoded_blob_new_and_accessors() {
         // Use test parameters with small K/N and row_size=64 for fast tests
         let cfg = BlobConfig::new_test(0, 4, 4, 1024, 4, 64);
         let data = vec![1u8; 200];
-        let blob = Blob::new(&data, cfg).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
 
-        assert_eq!(blob.data_size(), Some(200));
-        assert!(blob.data().is_some());
-        assert_eq!(blob.data().unwrap(), &data);
-        assert!(blob.row_size().unwrap() > 0);
-        assert!(blob.upload_size().unwrap() > 0);
-        assert!(blob.rlc_coeffs().is_some());
+        assert_eq!(blob.data_size(), 200);
+        assert!(blob.row_size() > 0);
+        assert!(blob.upload_size() > 0);
+        assert_eq!(blob.rlc_coeffs().len(), cfg.original_rows);
         assert!(blob.id().validate().is_ok());
     }
 
     #[test]
-    fn blob_new_empty_data() {
+    fn encoded_blob_new_empty_data() {
         let cfg = BlobConfig::new_test(0, 4, 4, 1024, 4, 64);
-        assert!(Blob::new(&[], cfg).is_err());
+        assert!(EncodedBlob::new(&[], cfg).is_err());
     }
 
     #[tokio::test]
@@ -561,25 +500,36 @@ mod tests {
         // Encode a blob with small test parameters
         let cfg = BlobConfig::new_test(0, 4, 4, 4096, 4, 64);
         let data: Vec<u8> = (0u8..=249).collect();
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
 
-        let mut empty = Blob::empty_with_config(blob.id().clone(), cfg);
+        let mut reconstruction = BlobReconstruction::with_config(blob.id().clone(), cfg);
 
         // Set enough rows (need at least K=4)
-        set_shard(&mut empty, shard_of(&blob, &[0, 1, 2, 3]))
+        set_shard(&mut reconstruction, shard_of(&blob, &[0, 1, 2, 3]))
             .await
             .unwrap();
 
-        // Reconstruct
-        empty.reconstruct().unwrap();
-        assert_eq!(empty.data().unwrap(), &data);
+        let reconstructed = reconstruction.reconstruct().unwrap();
+        assert_eq!(reconstructed.data(), &data);
+    }
+
+    #[test]
+    fn reconstruction_rejects_insufficient_rows() {
+        let cfg = BlobConfig::new_test(0, 4, 4, 4096, 4, 64);
+        let reconstruction = BlobReconstruction::with_config(BlobID::new(0, [0; 32]), cfg);
+
+        let err = reconstruction.reconstruct().unwrap_err();
+        assert!(matches!(
+            err,
+            FibreError::NotEnoughShards { got: 0, need: 4 }
+        ));
     }
 
     #[test]
     fn blob_too_large() {
         let cfg = BlobConfig::new_test(0, 4, 4, 100, 4, 64);
         let data = vec![0u8; 101];
-        match Blob::new(&data, cfg) {
+        match EncodedBlob::new(&data, cfg) {
             Err(FibreError::BlobTooLarge { size, max }) => {
                 assert_eq!(size, 101);
                 assert_eq!(max, 100);
@@ -593,7 +543,7 @@ mod tests {
         rlcs: Vec<rsema1d::GF128>,
     }
 
-    fn shard_of(blob: &Blob, indices: &[usize]) -> TestShard {
+    fn shard_of(blob: &EncodedBlob, indices: &[usize]) -> TestShard {
         TestShard {
             rows: indices
                 .iter()
@@ -606,86 +556,94 @@ mod tests {
                     }
                 })
                 .collect(),
-            rlcs: blob.rlc_coeffs().unwrap().to_vec(),
+            rlcs: blob.rlc_coeffs().to_vec(),
         }
     }
 
-    async fn set_shard(blob: &mut Blob, shard: TestShard) -> Result<usize, FibreError> {
+    async fn set_shard(
+        blob: &mut BlobReconstruction,
+        shard: TestShard,
+    ) -> Result<usize, FibreError> {
         let verifier = ShardVerifier::new(blob);
         let verified = verifier
             .verify(shard.rows, &shard.rlcs, &blob.stored_rows_bitmap())
             .await?;
-        blob.store_rows(verified)
+        Ok(blob.store_rows(verified))
     }
 
-    fn test_blob_pair() -> (Blob, Blob) {
+    fn test_blob_and_reconstruction() -> (EncodedBlob, BlobReconstruction) {
         let cfg = BlobConfig::new_test(0, 4, 4, 4096, 4, 64);
         let data: Vec<u8> = (0u8..=249).collect();
-        let blob = Blob::new(&data, cfg.clone()).unwrap();
-        let empty = Blob::empty_with_config(blob.id().clone(), cfg);
-        (blob, empty)
+        let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
+        let reconstruction = BlobReconstruction::with_config(blob.id().clone(), cfg);
+        (blob, reconstruction)
     }
 
     #[tokio::test]
     async fn set_shard_counts_only_new_rows() {
-        let (blob, mut empty) = test_blob_pair();
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
 
-        let unique = set_shard(&mut empty, shard_of(&blob, &[0, 1, 2]))
+        let unique = set_shard(&mut reconstruction, shard_of(&blob, &[0, 1, 2]))
             .await
             .unwrap()
-            + set_shard(&mut empty, shard_of(&blob, &[2, 3]))
+            + set_shard(&mut reconstruction, shard_of(&blob, &[2, 3]))
                 .await
                 .unwrap();
 
         assert_eq!(unique, 4);
-        empty.reconstruct().unwrap();
-        assert_eq!(empty.data().unwrap(), blob.data().unwrap());
+        reconstruction.reconstruct().unwrap();
     }
 
     #[tokio::test]
     async fn set_shard_failing_shard_stores_nothing() {
-        let (blob, mut empty) = test_blob_pair();
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
 
         // Tamper with the second row; the whole shard must be rejected.
         let mut shard = shard_of(&blob, &[0, 1]);
         shard.rows[1].row.to_mut()[0] ^= 1;
-        assert!(set_shard(&mut empty, shard).await.is_err());
+        assert!(set_shard(&mut reconstruction, shard).await.is_err());
 
         // Row 0 was valid in the failing shard but must not have been stored.
         assert_eq!(
-            set_shard(&mut empty, shard_of(&blob, &[0])).await.unwrap(),
+            set_shard(&mut reconstruction, shard_of(&blob, &[0]))
+                .await
+                .unwrap(),
             1
         );
     }
 
     #[tokio::test]
     async fn set_shard_rejects_wrong_rlc_count() {
-        let (blob, mut empty) = test_blob_pair();
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
         let mut shard = shard_of(&blob, &[0]);
         shard.rlcs.pop();
 
-        assert!(set_shard(&mut empty, shard).await.is_err());
+        assert!(set_shard(&mut reconstruction, shard).await.is_err());
     }
 
     #[tokio::test]
     async fn set_shard_rejects_wrong_rlc_value() {
-        let (blob, mut empty) = test_blob_pair();
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
         let mut shard = shard_of(&blob, &[0]);
         shard.rlcs[0].limbs[0] ^= 1;
 
-        assert!(set_shard(&mut empty, shard).await.is_err());
+        assert!(set_shard(&mut reconstruction, shard).await.is_err());
     }
 
     #[tokio::test]
     async fn verify_rejects_oversized_row() {
-        let (blob, empty) = test_blob_pair();
+        let (blob, reconstruction) = test_blob_and_reconstruction();
         let mut shard = shard_of(&blob, &[0]);
         // Larger than row_size(max_data_size) for the test config.
         shard.rows[0].row = std::borrow::Cow::Owned(vec![0u8; 2048]);
 
-        let verifier = ShardVerifier::new(&empty);
+        let verifier = ShardVerifier::new(&reconstruction);
         let err = verifier
-            .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, FibreError::InvalidData(_)), "got {err}");
@@ -693,13 +651,17 @@ mod tests {
 
     #[tokio::test]
     async fn verify_rejects_out_of_range_index() {
-        let (blob, empty) = test_blob_pair();
+        let (blob, reconstruction) = test_blob_and_reconstruction();
         let mut shard = shard_of(&blob, &[0]);
-        shard.rows[0].index = empty.config().total_rows();
+        shard.rows[0].index = reconstruction.config().total_rows();
 
-        let verifier = ShardVerifier::new(&empty);
+        let verifier = ShardVerifier::new(&reconstruction);
         let err = verifier
-            .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, FibreError::InvalidData(_)), "got {err}");
@@ -707,9 +669,9 @@ mod tests {
 
     #[tokio::test]
     async fn verify_skips_duplicate_indices_within_response() {
-        let (blob, mut empty) = test_blob_pair();
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
 
-        let applied = set_shard(&mut empty, shard_of(&blob, &[0, 0, 1]))
+        let applied = set_shard(&mut reconstruction, shard_of(&blob, &[0, 0, 1]))
             .await
             .unwrap();
         assert_eq!(applied, 2);
@@ -717,8 +679,8 @@ mod tests {
 
     #[tokio::test]
     async fn verify_skips_already_stored_rows_before_crypto() {
-        let (blob, mut empty) = test_blob_pair();
-        set_shard(&mut empty, shard_of(&blob, &[0, 1]))
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
+        set_shard(&mut reconstruction, shard_of(&blob, &[0, 1]))
             .await
             .unwrap();
 
@@ -727,41 +689,55 @@ mod tests {
         let mut shard = shard_of(&blob, &[0]);
         shard.rows[0].row.to_mut()[0] ^= 1;
 
-        let verifier = ShardVerifier::new(&empty);
+        let verifier = ShardVerifier::new(&reconstruction);
         let verified = verifier
-            .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap();
-        assert_eq!(empty.store_rows(verified).unwrap(), 0);
+        assert_eq!(reconstruction.store_rows(verified), 0);
     }
 
     #[tokio::test]
     async fn verify_uses_first_needed_row_size() {
-        let (blob, mut empty) = test_blob_pair();
-        set_shard(&mut empty, shard_of(&blob, &[0])).await.unwrap();
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
+        set_shard(&mut reconstruction, shard_of(&blob, &[0]))
+            .await
+            .unwrap();
 
         let mut shard = shard_of(&blob, &[0, 1]);
         shard.rows[0].row = std::borrow::Cow::Owned(vec![0; 128]);
 
-        let verifier = ShardVerifier::new(&empty);
+        let verifier = ShardVerifier::new(&reconstruction);
         let verified = verifier
-            .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap();
 
-        assert_eq!(empty.store_rows(verified).unwrap(), 1);
+        assert_eq!(reconstruction.store_rows(verified), 1);
     }
 
     #[tokio::test]
     async fn verify_caches_context_and_rejects_mismatched_rlcs() {
-        let (blob, mut empty) = test_blob_pair();
-        let verifier = ShardVerifier::new(&empty);
+        let (blob, mut reconstruction) = test_blob_and_reconstruction();
+        let verifier = ShardVerifier::new(&reconstruction);
 
         let mut shard = shard_of(&blob, &[0]);
         shard.rows[0].row.to_mut()[0] ^= 1;
         assert!(
             verifier
-                .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+                .verify(
+                    shard.rows,
+                    &shard.rlcs,
+                    &reconstruction.stored_rows_bitmap(),
+                )
                 .await
                 .is_err()
         );
@@ -769,31 +745,50 @@ mod tests {
         // First shard authenticates the RLC vector and fills the cache.
         let shard = shard_of(&blob, &[0, 1]);
         let verified = verifier
-            .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap();
-        empty.store_rows(verified).unwrap();
+        reconstruction.store_rows(verified);
 
         // Same vector: verifies against the cached context.
         let shard = shard_of(&blob, &[2, 3]);
         let verified = verifier
-            .verify(shard.rows, &shard.rlcs, &empty.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap();
-        assert_eq!(empty.store_rows(verified).unwrap(), 2);
+        assert_eq!(reconstruction.store_rows(verified), 2);
 
         // Different vector: rejected by the cheap cache comparison.
         let mut shard = shard_of(&blob, &[2, 3]);
         shard.rlcs[0].limbs[0] ^= 1;
-        let fresh = Blob::empty_with_config(
+        let fresh_reconstruction = BlobReconstruction::with_config(
             blob.id().clone(),
             BlobConfig::new_test(0, 4, 4, 4096, 4, 64),
         );
         let err = verifier
-            .verify(shard.rows, &shard.rlcs, &fresh.stored_rows_bitmap())
+            .verify(
+                shard.rows,
+                &shard.rlcs,
+                &fresh_reconstruction.stored_rows_bitmap(),
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, FibreError::InvalidData(_)), "got {err}");
-        assert_eq!(fresh.stored_rows_bitmap().iter().filter(|s| **s).count(), 0);
+        assert_eq!(
+            fresh_reconstruction
+                .stored_rows_bitmap()
+                .iter()
+                .filter(|s| **s)
+                .count(),
+            0
+        );
     }
 }

--- a/fibre/src/domain/payment_promise.rs
+++ b/fibre/src/domain/payment_promise.rs
@@ -45,7 +45,7 @@ pub struct PaymentPromise {
     pub height: u64,
     /// The namespace the blob is associated with.
     pub namespace: Namespace,
-    /// Upload size of the blob (with padding, without parity), matching `Blob::upload_size()`.
+    /// Upload size of the blob (with padding, without parity), matching `EncodedBlob::upload_size()`.
     pub upload_size: u32,
     /// Version of the blob format.
     pub blob_version: u32,

--- a/fibre/src/lib.rs
+++ b/fibre/src/lib.rs
@@ -28,7 +28,7 @@ pub use client::{FibreClient, FibreClientBuilder};
 pub use config::{
     BlobConfig, DEFAULT_PROTOCOL_PARAMS, FibreClientConfig, Fraction, ProtocolParams,
 };
-pub use domain::blob::{Blob, BlobID, Commitment};
+pub use domain::blob::{Blob, BlobID, Commitment, EncodedBlob};
 pub use domain::payment_promise::{PaymentPromise, SignedPaymentPromise};
 pub use error::{FibreError, Result};
 pub use transport::grpc_validator_client::GrpcValidatorConnector;

--- a/fibre/src/roundtrip_test.rs
+++ b/fibre/src/roundtrip_test.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use crate::blob::Blob;
+use crate::blob::EncodedBlob;
 use crate::test_utils::{
     MockConnector, MockValidatorConnection, build_test_client, make_connector, make_validator,
     test_blob_config,
@@ -17,7 +17,7 @@ async fn upload_then_download_roundtrip() {
     let cfg = test_blob_config();
     let original_data: Vec<u8> = (0u8..200).collect();
 
-    let blob = Blob::new(&original_data, cfg.clone()).unwrap();
+    let blob = EncodedBlob::new(&original_data, cfg.clone()).unwrap();
     let blob_id = blob.id().clone();
 
     let validators = vec![
@@ -66,7 +66,7 @@ async fn upload_then_download_roundtrip() {
 
     let downloaded = downloaded.unwrap();
     assert_eq!(
-        downloaded.data().unwrap(),
+        downloaded.data(),
         &original_data,
         "downloaded data should match original"
     );
@@ -78,7 +78,7 @@ async fn roundtrip_with_partial_validator_failure() {
     let cfg = test_blob_config();
     let original_data: Vec<u8> = (0u8..200).collect();
 
-    let blob = Blob::new(&original_data, cfg.clone()).unwrap();
+    let blob = EncodedBlob::new(&original_data, cfg.clone()).unwrap();
     let blob_id = blob.id().clone();
 
     // 5 validators: first 3 succeed, last 2 fail.
@@ -134,5 +134,5 @@ async fn roundtrip_with_partial_validator_failure() {
         "download should succeed: {:?}",
         downloaded.err()
     );
-    assert_eq!(downloaded.unwrap().data().unwrap(), &original_data);
+    assert_eq!(downloaded.unwrap().data(), &original_data);
 }


### PR DESCRIPTION
## Overview

Separate upload-ready `EncodedBlob` from decoded `Blob` and keep reconstruction state private.

BREAKING CHANGE: replace `Blob::new` with `EncodedBlob::new`; 
Fibre upload APIs now accept `EncodedBlob`, and downloaded `Blob` data is always present.

Resolves #993 
