### PR TITLE
perf(fibre): safe hugepage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,6 +3741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,6 +4905,7 @@ dependencies = [
  "criterion",
  "getrandom 0.2.17",
  "hex",
+ "memmap2",
  "num_cpus",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -165,9 +165,8 @@ impl EncodedBlob {
         // Write header + data directly into the first K rows; parity rows stay
         // zeroed and will be filled by encode_in_place.
         let total_rows = cfg.original_rows + cfg.parity_rows;
-        let mut flat = vec![0u8; total_rows * row_size];
-        header.encode_into_buffer(data, &mut flat);
-        let extended = rsema1d::RowMatrix::with_shape(flat, total_rows, row_size)?;
+        let mut extended = rsema1d::RowMatrix::zeroed(total_rows, row_size)?;
+        header.encode_into_buffer(data, extended.as_row_major_mut());
         let params = rsema1d::Parameters::new(cfg.original_rows, cfg.parity_rows, row_size)?;
         let (extended_data, commitment, _) =
             rsema1d::encode_in_place_with_work_budget(extended, &params, work_budget)?;

--- a/fibre/src/lib.rs
+++ b/fibre/src/lib.rs
@@ -4,6 +4,8 @@
 //! blob data on-chain, Fibre distributes it directly to validators via gRPC. Only a
 //! small payment receipt (`MsgPayForFibre`) goes on-chain.
 
+#![forbid(unsafe_code)]
+
 pub mod client;
 pub mod domain;
 pub mod transport;

--- a/rsema1d/Cargo.toml
+++ b/rsema1d/Cargo.toml
@@ -20,6 +20,9 @@ serde_json.workspace = true
 hex.workspace = true
 num_cpus = "1.17"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+memmap2 = "0.9"
+
 [dev-dependencies]
 rand.workspace = true
 rand_chacha = "0.3.1"

--- a/rsema1d/src/codec/reconstruct.rs
+++ b/rsema1d/src/codec/reconstruct.rs
@@ -78,8 +78,7 @@ pub fn reconstruct_data(
         .decode()
         .map_err(|e| Error::ReedSolomon(format!("Failed to decode: {:?}", e)))?;
 
-    let mut all_original =
-        RowMatrix::with_shape(vec![0u8; params.k * row_size], params.k, params.row_size)?;
+    let mut all_original = RowMatrix::zeroed(params.k, row_size)?;
 
     for (i, &index) in indices.iter().enumerate() {
         if index < params.k {

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -1,10 +1,80 @@
 use crate::error::{Error, Result};
 use crate::params::Parameters;
+use std::fmt;
+
+#[cfg(target_os = "linux")]
+const HUGE_PAGE_THRESHOLD: usize = 4 * 1024 * 1024;
+
+enum RowStorage {
+    Heap(Vec<u8>),
+    #[cfg(target_os = "linux")]
+    Mapped(memmap2::MmapMut),
+}
+
+impl RowStorage {
+    fn zeroed(len: usize) -> Self {
+        #[cfg(target_os = "linux")]
+        if len >= HUGE_PAGE_THRESHOLD {
+            if let Ok(data) = memmap2::MmapMut::map_anon(len) {
+                let _ = data.advise(memmap2::Advice::HugePage);
+                return Self::Mapped(data);
+            }
+        }
+
+        Self::Heap(vec![0u8; len])
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Heap(data) => data,
+            #[cfg(target_os = "linux")]
+            Self::Mapped(data) => data,
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Self::Heap(data) => data,
+            #[cfg(target_os = "linux")]
+            Self::Mapped(data) => data,
+        }
+    }
+
+    fn into_vec(self) -> Vec<u8> {
+        match self {
+            Self::Heap(data) => data,
+            #[cfg(target_os = "linux")]
+            Self::Mapped(data) => data.to_vec(),
+        }
+    }
+}
+
+impl fmt::Debug for RowStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_slice().fmt(f)
+    }
+}
+
+impl Clone for RowStorage {
+    fn clone(&self) -> Self {
+        let mut clone = Self::zeroed(self.as_slice().len());
+        clone.as_mut_slice().copy_from_slice(self.as_slice());
+        clone
+    }
+}
+
+impl PartialEq for RowStorage {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for RowStorage {}
 
 /// Contiguous row-major byte matrix (rows × row_size).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RowMatrix {
-    data: Vec<u8>,
+    data: RowStorage,
     row_size: usize,
     rows: usize,
 }
@@ -25,7 +95,19 @@ impl RowMatrix {
             )));
         }
         Ok(Self {
-            data,
+            data: RowStorage::Heap(data),
+            row_size,
+            rows,
+        })
+    }
+
+    /// Creates a zero-initialized matrix with the given shape.
+    pub fn zeroed(rows: usize, row_size: usize) -> Result<Self> {
+        if row_size == 0 {
+            return Err(Error::InvalidParameters("row_size must be > 0".to_string()));
+        }
+        Ok(Self {
+            data: RowStorage::zeroed(rows * row_size),
             row_size,
             rows,
         })
@@ -43,17 +125,17 @@ impl RowMatrix {
 
     /// Returns the underlying flat buffer as a byte slice.
     pub fn as_row_major(&self) -> &[u8] {
-        &self.data
+        self.data.as_slice()
     }
 
     /// Returns the underlying flat buffer as a mutable byte slice.
     pub fn as_row_major_mut(&mut self) -> &mut [u8] {
-        &mut self.data
+        self.data.as_mut_slice()
     }
 
-    /// Consumes the matrix and returns the underlying byte buffer.
+    /// Consumes the matrix and returns a flat byte buffer.
     pub fn into_row_major(self) -> Vec<u8> {
-        self.data
+        self.data.into_vec()
     }
 
     /// Returns the row at `index`, or an error if out of bounds.
@@ -75,13 +157,13 @@ impl RowMatrix {
     pub(crate) fn row_unchecked(&self, index: usize) -> &[u8] {
         let start = index * self.row_size;
         let end = start + self.row_size;
-        &self.data[start..end]
+        &self.data.as_slice()[start..end]
     }
 
     pub(crate) fn row_mut_unchecked(&mut self, index: usize) -> &mut [u8] {
         let start = index * self.row_size;
         let end = start + self.row_size;
-        &mut self.data[start..end]
+        &mut self.data.as_mut_slice()[start..end]
     }
 
     /// Creates a new matrix containing only the rows at the given indices.
@@ -157,6 +239,35 @@ impl AsRef<[u8]> for RowMatrix {
 impl From<RowMatrix> for Vec<u8> {
     fn from(value: RowMatrix) -> Self {
         value.into_row_major()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zeroed_matrix_round_trip() {
+        let mut matrix = RowMatrix::zeroed(4, 64).unwrap();
+        assert_eq!(matrix.as_row_major(), &[0u8; 256]);
+
+        matrix.row_mut(2).unwrap()[7] = 42;
+        let clone = matrix.clone();
+        assert_eq!(clone, matrix);
+        assert_eq!(clone.into_row_major(), matrix.as_row_major());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn large_zeroed_matrix_uses_mapping() {
+        let mut matrix = RowMatrix::zeroed(HUGE_PAGE_THRESHOLD / 64, 64).unwrap();
+        assert!(matches!(matrix.data, RowStorage::Mapped(_)));
+        assert!(matrix.as_row_major().iter().all(|byte| *byte == 0));
+
+        matrix.row_mut(1).unwrap()[1] = 7;
+        let clone = matrix.clone();
+        assert_eq!(clone, matrix);
+        assert_eq!(clone.into_row_major(), matrix.as_row_major());
     }
 }
 

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -57,9 +57,15 @@ impl fmt::Debug for RowStorage {
 
 impl Clone for RowStorage {
     fn clone(&self) -> Self {
-        let mut clone = Self::zeroed(self.as_slice().len());
-        clone.as_mut_slice().copy_from_slice(self.as_slice());
-        clone
+        match self {
+            Self::Heap(data) => Self::Heap(data.clone()),
+            #[cfg(target_os = "linux")]
+            Self::Mapped(data) => {
+                let mut clone = Self::zeroed(data.len());
+                clone.as_mut_slice().copy_from_slice(data);
+                clone
+            }
+        }
     }
 }
 
@@ -80,15 +86,24 @@ pub struct RowMatrix {
 }
 
 impl RowMatrix {
+    fn checked_len(rows: usize, row_size: usize) -> Result<usize> {
+        rows.checked_mul(row_size).ok_or_else(|| {
+            Error::InvalidParameters(format!(
+                "row buffer size overflow: rows={rows} row_size={row_size}"
+            ))
+        })
+    }
+
     /// Create a matrix from a flat byte buffer with the given shape.
     pub fn with_shape(data: Vec<u8>, rows: usize, row_size: usize) -> Result<Self> {
         if row_size == 0 {
             return Err(Error::InvalidParameters("row_size must be > 0".to_string()));
         }
-        if rows * row_size != data.len() {
+        let expected_len = Self::checked_len(rows, row_size)?;
+        if expected_len != data.len() {
             return Err(Error::InvalidParameters(format!(
                 "row buffer size mismatch: expected {} bytes (rows={} row_size={}), got {}",
-                rows * row_size,
+                expected_len,
                 rows,
                 row_size,
                 data.len()
@@ -106,8 +121,9 @@ impl RowMatrix {
         if row_size == 0 {
             return Err(Error::InvalidParameters("row_size must be > 0".to_string()));
         }
+        let len = Self::checked_len(rows, row_size)?;
         Ok(Self {
-            data: RowStorage::zeroed(rows * row_size),
+            data: RowStorage::zeroed(len),
             row_size,
             rows,
         })
@@ -134,6 +150,8 @@ impl RowMatrix {
     }
 
     /// Consumes the matrix and returns a flat byte buffer.
+    ///
+    /// Heap storage is returned directly. Memory-mapped storage is copied into a new allocation.
     pub fn into_row_major(self) -> Vec<u8> {
         self.data.into_vec()
     }
@@ -237,6 +255,7 @@ impl AsRef<[u8]> for RowMatrix {
 }
 
 impl From<RowMatrix> for Vec<u8> {
+    /// Uses the same allocation behavior as [`RowMatrix::into_row_major`].
     fn from(value: RowMatrix) -> Self {
         value.into_row_major()
     }
@@ -257,17 +276,41 @@ mod tests {
         assert_eq!(clone.into_row_major(), matrix.as_row_major());
     }
 
+    #[test]
+    fn shape_size_overflow_is_rejected() {
+        for result in [
+            RowMatrix::with_shape(Vec::new(), 2, usize::MAX),
+            RowMatrix::zeroed(2, usize::MAX),
+        ] {
+            let Error::InvalidParameters(message) = result.unwrap_err() else {
+                panic!("expected invalid parameters error");
+            };
+            assert!(message.contains("overflow"));
+        }
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
-    fn large_zeroed_matrix_uses_mapping() {
+    fn large_zeroed_matrix_round_trip() {
         let mut matrix = RowMatrix::zeroed(HUGE_PAGE_THRESHOLD / 64, 64).unwrap();
-        assert!(matches!(matrix.data, RowStorage::Mapped(_)));
         assert!(matrix.as_row_major().iter().all(|byte| *byte == 0));
 
         matrix.row_mut(1).unwrap()[1] = 7;
         let clone = matrix.clone();
         assert_eq!(clone, matrix);
         assert_eq!(clone.into_row_major(), matrix.as_row_major());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn large_heap_clone_stays_heap() {
+        let rows = HUGE_PAGE_THRESHOLD / 64;
+        let matrix = RowMatrix::with_shape(vec![1u8; HUGE_PAGE_THRESHOLD], rows, 64).unwrap();
+        assert!(matches!(&matrix.data, RowStorage::Heap(_)));
+
+        let clone = matrix.clone();
+        assert!(matches!(&clone.data, RowStorage::Heap(_)));
+        assert_eq!(clone, matrix);
     }
 }
 

--- a/rsema1d/src/codec/rs.rs
+++ b/rsema1d/src/codec/rs.rs
@@ -270,9 +270,9 @@ pub fn extend_data_with_work_budget(
     params: &Parameters,
     work_budget: NonZeroUsize,
 ) -> Result<RowMatrix> {
-    let mut all_rows = vec![0u8; (params.k + params.n) * params.row_size];
+    let mut all_rows = RowMatrix::zeroed(params.total_rows(), params.row_size)?;
     let split_at = params.k * params.row_size;
-    let (orig, parity) = all_rows.split_at_mut(split_at);
+    let (orig, parity) = all_rows.as_row_major_mut().split_at_mut(split_at);
     orig.copy_from_slice(original_rows.as_row_major());
     fill_parity_with_work_budget(
         orig,
@@ -282,7 +282,7 @@ pub fn extend_data_with_work_budget(
         params.row_size,
         work_budget,
     )?;
-    RowMatrix::with_shape(all_rows, params.total_rows(), params.row_size)
+    Ok(all_rows)
 }
 
 /// Encode parity rows in place into an already allocated extended matrix.

--- a/rsema1d/src/lib.rs
+++ b/rsema1d/src/lib.rs
@@ -1,5 +1,7 @@
 //! Reed-Solomon erasure coding with Merkle commitments and Random Linear Combinations.
 
+#![forbid(unsafe_code)]
+
 pub mod codec;
 /// Cryptographic primitives: hashing, Merkle trees, and RLC coefficient derivation.
 pub mod crypto;


### PR DESCRIPTION
## Overview

Successor of https://github.com/celestiaorg/lumina/pull/1004

It adds a storage abstraction behind `RowMatrix` with two implementations:

- Small matrices and non-Linux platforms continue using `Vec<u8>`.
- Linux matrices of at least 4 MiB use a safe anonymous `memmap2` mapping with a best-effort `MADV_HUGEPAGE` hint

The new allocator is used by:

- Fibre’s extended encoding matrix.
- rsema1d parity extension.
- rsema1d reconstruction output.

### Why

Encoding and reconstructing large blobs operates over large contiguous matrices. With normal memory pages, the CPU needs many page-table and TLB entries to access that memory.
Transparent Huge Pages cover the same memory with fewer entries, reducing address-translation overhead.


### Safety

The implementation uses only the safe `memmap2` API. Both affected crates now explicitly reject local unsafe code at compile time.

The existing `RowMatrix::with_shape(Vec<u8>, ...)` API remains heap-backed and unchanged for callers providing their own buffer.

### Performance

Measured against `perf/rsema1d-safe-striped-parity:`


```
RUSTFLAGS='-C target-cpu=native' cargo bench \
    -p celestia-fibre \
    --bench fibre_bench \
    -- 'blob_new/128MB' \
    --baseline safe-striped \
    --noplot

   Blob size       Before        After    Improvement
  ━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━━━
   8 MiB        22.085 ms    16.769 ms          24.1%
  ───────────  ───────────  ───────────  ─────────────
   128 MiB      186.99 ms    92.989 ms          50.3%
```

Please note, that this is linux only and with special configuration on this host
