### PR TITLE
chore(fibre,rsema1d): add wasm32 benchmarks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+runner = "wasm-bindgen-test-runner"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,8 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+ "wasm-bindgen-test",
+ "web-time",
  "x509-parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,6 @@ dependencies = [
  "tower",
  "tracing",
  "wasm-bindgen-test",
- "web-time",
  "x509-parser",
 ]
 

--- a/fibre/Cargo.toml
+++ b/fibre/Cargo.toml
@@ -66,7 +66,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
-web-time = "1.1"
 
 [[bench]]
 name = "fibre_bench"

--- a/fibre/Cargo.toml
+++ b/fibre/Cargo.toml
@@ -64,6 +64,10 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test.workspace = true
+web-time = "1.1"
+
 [[bench]]
 name = "fibre_bench"
 harness = false

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -1,75 +1,14 @@
-//! Benchmarks for the CPU-bound (network-free) paths of the fibre client.
-//!
-//! Upload path: blob encoding, per-row proof generation, payment promise
-//! signing, validator signature verification, deterministic shard assignment.
-//! Download path: wire decoding. Shard verification and reconstruction are
-//! benchmarked in `rsema1d/benches/codec_bench.rs` (groups
-//! `verification_context`, `verification`, and `reconstruct`), where those
-//! code paths are public API; the fibre layer only adds thin bookkeeping on
-//! top of them.
-//!
-//! These benchmarks use the production v0 protocol parameters (K=4096,
-//! N=12288) and only the crate's public API.
-//!
-//! Measurement windows are deliberately long (10s for cheap groups, 30s for
-//! heavy ones) so results are stable enough for regression detection. To
-//! compare two revisions, save a baseline before the change and compare after:
+//! CPU benchmarks for Fibre's upload and download paths using v0 parameters.
+//! RSEMA verification and reconstruction are benchmarked in `rsema1d`.
 //!
 //! ```sh
-//! cargo bench -p celestia-fibre --bench fibre_bench -- --save-baseline main
-//! # ...apply the change...
-//! cargo bench -p celestia-fibre --bench fibre_bench -- --baseline main
+//! cargo bench -p celestia-fibre --bench fibre_bench
+//! cargo bench -p celestia-fibre --bench fibre_bench --target wasm32-unknown-unknown
+//! cargo bench -p celestia-fibre --bench fibre_bench --target wasm32-unknown-unknown -- --include-ignored blob_new_32mb
 //! ```
-//!
-//! A fast sanity pass (each case runs once) is `-- --test`. Blob encoding is
-//! partially parallel via rayon; set `RAYON_NUM_THREADS=1` for
-//! single-threaded numbers.
-//!
-//! ## Reading criterion's change verdicts
-//!
-//! Per-group noise thresholds below are tuned from A/A runs (same binary, no
-//! code change) on a 32-core desktop: differences within the threshold are
-//! reported as noise rather than a change. Residual run-to-run variance comes
-//! from ASLR-dependent memory layout (dominant for sub-microsecond benches),
-//! turbo/thermal clocking, and background load. For tighter comparisons:
-//! run with ASLR disabled (`setarch -R cargo bench ...`), and before trusting
-//! a verdict do an A/A pass (re-run the baseline once) to see the machine's
-//! current noise floor.
-//!
-//! ## wasm32-unknown-unknown
-//!
-//! The same code paths can be benchmarked as wasm, executed by Node through
-//! `wasm-bindgen-test-runner`, which `.cargo/config.toml` configures as the
-//! cargo runner for the target. Install `wasm-bindgen-cli` at exactly the
-//! `wasm-bindgen` version pinned in `Cargo.lock` (the nix devshell provides it):
-//!
-//! ```sh
-//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench
-//! # list cases, run a subset by name, run the ignored (>= 32 MiB) cases
-//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- --list
-//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- payment_promise
-//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- --ignored
-//! ```
-//!
-//! Always pass `--bench fibre_bench`; without it cargo also hands the library
-//! to the runner. The wasm harness is the trimmed criterion port bundled with
-//! `wasm-bindgen-test`: there are no benchmark groups, throughput lines,
-//! `--save-baseline` or `--test`. Every (group, case) pair is therefore its
-//! own bench function so it can be selected by name (`--exact` and `--skip`
-//! also work). The 32 MiB and 128 MiB blob cases are `#[ignore]`d: wasm runs
-//! single-threaded and the Reed-Solomon engine has no wasm SIMD backend, so
-//! each takes minutes.
-//!
-//! The runner stores the previous run in `target/wbg_benchmark.json` (relative
-//! to the current directory) and prints a change verdict against it on the
-//! next run. Set `WASM_BINDGEN_BENCH_RESULT=<path>` to use a dedicated file,
-//! e.g. run once on the baseline revision and once on the change with the same
-//! path. To run in a browser instead of Node, add
-//! `wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);` to the
-//! `wasm` module below and have `chromedriver` on `PATH`.
 
 use std::num::NonZeroU64;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use rand::Rng;
 use rand::rngs::OsRng;
@@ -82,8 +21,6 @@ use celestia_fibre::{
 use celestia_proto::celestia::fibre::v1 as proto;
 use celestia_types::nmt::Namespace;
 
-/// Blob payload sizes exercised by the encode/decode benchmarks. The largest
-/// entry is the protocol maximum (128 MiB minus the blob header).
 fn blob_sizes() -> Vec<(&'static str, usize)> {
     vec![
         ("128KB", 128 << 10),
@@ -94,7 +31,6 @@ fn blob_sizes() -> Vec<(&'static str, usize)> {
     ]
 }
 
-/// Rows per shard, matching the protocol's min_rows_per_validator (148 for v0).
 fn rows_per_shard() -> usize {
     FibreClientConfig::default().min_rows_per_validator
 }
@@ -128,20 +64,6 @@ fn make_validators(count: usize) -> (Vec<ed25519_dalek::SigningKey>, Vec<Validat
         .unzip()
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-fn now() -> SystemTime {
-    SystemTime::now()
-}
-
-/// `std::time::SystemTime::now()` panics on wasm32-unknown-unknown; read the
-/// clock through `Date.now()` instead.
-#[cfg(target_arch = "wasm32")]
-fn now() -> SystemTime {
-    use web_time::web::SystemTimeExt;
-    web_time::SystemTime::now().to_std()
-}
-
-/// A signed payment promise for a 1 MiB upload, with its signing key.
 fn signed_promise() -> (k256::ecdsa::SigningKey, PaymentPromise) {
     let signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
     let mut promise = PaymentPromise {
@@ -151,7 +73,7 @@ fn signed_promise() -> (k256::ecdsa::SigningKey, PaymentPromise) {
         upload_size: BlobConfig::v0().upload_size(1 << 20) as u32,
         blob_version: 0,
         commitment: [7u8; 32],
-        creation_timestamp: now(),
+        creation_timestamp: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
         signer_pubkey: *signing_key.verifying_key(),
         signature: None,
     };
@@ -159,8 +81,6 @@ fn signed_promise() -> (k256::ecdsa::SigningKey, PaymentPromise) {
     (signing_key, promise)
 }
 
-/// A validator's wire response holding one shard (`rows_per_shard()` rows) of
-/// a 1 MiB blob.
 fn download_response() -> proto::DownloadShardResponse {
     let shard = rows_per_shard();
     let blob = EncodedBlob::new(&generate_data(1 << 20), BlobConfig::v0()).unwrap();
@@ -186,205 +106,184 @@ fn download_response() -> proto::DownloadShardResponse {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-mod native {
-    use std::time::Duration;
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, black_box, criterion_group,
+};
 
-    use criterion::{
-        BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, black_box, criterion_group,
-    };
+#[cfg(not(target_arch = "wasm32"))]
+const CHEAP_MEASUREMENT: Duration = Duration::from_secs(10);
+#[cfg(not(target_arch = "wasm32"))]
+const HEAVY_MEASUREMENT: Duration = Duration::from_secs(30);
+#[cfg(not(target_arch = "wasm32"))]
+const HEAVY_WARM_UP: Duration = Duration::from_secs(5);
 
-    use super::*;
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_blob_new(c: &mut Criterion) {
+    let mut group = c.benchmark_group("blob_new");
+    group.sample_size(10);
+    group.measurement_time(HEAVY_MEASUREMENT);
+    group.warm_up_time(HEAVY_WARM_UP);
+    group.sampling_mode(SamplingMode::Flat);
+    group.noise_threshold(0.02);
 
-    /// Measurement window for cheap (sub-millisecond) benchmarks.
-    const CHEAP_MEASUREMENT: Duration = Duration::from_secs(10);
-    /// Measurement window for heavy benchmarks (blob encoding).
-    const HEAVY_MEASUREMENT: Duration = Duration::from_secs(30);
-    const HEAVY_WARM_UP: Duration = Duration::from_secs(5);
-
-    /// Upload path: full client-side encode (header write + rsema1d encode_in_place
-    /// over the (K+N) x row_size matrix). The dominant CPU sink of `upload()`.
-    fn bench_blob_new(c: &mut Criterion) {
-        let mut group = c.benchmark_group("blob_new");
-        group.sample_size(10);
-        group.measurement_time(HEAVY_MEASUREMENT);
-        group.warm_up_time(HEAVY_WARM_UP);
-        // Flat sampling: iteration counts don't grow across samples, so the 128MB
-        // case fits the measurement window without criterion warning about it.
-        group.sampling_mode(SamplingMode::Flat);
-        group.noise_threshold(0.02);
-
-        for (name, len) in blob_sizes() {
-            let data = generate_data(len);
-            group.throughput(Throughput::Bytes(len as u64));
-            group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
-                b.iter(|| EncodedBlob::new(black_box(data), BlobConfig::v0()).unwrap());
-            });
-        }
-
-        group.finish();
-    }
-
-    /// Upload path: per-row inclusion proof generation, called once per row per
-    /// validator when building upload shards.
-    ///
-    /// Measured per shard (148 rows), not per single row: a lone ~100ns row proof
-    /// is dominated by where that row's pages landed in memory, which varies
-    /// between processes (ASLR) and made single-row numbers swing >15% run to
-    /// run. Averaging over a shard's worth of rows removes that; divide by 148
-    /// for the per-row cost.
-    fn bench_blob_row_proofs(c: &mut Criterion) {
-        let mut group = c.benchmark_group("blob_row_proofs");
-        group.measurement_time(CHEAP_MEASUREMENT);
-        group.noise_threshold(0.03);
-
-        for &(name, len) in &[("1MB", 1 << 20), ("8MB", 8 << 20)] {
-            let blob = EncodedBlob::new(&generate_data(len), BlobConfig::v0()).unwrap();
-
-            let shard = rows_per_shard();
-            group.bench_function(BenchmarkId::new(format!("shard_{shard}_rows"), name), |b| {
-                b.iter(|| {
-                    for i in 0..shard {
-                        black_box(blob.row(i).unwrap());
-                    }
-                });
-            });
-        }
-
-        group.finish();
-    }
-
-    /// Upload path: payment promise canonical serialization, secp256k1
-    /// sign/verify, and hashing.
-    fn bench_payment_promise(c: &mut Criterion) {
-        let mut group = c.benchmark_group("payment_promise");
-        group.measurement_time(CHEAP_MEASUREMENT);
-        group.noise_threshold(0.03);
-
-        let (signing_key, mut promise) = signed_promise();
-
-        group.bench_function("sign_bytes", |b| b.iter(|| promise.sign_bytes().unwrap()));
-        group.bench_function("sign", |b| b.iter(|| promise.sign(&signing_key).unwrap()));
-        group.bench_function("validate", |b| b.iter(|| promise.validate().unwrap()));
-        group.bench_function("hash", |b| b.iter(|| promise.hash().unwrap()));
-
-        group.finish();
-    }
-
-    /// Upload path: ed25519 signature verification of validator responses, and
-    /// collecting a full validator set's worth of signatures.
-    fn bench_signature_set(c: &mut Criterion) {
-        let mut group = c.benchmark_group("signature_set");
-        // collect_100 runs ~3ms/iter; 100 samples need more than the cheap window.
-        group.measurement_time(Duration::from_secs(20));
-        group.noise_threshold(0.03);
-
-        let (keys, validators) = make_validators(100);
-        let payload = generate_data(200);
-        let signatures: Vec<Vec<u8>> = keys
-            .iter()
-            .map(|k| {
-                use ed25519_dalek::Signer;
-                k.sign(&payload).to_bytes().to_vec()
-            })
-            .collect();
-
-        let set = ValidatorSet::new(validators.clone(), 1);
-        let threshold = Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap());
-
-        let signature_set = set.new_signature_set(threshold, payload.clone());
-        group.bench_function("add_one", |b| {
-            b.iter(|| signature_set.add(&validators[0], &signatures[0]).unwrap());
+    for (name, len) in blob_sizes() {
+        let data = generate_data(len);
+        group.throughput(Throughput::Bytes(len as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
+            b.iter(|| EncodedBlob::new(black_box(data), BlobConfig::v0()).unwrap());
         });
-
-        group.bench_function("collect_100", |b| {
-            b.iter_batched(
-                || set.new_signature_set(threshold, payload.clone()),
-                |signature_set| {
-                    for (validator, signature) in validators.iter().zip(&signatures) {
-                        signature_set.add(validator, signature).unwrap();
-                    }
-                    signature_set.signatures().unwrap()
-                },
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.finish();
     }
 
-    /// Deterministic stake-weighted shard assignment (upload) and validator
-    /// selection (download), scaling over validator count.
-    ///
-    /// The `select` benches are sub-microsecond, allocation- and RNG-heavy, and
-    /// show up to ~10% ASLR-driven run-to-run variance on an unquiesced machine;
-    /// hence the wide noise threshold. Treat only large `select` deltas (or
-    /// deltas that survive an A/A re-run) as real. `assign` is stable (<2%).
-    fn bench_validator_assign(c: &mut Criterion) {
-        let mut group = c.benchmark_group("validator_assign");
-        group.measurement_time(CHEAP_MEASUREMENT);
-        group.noise_threshold(0.10);
-
-        let cfg = BlobConfig::v0();
-        let min_rows = rows_per_shard();
-
-        for count in [10, 50, 100] {
-            let (_, validators) = make_validators(count);
-            let set = ValidatorSet::new(validators, 1);
-
-            group.bench_with_input(BenchmarkId::new("assign", count), &set, |b, set| {
-                b.iter(|| {
-                    set.assign(
-                        black_box([42u8; 32]),
-                        cfg.total_rows(),
-                        cfg.original_rows,
-                        min_rows,
-                        liveness(),
-                    )
-                });
-            });
-
-            group.bench_with_input(BenchmarkId::new("select", count), &set, |b, set| {
-                b.iter(|| set.select(cfg.original_rows, min_rows, liveness()));
-            });
-        }
-
-        group.finish();
-    }
-
-    /// Download path: decoding a validator's wire response (proof hash conversion
-    /// + RLC vector parse), run once per validator response.
-    fn bench_parse_download_response(c: &mut Criterion) {
-        let mut group = c.benchmark_group("parse_download_response");
-        group.measurement_time(CHEAP_MEASUREMENT);
-        group.noise_threshold(0.03);
-
-        let shard = rows_per_shard();
-        let response = download_response();
-
-        group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {
-            b.iter_batched(
-                || response.clone(),
-                |response| proto_conv::parse_download_response(response).unwrap(),
-                BatchSize::SmallInput,
-            );
-        });
-
-        group.finish();
-    }
-
-    criterion_group!(
-        benches,
-        bench_blob_new,
-        bench_blob_row_proofs,
-        bench_payment_promise,
-        bench_signature_set,
-        bench_validator_assign,
-        bench_parse_download_response
-    );
+    group.finish();
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-criterion::criterion_main!(native::benches);
+fn bench_blob_row_proofs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("blob_row_proofs");
+    group.measurement_time(CHEAP_MEASUREMENT);
+    group.noise_threshold(0.03);
+
+    for &(name, len) in &[("1MB", 1 << 20), ("8MB", 8 << 20)] {
+        let blob = EncodedBlob::new(&generate_data(len), BlobConfig::v0()).unwrap();
+
+        let shard = rows_per_shard();
+        group.bench_function(BenchmarkId::new(format!("shard_{shard}_rows"), name), |b| {
+            b.iter(|| {
+                for i in 0..shard {
+                    black_box(blob.row(i).unwrap());
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_payment_promise(c: &mut Criterion) {
+    let mut group = c.benchmark_group("payment_promise");
+    group.measurement_time(CHEAP_MEASUREMENT);
+    group.noise_threshold(0.03);
+
+    let (signing_key, mut promise) = signed_promise();
+
+    group.bench_function("sign_bytes", |b| b.iter(|| promise.sign_bytes().unwrap()));
+    group.bench_function("sign", |b| b.iter(|| promise.sign(&signing_key).unwrap()));
+    group.bench_function("validate", |b| b.iter(|| promise.validate().unwrap()));
+    group.bench_function("hash", |b| b.iter(|| promise.hash().unwrap()));
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_signature_set(c: &mut Criterion) {
+    let mut group = c.benchmark_group("signature_set");
+    group.measurement_time(Duration::from_secs(20));
+    group.noise_threshold(0.03);
+
+    let (keys, validators) = make_validators(100);
+    let payload = generate_data(200);
+    let signatures: Vec<Vec<u8>> = keys
+        .iter()
+        .map(|k| {
+            use ed25519_dalek::Signer;
+            k.sign(&payload).to_bytes().to_vec()
+        })
+        .collect();
+
+    let set = ValidatorSet::new(validators.clone(), 1);
+    let threshold = Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap());
+
+    group.bench_function("add_one", |b| {
+        b.iter_batched(
+            || set.new_signature_set(threshold, payload.clone()),
+            |signature_set| signature_set.add(&validators[0], &signatures[0]).unwrap(),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("collect_100", |b| {
+        b.iter_batched(
+            || set.new_signature_set(threshold, payload.clone()),
+            |signature_set| {
+                for (validator, signature) in validators.iter().zip(&signatures) {
+                    signature_set.add(validator, signature).unwrap();
+                }
+                signature_set.signatures().unwrap()
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_validator_assign(c: &mut Criterion) {
+    let mut group = c.benchmark_group("validator_assign");
+    group.measurement_time(CHEAP_MEASUREMENT);
+    group.noise_threshold(0.10);
+
+    let cfg = BlobConfig::v0();
+    let min_rows = rows_per_shard();
+
+    for count in [10, 50, 100] {
+        let (_, validators) = make_validators(count);
+        let set = ValidatorSet::new(validators, 1);
+
+        group.bench_with_input(BenchmarkId::new("assign", count), &set, |b, set| {
+            b.iter(|| {
+                set.assign(
+                    black_box([42u8; 32]),
+                    cfg.total_rows(),
+                    cfg.original_rows,
+                    min_rows,
+                    liveness(),
+                )
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("select", count), &set, |b, set| {
+            b.iter(|| set.select(cfg.original_rows, min_rows, liveness()));
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_parse_download_response(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_download_response");
+    group.measurement_time(CHEAP_MEASUREMENT);
+    group.noise_threshold(0.03);
+
+    let shard = rows_per_shard();
+    let response = download_response();
+
+    group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {
+        b.iter_batched(
+            || response.clone(),
+            |response| proto_conv::parse_download_response(response).unwrap(),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion_group!(
+    benches,
+    bench_blob_new,
+    bench_blob_row_proofs,
+    bench_payment_promise,
+    bench_signature_set,
+    bench_validator_assign,
+    bench_parse_download_response
+);
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(benches);
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
@@ -395,16 +294,6 @@ mod wasm {
 
     use super::*;
 
-    /// The bundled criterion's builder methods take `self` by value while the
-    /// bench macro hands out `&mut Criterion`; reconfigure in place.
-    fn configure(c: &mut Criterion, f: impl FnOnce(Criterion) -> Criterion) {
-        let configured = f(std::mem::take(c));
-        *c = configured;
-    }
-
-    /// Applies a sampling profile. Windows are shorter than the native ones
-    /// because wasm has neither threads nor a SIMD Reed-Solomon engine; the
-    /// noise thresholds mirror the native groups.
     fn profile(
         c: &mut Criterion,
         sample_size: usize,
@@ -412,12 +301,11 @@ mod wasm {
         measurement_secs: u64,
         noise_threshold: f64,
     ) {
-        configure(c, |c| {
-            c.sample_size(sample_size)
-                .warm_up_time(Duration::from_secs(warm_up_secs))
-                .measurement_time(Duration::from_secs(measurement_secs))
-                .noise_threshold(noise_threshold)
-        });
+        *c = std::mem::take(c)
+            .sample_size(sample_size)
+            .warm_up_time(Duration::from_secs(warm_up_secs))
+            .measurement_time(Duration::from_secs(measurement_secs))
+            .noise_threshold(noise_threshold);
     }
 
     fn blob_size(name: &str) -> usize {
@@ -459,7 +347,6 @@ mod wasm {
         });
     }
 
-    /// Validators, their signatures over `payload`, and the payload itself.
     fn signature_set_setup() -> (Vec<ValidatorInfo>, Vec<Vec<u8>>, Vec<u8>) {
         let (keys, validators) = make_validators(100);
         let payload = generate_data(200);
@@ -509,8 +396,6 @@ mod wasm {
         });
     }
 
-    /// Declares one `#[wasm_bindgen_bench]` function per case so each can be
-    /// selected by name from the runner's filter.
     macro_rules! cases {
         ($case:ident: $( $( #[$attr:ident] )* $id:ident = $arg:literal ),* $(,)?) => {
             $(
@@ -576,11 +461,21 @@ mod wasm {
     fn signature_set_add_one(c: &mut Criterion) {
         let (validators, signatures, payload) = signature_set_setup();
         let set = ValidatorSet::new(validators.clone(), 1);
-        let signature_set = set.new_signature_set(threshold(), payload);
+        let threshold = threshold();
 
         profile(c, 50, 1, 5, 0.03);
         c.bench_function("signature_set/add_one", |b| {
-            b.iter(|| signature_set.add(&validators[0], &signatures[0]).unwrap());
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let signature_set = set.new_signature_set(threshold, payload.clone());
+                    let start = Instant::now();
+                    let result = signature_set.add(&validators[0], &signatures[0]);
+                    total += start.elapsed();
+                    black_box(result.unwrap());
+                }
+                total
+            });
         });
     }
 
@@ -588,17 +483,24 @@ mod wasm {
     fn signature_set_collect_100(c: &mut Criterion) {
         let (validators, signatures, payload) = signature_set_setup();
         let set = ValidatorSet::new(validators.clone(), 1);
+        let threshold = threshold();
 
         profile(c, 30, 2, 10, 0.03);
         c.bench_function("signature_set/collect_100", |b| {
-            // Creating the empty signature set is negligible next to the 100
-            // ed25519 verifications, so it stays inside the timed region.
-            b.iter(|| {
-                let signature_set = set.new_signature_set(threshold(), payload.clone());
-                for (validator, signature) in validators.iter().zip(&signatures) {
-                    signature_set.add(validator, signature).unwrap();
+            // Exclude setup to match native `iter_batched`.
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let signature_set = set.new_signature_set(threshold, payload.clone());
+                    let start = Instant::now();
+                    for (validator, signature) in validators.iter().zip(&signatures) {
+                        signature_set.add(validator, signature).unwrap();
+                    }
+                    let result = signature_set.signatures().unwrap();
+                    total += start.elapsed();
+                    black_box(result);
                 }
-                signature_set.signatures().unwrap()
+                total
             });
         });
     }
@@ -624,8 +526,7 @@ mod wasm {
         c.bench_function(
             &format!("parse_download_response/shard_{shard}_rows_1MB"),
             |b| {
-                // Parsing consumes the response, so clone per iteration outside
-                // the timed region (the wasm harness has no `iter_batched`).
+                // Exclude cloning to match native `iter_batched`.
                 b.iter_custom(|iters| {
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
@@ -641,7 +542,5 @@ mod wasm {
     }
 }
 
-/// The wasm bench functions are discovered by `wasm-bindgen-test-runner`
-/// through their exports; the binary entry point is unused.
 #[cfg(target_arch = "wasm32")]
 fn main() {}

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -35,14 +35,42 @@
 //! run with ASLR disabled (`setarch -R cargo bench ...`), and before trusting
 //! a verdict do an A/A pass (re-run the baseline once) to see the machine's
 //! current noise floor.
+//!
+//! ## wasm32-unknown-unknown
+//!
+//! The same code paths can be benchmarked as wasm, executed by Node through
+//! `wasm-bindgen-test-runner`, which `.cargo/config.toml` configures as the
+//! cargo runner for the target. Install `wasm-bindgen-cli` at exactly the
+//! `wasm-bindgen` version pinned in `Cargo.lock` (the nix devshell provides it):
+//!
+//! ```sh
+//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench
+//! # list cases, run a subset by name, run the ignored (>= 32 MiB) cases
+//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- --list
+//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- payment_promise
+//! cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- --ignored
+//! ```
+//!
+//! Always pass `--bench fibre_bench`; without it cargo also hands the library
+//! to the runner. The wasm harness is the trimmed criterion port bundled with
+//! `wasm-bindgen-test`: there are no benchmark groups, throughput lines,
+//! `--save-baseline` or `--test`. Every (group, case) pair is therefore its
+//! own bench function so it can be selected by name (`--exact` and `--skip`
+//! also work). The 32 MiB and 128 MiB blob cases are `#[ignore]`d: wasm runs
+//! single-threaded and the Reed-Solomon engine has no wasm SIMD backend, so
+//! each takes minutes.
+//!
+//! The runner stores the previous run in `target/wbg_benchmark.json` (relative
+//! to the current directory) and prints a change verdict against it on the
+//! next run. Set `WASM_BINDGEN_BENCH_RESULT=<path>` to use a dedicated file,
+//! e.g. run once on the baseline revision and once on the change with the same
+//! path. To run in a browser instead of Node, add
+//! `wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);` to the
+//! `wasm` module below and have `chromedriver` on `PATH`.
 
 use std::num::NonZeroU64;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, black_box, criterion_group,
-    criterion_main,
-};
 use rand::Rng;
 use rand::rngs::OsRng;
 
@@ -65,12 +93,6 @@ fn blob_sizes() -> Vec<(&'static str, usize)> {
         ("128MB", BlobConfig::v0().max_data_size),
     ]
 }
-
-/// Measurement window for cheap (sub-millisecond) benchmarks.
-const CHEAP_MEASUREMENT: Duration = Duration::from_secs(10);
-/// Measurement window for heavy benchmarks (blob encoding).
-const HEAVY_MEASUREMENT: Duration = Duration::from_secs(30);
-const HEAVY_WARM_UP: Duration = Duration::from_secs(5);
 
 /// Rows per shard, matching the protocol's min_rows_per_validator (148 for v0).
 fn rows_per_shard() -> usize {
@@ -106,65 +128,21 @@ fn make_validators(count: usize) -> (Vec<ed25519_dalek::SigningKey>, Vec<Validat
         .unzip()
 }
 
-/// Upload path: full client-side encode (header write + rsema1d encode_in_place
-/// over the (K+N) x row_size matrix). The dominant CPU sink of `upload()`.
-fn bench_blob_new(c: &mut Criterion) {
-    let mut group = c.benchmark_group("blob_new");
-    group.sample_size(10);
-    group.measurement_time(HEAVY_MEASUREMENT);
-    group.warm_up_time(HEAVY_WARM_UP);
-    // Flat sampling: iteration counts don't grow across samples, so the 128MB
-    // case fits the measurement window without criterion warning about it.
-    group.sampling_mode(SamplingMode::Flat);
-    group.noise_threshold(0.02);
-
-    for (name, len) in blob_sizes() {
-        let data = generate_data(len);
-        group.throughput(Throughput::Bytes(len as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
-            b.iter(|| EncodedBlob::new(black_box(data), BlobConfig::v0()).unwrap());
-        });
-    }
-
-    group.finish();
+#[cfg(not(target_arch = "wasm32"))]
+fn now() -> SystemTime {
+    SystemTime::now()
 }
 
-/// Upload path: per-row inclusion proof generation, called once per row per
-/// validator when building upload shards.
-///
-/// Measured per shard (148 rows), not per single row: a lone ~100ns row proof
-/// is dominated by where that row's pages landed in memory, which varies
-/// between processes (ASLR) and made single-row numbers swing >15% run to
-/// run. Averaging over a shard's worth of rows removes that; divide by 148
-/// for the per-row cost.
-fn bench_blob_row_proofs(c: &mut Criterion) {
-    let mut group = c.benchmark_group("blob_row_proofs");
-    group.measurement_time(CHEAP_MEASUREMENT);
-    group.noise_threshold(0.03);
-
-    for &(name, len) in &[("1MB", 1 << 20), ("8MB", 8 << 20)] {
-        let blob = EncodedBlob::new(&generate_data(len), BlobConfig::v0()).unwrap();
-
-        let shard = rows_per_shard();
-        group.bench_function(BenchmarkId::new(format!("shard_{shard}_rows"), name), |b| {
-            b.iter(|| {
-                for i in 0..shard {
-                    black_box(blob.row(i).unwrap());
-                }
-            });
-        });
-    }
-
-    group.finish();
+/// `std::time::SystemTime::now()` panics on wasm32-unknown-unknown; read the
+/// clock through `Date.now()` instead.
+#[cfg(target_arch = "wasm32")]
+fn now() -> SystemTime {
+    use web_time::web::SystemTimeExt;
+    web_time::SystemTime::now().to_std()
 }
 
-/// Upload path: payment promise canonical serialization, secp256k1
-/// sign/verify, and hashing.
-fn bench_payment_promise(c: &mut Criterion) {
-    let mut group = c.benchmark_group("payment_promise");
-    group.measurement_time(CHEAP_MEASUREMENT);
-    group.noise_threshold(0.03);
-
+/// A signed payment promise for a 1 MiB upload, with its signing key.
+fn signed_promise() -> (k256::ecdsa::SigningKey, PaymentPromise) {
     let signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
     let mut promise = PaymentPromise {
         chain_id: "private".into(),
@@ -173,108 +151,17 @@ fn bench_payment_promise(c: &mut Criterion) {
         upload_size: BlobConfig::v0().upload_size(1 << 20) as u32,
         blob_version: 0,
         commitment: [7u8; 32],
-        creation_timestamp: SystemTime::now(),
+        creation_timestamp: now(),
         signer_pubkey: *signing_key.verifying_key(),
         signature: None,
     };
     promise.sign(&signing_key).unwrap();
-
-    group.bench_function("sign_bytes", |b| b.iter(|| promise.sign_bytes().unwrap()));
-    group.bench_function("sign", |b| b.iter(|| promise.sign(&signing_key).unwrap()));
-    group.bench_function("validate", |b| b.iter(|| promise.validate().unwrap()));
-    group.bench_function("hash", |b| b.iter(|| promise.hash().unwrap()));
-
-    group.finish();
+    (signing_key, promise)
 }
 
-/// Upload path: ed25519 signature verification of validator responses, and
-/// collecting a full validator set's worth of signatures.
-fn bench_signature_set(c: &mut Criterion) {
-    let mut group = c.benchmark_group("signature_set");
-    // collect_100 runs ~3ms/iter; 100 samples need more than the cheap window.
-    group.measurement_time(Duration::from_secs(20));
-    group.noise_threshold(0.03);
-
-    let (keys, validators) = make_validators(100);
-    let payload = generate_data(200);
-    let signatures: Vec<Vec<u8>> = keys
-        .iter()
-        .map(|k| {
-            use ed25519_dalek::Signer;
-            k.sign(&payload).to_bytes().to_vec()
-        })
-        .collect();
-
-    let set = ValidatorSet::new(validators.clone(), 1);
-    let threshold = Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap());
-
-    let signature_set = set.new_signature_set(threshold, payload.clone());
-    group.bench_function("add_one", |b| {
-        b.iter(|| signature_set.add(&validators[0], &signatures[0]).unwrap());
-    });
-
-    group.bench_function("collect_100", |b| {
-        b.iter_batched(
-            || set.new_signature_set(threshold, payload.clone()),
-            |signature_set| {
-                for (validator, signature) in validators.iter().zip(&signatures) {
-                    signature_set.add(validator, signature).unwrap();
-                }
-                signature_set.signatures().unwrap()
-            },
-            BatchSize::SmallInput,
-        );
-    });
-
-    group.finish();
-}
-
-/// Deterministic stake-weighted shard assignment (upload) and validator
-/// selection (download), scaling over validator count.
-///
-/// The `select` benches are sub-microsecond, allocation- and RNG-heavy, and
-/// show up to ~10% ASLR-driven run-to-run variance on an unquiesced machine;
-/// hence the wide noise threshold. Treat only large `select` deltas (or
-/// deltas that survive an A/A re-run) as real. `assign` is stable (<2%).
-fn bench_validator_assign(c: &mut Criterion) {
-    let mut group = c.benchmark_group("validator_assign");
-    group.measurement_time(CHEAP_MEASUREMENT);
-    group.noise_threshold(0.10);
-
-    let cfg = BlobConfig::v0();
-    let min_rows = rows_per_shard();
-
-    for count in [10, 50, 100] {
-        let (_, validators) = make_validators(count);
-        let set = ValidatorSet::new(validators, 1);
-
-        group.bench_with_input(BenchmarkId::new("assign", count), &set, |b, set| {
-            b.iter(|| {
-                set.assign(
-                    black_box([42u8; 32]),
-                    cfg.total_rows(),
-                    cfg.original_rows,
-                    min_rows,
-                    liveness(),
-                )
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("select", count), &set, |b, set| {
-            b.iter(|| set.select(cfg.original_rows, min_rows, liveness()));
-        });
-    }
-
-    group.finish();
-}
-
-/// Download path: decoding a validator's wire response (proof hash conversion
-/// + RLC vector parse), run once per validator response.
-fn bench_parse_download_response(c: &mut Criterion) {
-    let mut group = c.benchmark_group("parse_download_response");
-    group.measurement_time(CHEAP_MEASUREMENT);
-    group.noise_threshold(0.03);
-
+/// A validator's wire response holding one shard (`rows_per_shard()` rows) of
+/// a 1 MiB blob.
+fn download_response() -> proto::DownloadShardResponse {
     let shard = rows_per_shard();
     let blob = EncodedBlob::new(&generate_data(1 << 20), BlobConfig::v0()).unwrap();
 
@@ -293,28 +180,468 @@ fn bench_parse_download_response(c: &mut Criterion) {
         .iter()
         .flat_map(|rlc| rlc.to_bytes())
         .collect();
-    let response = proto::DownloadShardResponse {
+    proto::DownloadShardResponse {
         shard: Some(proto::BlobShard { rows, rlcs }),
-    };
-
-    group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {
-        b.iter_batched(
-            || response.clone(),
-            |response| proto_conv::parse_download_response(response).unwrap(),
-            BatchSize::SmallInput,
-        );
-    });
-
-    group.finish();
+    }
 }
 
-criterion_group!(
-    benches,
-    bench_blob_new,
-    bench_blob_row_proofs,
-    bench_payment_promise,
-    bench_signature_set,
-    bench_validator_assign,
-    bench_parse_download_response
-);
-criterion_main!(benches);
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::time::Duration;
+
+    use criterion::{
+        BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, black_box, criterion_group,
+    };
+
+    use super::*;
+
+    /// Measurement window for cheap (sub-millisecond) benchmarks.
+    const CHEAP_MEASUREMENT: Duration = Duration::from_secs(10);
+    /// Measurement window for heavy benchmarks (blob encoding).
+    const HEAVY_MEASUREMENT: Duration = Duration::from_secs(30);
+    const HEAVY_WARM_UP: Duration = Duration::from_secs(5);
+
+    /// Upload path: full client-side encode (header write + rsema1d encode_in_place
+    /// over the (K+N) x row_size matrix). The dominant CPU sink of `upload()`.
+    fn bench_blob_new(c: &mut Criterion) {
+        let mut group = c.benchmark_group("blob_new");
+        group.sample_size(10);
+        group.measurement_time(HEAVY_MEASUREMENT);
+        group.warm_up_time(HEAVY_WARM_UP);
+        // Flat sampling: iteration counts don't grow across samples, so the 128MB
+        // case fits the measurement window without criterion warning about it.
+        group.sampling_mode(SamplingMode::Flat);
+        group.noise_threshold(0.02);
+
+        for (name, len) in blob_sizes() {
+            let data = generate_data(len);
+            group.throughput(Throughput::Bytes(len as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
+                b.iter(|| EncodedBlob::new(black_box(data), BlobConfig::v0()).unwrap());
+            });
+        }
+
+        group.finish();
+    }
+
+    /// Upload path: per-row inclusion proof generation, called once per row per
+    /// validator when building upload shards.
+    ///
+    /// Measured per shard (148 rows), not per single row: a lone ~100ns row proof
+    /// is dominated by where that row's pages landed in memory, which varies
+    /// between processes (ASLR) and made single-row numbers swing >15% run to
+    /// run. Averaging over a shard's worth of rows removes that; divide by 148
+    /// for the per-row cost.
+    fn bench_blob_row_proofs(c: &mut Criterion) {
+        let mut group = c.benchmark_group("blob_row_proofs");
+        group.measurement_time(CHEAP_MEASUREMENT);
+        group.noise_threshold(0.03);
+
+        for &(name, len) in &[("1MB", 1 << 20), ("8MB", 8 << 20)] {
+            let blob = EncodedBlob::new(&generate_data(len), BlobConfig::v0()).unwrap();
+
+            let shard = rows_per_shard();
+            group.bench_function(BenchmarkId::new(format!("shard_{shard}_rows"), name), |b| {
+                b.iter(|| {
+                    for i in 0..shard {
+                        black_box(blob.row(i).unwrap());
+                    }
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    /// Upload path: payment promise canonical serialization, secp256k1
+    /// sign/verify, and hashing.
+    fn bench_payment_promise(c: &mut Criterion) {
+        let mut group = c.benchmark_group("payment_promise");
+        group.measurement_time(CHEAP_MEASUREMENT);
+        group.noise_threshold(0.03);
+
+        let (signing_key, mut promise) = signed_promise();
+
+        group.bench_function("sign_bytes", |b| b.iter(|| promise.sign_bytes().unwrap()));
+        group.bench_function("sign", |b| b.iter(|| promise.sign(&signing_key).unwrap()));
+        group.bench_function("validate", |b| b.iter(|| promise.validate().unwrap()));
+        group.bench_function("hash", |b| b.iter(|| promise.hash().unwrap()));
+
+        group.finish();
+    }
+
+    /// Upload path: ed25519 signature verification of validator responses, and
+    /// collecting a full validator set's worth of signatures.
+    fn bench_signature_set(c: &mut Criterion) {
+        let mut group = c.benchmark_group("signature_set");
+        // collect_100 runs ~3ms/iter; 100 samples need more than the cheap window.
+        group.measurement_time(Duration::from_secs(20));
+        group.noise_threshold(0.03);
+
+        let (keys, validators) = make_validators(100);
+        let payload = generate_data(200);
+        let signatures: Vec<Vec<u8>> = keys
+            .iter()
+            .map(|k| {
+                use ed25519_dalek::Signer;
+                k.sign(&payload).to_bytes().to_vec()
+            })
+            .collect();
+
+        let set = ValidatorSet::new(validators.clone(), 1);
+        let threshold = Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap());
+
+        let signature_set = set.new_signature_set(threshold, payload.clone());
+        group.bench_function("add_one", |b| {
+            b.iter(|| signature_set.add(&validators[0], &signatures[0]).unwrap());
+        });
+
+        group.bench_function("collect_100", |b| {
+            b.iter_batched(
+                || set.new_signature_set(threshold, payload.clone()),
+                |signature_set| {
+                    for (validator, signature) in validators.iter().zip(&signatures) {
+                        signature_set.add(validator, signature).unwrap();
+                    }
+                    signature_set.signatures().unwrap()
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    /// Deterministic stake-weighted shard assignment (upload) and validator
+    /// selection (download), scaling over validator count.
+    ///
+    /// The `select` benches are sub-microsecond, allocation- and RNG-heavy, and
+    /// show up to ~10% ASLR-driven run-to-run variance on an unquiesced machine;
+    /// hence the wide noise threshold. Treat only large `select` deltas (or
+    /// deltas that survive an A/A re-run) as real. `assign` is stable (<2%).
+    fn bench_validator_assign(c: &mut Criterion) {
+        let mut group = c.benchmark_group("validator_assign");
+        group.measurement_time(CHEAP_MEASUREMENT);
+        group.noise_threshold(0.10);
+
+        let cfg = BlobConfig::v0();
+        let min_rows = rows_per_shard();
+
+        for count in [10, 50, 100] {
+            let (_, validators) = make_validators(count);
+            let set = ValidatorSet::new(validators, 1);
+
+            group.bench_with_input(BenchmarkId::new("assign", count), &set, |b, set| {
+                b.iter(|| {
+                    set.assign(
+                        black_box([42u8; 32]),
+                        cfg.total_rows(),
+                        cfg.original_rows,
+                        min_rows,
+                        liveness(),
+                    )
+                });
+            });
+
+            group.bench_with_input(BenchmarkId::new("select", count), &set, |b, set| {
+                b.iter(|| set.select(cfg.original_rows, min_rows, liveness()));
+            });
+        }
+
+        group.finish();
+    }
+
+    /// Download path: decoding a validator's wire response (proof hash conversion
+    /// + RLC vector parse), run once per validator response.
+    fn bench_parse_download_response(c: &mut Criterion) {
+        let mut group = c.benchmark_group("parse_download_response");
+        group.measurement_time(CHEAP_MEASUREMENT);
+        group.noise_threshold(0.03);
+
+        let shard = rows_per_shard();
+        let response = download_response();
+
+        group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {
+            b.iter_batched(
+                || response.clone(),
+                |response| proto_conv::parse_download_response(response).unwrap(),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    }
+
+    criterion_group!(
+        benches,
+        bench_blob_new,
+        bench_blob_row_proofs,
+        bench_payment_promise,
+        bench_signature_set,
+        bench_validator_assign,
+        bench_parse_download_response
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(native::benches);
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use std::hint::black_box;
+    use std::time::Duration;
+
+    use wasm_bindgen_test::{Criterion, Instant, wasm_bindgen_bench};
+
+    use super::*;
+
+    /// The bundled criterion's builder methods take `self` by value while the
+    /// bench macro hands out `&mut Criterion`; reconfigure in place.
+    fn configure(c: &mut Criterion, f: impl FnOnce(Criterion) -> Criterion) {
+        let configured = f(std::mem::take(c));
+        *c = configured;
+    }
+
+    /// Applies a sampling profile. Windows are shorter than the native ones
+    /// because wasm has neither threads nor a SIMD Reed-Solomon engine; the
+    /// noise thresholds mirror the native groups.
+    fn profile(
+        c: &mut Criterion,
+        sample_size: usize,
+        warm_up_secs: u64,
+        measurement_secs: u64,
+        noise_threshold: f64,
+    ) {
+        configure(c, |c| {
+            c.sample_size(sample_size)
+                .warm_up_time(Duration::from_secs(warm_up_secs))
+                .measurement_time(Duration::from_secs(measurement_secs))
+                .noise_threshold(noise_threshold)
+        });
+    }
+
+    fn blob_size(name: &str) -> usize {
+        blob_sizes()
+            .into_iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, len)| len)
+            .unwrap_or_else(|| panic!("unknown blob size {name}"))
+    }
+
+    fn blob_new_case(c: &mut Criterion, name: &str) {
+        let len = blob_size(name);
+        let (sample_size, warm_up_secs, measurement_secs) = if len >= 32 << 20 {
+            (10, 3, 20)
+        } else if len >= 4 << 20 {
+            (10, 2, 10)
+        } else {
+            (20, 1, 10)
+        };
+        profile(c, sample_size, warm_up_secs, measurement_secs, 0.02);
+
+        let data = generate_data(len);
+        c.bench_function(&format!("blob_new/{name}"), |b| {
+            b.iter(|| EncodedBlob::new(black_box(&data), BlobConfig::v0()).unwrap());
+        });
+    }
+
+    fn blob_row_proofs_case(c: &mut Criterion, name: &str) {
+        let blob = EncodedBlob::new(&generate_data(blob_size(name)), BlobConfig::v0()).unwrap();
+        let shard = rows_per_shard();
+
+        profile(c, 50, 1, 5, 0.03);
+        c.bench_function(&format!("blob_row_proofs/shard_{shard}_rows/{name}"), |b| {
+            b.iter(|| {
+                for i in 0..shard {
+                    black_box(blob.row(i).unwrap());
+                }
+            });
+        });
+    }
+
+    /// Validators, their signatures over `payload`, and the payload itself.
+    fn signature_set_setup() -> (Vec<ValidatorInfo>, Vec<Vec<u8>>, Vec<u8>) {
+        let (keys, validators) = make_validators(100);
+        let payload = generate_data(200);
+        let signatures = keys
+            .iter()
+            .map(|k| {
+                use ed25519_dalek::Signer;
+                k.sign(&payload).to_bytes().to_vec()
+            })
+            .collect();
+        (validators, signatures, payload)
+    }
+
+    fn threshold() -> Fraction {
+        Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap())
+    }
+
+    fn assign_case(c: &mut Criterion, count: usize) {
+        let cfg = BlobConfig::v0();
+        let min_rows = rows_per_shard();
+        let (_, validators) = make_validators(count);
+        let set = ValidatorSet::new(validators, 1);
+
+        profile(c, 50, 1, 5, 0.10);
+        c.bench_function(&format!("validator_assign/assign/{count}"), |b| {
+            b.iter(|| {
+                set.assign(
+                    black_box([42u8; 32]),
+                    cfg.total_rows(),
+                    cfg.original_rows,
+                    min_rows,
+                    liveness(),
+                )
+            });
+        });
+    }
+
+    fn select_case(c: &mut Criterion, count: usize) {
+        let cfg = BlobConfig::v0();
+        let min_rows = rows_per_shard();
+        let (_, validators) = make_validators(count);
+        let set = ValidatorSet::new(validators, 1);
+
+        profile(c, 50, 1, 5, 0.10);
+        c.bench_function(&format!("validator_assign/select/{count}"), |b| {
+            b.iter(|| set.select(cfg.original_rows, min_rows, liveness()));
+        });
+    }
+
+    /// Declares one `#[wasm_bindgen_bench]` function per case so each can be
+    /// selected by name from the runner's filter.
+    macro_rules! cases {
+        ($case:ident: $( $( #[$attr:ident] )* $id:ident = $arg:literal ),* $(,)?) => {
+            $(
+                #[wasm_bindgen_bench]
+                $( #[$attr] )*
+                fn $id(c: &mut Criterion) {
+                    $case(c, $arg);
+                }
+            )*
+        };
+    }
+
+    cases!(blob_new_case:
+        blob_new_128kb = "128KB",
+        blob_new_1mb = "1MB",
+        blob_new_8mb = "8MB",
+        #[ignore] blob_new_32mb = "32MB",
+        #[ignore] blob_new_128mb = "128MB",
+    );
+
+    cases!(blob_row_proofs_case:
+        blob_row_proofs_1mb = "1MB",
+        blob_row_proofs_8mb = "8MB",
+    );
+
+    #[wasm_bindgen_bench]
+    fn payment_promise_sign_bytes(c: &mut Criterion) {
+        let (_, promise) = signed_promise();
+        profile(c, 50, 1, 5, 0.03);
+        c.bench_function("payment_promise/sign_bytes", |b| {
+            b.iter(|| promise.sign_bytes().unwrap());
+        });
+    }
+
+    #[wasm_bindgen_bench]
+    fn payment_promise_sign(c: &mut Criterion) {
+        let (signing_key, mut promise) = signed_promise();
+        profile(c, 50, 1, 5, 0.03);
+        c.bench_function("payment_promise/sign", |b| {
+            b.iter(|| promise.sign(&signing_key).unwrap());
+        });
+    }
+
+    #[wasm_bindgen_bench]
+    fn payment_promise_validate(c: &mut Criterion) {
+        let (_, promise) = signed_promise();
+        profile(c, 50, 1, 5, 0.03);
+        c.bench_function("payment_promise/validate", |b| {
+            b.iter(|| promise.validate().unwrap());
+        });
+    }
+
+    #[wasm_bindgen_bench]
+    fn payment_promise_hash(c: &mut Criterion) {
+        let (_, promise) = signed_promise();
+        profile(c, 50, 1, 5, 0.03);
+        c.bench_function("payment_promise/hash", |b| {
+            b.iter(|| promise.hash().unwrap());
+        });
+    }
+
+    #[wasm_bindgen_bench]
+    fn signature_set_add_one(c: &mut Criterion) {
+        let (validators, signatures, payload) = signature_set_setup();
+        let set = ValidatorSet::new(validators.clone(), 1);
+        let signature_set = set.new_signature_set(threshold(), payload);
+
+        profile(c, 50, 1, 5, 0.03);
+        c.bench_function("signature_set/add_one", |b| {
+            b.iter(|| signature_set.add(&validators[0], &signatures[0]).unwrap());
+        });
+    }
+
+    #[wasm_bindgen_bench]
+    fn signature_set_collect_100(c: &mut Criterion) {
+        let (validators, signatures, payload) = signature_set_setup();
+        let set = ValidatorSet::new(validators.clone(), 1);
+
+        profile(c, 30, 2, 10, 0.03);
+        c.bench_function("signature_set/collect_100", |b| {
+            // Creating the empty signature set is negligible next to the 100
+            // ed25519 verifications, so it stays inside the timed region.
+            b.iter(|| {
+                let signature_set = set.new_signature_set(threshold(), payload.clone());
+                for (validator, signature) in validators.iter().zip(&signatures) {
+                    signature_set.add(validator, signature).unwrap();
+                }
+                signature_set.signatures().unwrap()
+            });
+        });
+    }
+
+    cases!(assign_case:
+        validator_assign_assign_10 = 10,
+        validator_assign_assign_50 = 50,
+        validator_assign_assign_100 = 100,
+    );
+
+    cases!(select_case:
+        validator_assign_select_10 = 10,
+        validator_assign_select_50 = 50,
+        validator_assign_select_100 = 100,
+    );
+
+    #[wasm_bindgen_bench]
+    fn parse_download_response_1mb(c: &mut Criterion) {
+        let shard = rows_per_shard();
+        let response = download_response();
+
+        profile(c, 30, 1, 5, 0.03);
+        c.bench_function(
+            &format!("parse_download_response/shard_{shard}_rows_1MB"),
+            |b| {
+                // Parsing consumes the response, so clone per iteration outside
+                // the timed region (the wasm harness has no `iter_batched`).
+                b.iter_custom(|iters| {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let input = response.clone();
+                        let start = Instant::now();
+                        black_box(proto_conv::parse_download_response(input).unwrap());
+                        total += start.elapsed();
+                    }
+                    total
+                });
+            },
+        );
+    }
+}
+
+/// The wasm bench functions are discovered by `wasm-bindgen-test-runner`
+/// through their exports; the binary entry point is unused.
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/rsema1d/Cargo.toml
+++ b/rsema1d/Cargo.toml
@@ -32,4 +32,4 @@ harness = false
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test.workspace = true

--- a/rsema1d/README.md
+++ b/rsema1d/README.md
@@ -18,6 +18,11 @@ cargo test
 
 # wasm32 benchmarks, run in Node (needs wasm-bindgen-cli matching Cargo.lock)
 cargo bench --target wasm32-unknown-unknown --bench codec_bench
+# list cases or filter by name
+cargo bench --target wasm32-unknown-unknown --bench codec_bench -- --list
+cargo bench --target wasm32-unknown-unknown --bench codec_bench -- encode_8mb
+# opt into the ignored 128 MiB cases
+cargo bench --target wasm32-unknown-unknown --bench codec_bench -- --include-ignored 128mb
 RUN_RUST_BENCH=0 RUN_GO_BENCH=0 RUN_WASM_BENCH=1 ./scripts/run_benchmarks.sh
 
 # regenerate Go fuzzy vectors and run Rust Go-compat test

--- a/rsema1d/README.md
+++ b/rsema1d/README.md
@@ -16,6 +16,10 @@ cargo test
 # benchmark runner (Rust and Go)
 ./scripts/run_benchmarks.sh
 
+# wasm32 benchmarks, run in Node (needs wasm-bindgen-cli matching Cargo.lock)
+cargo bench --target wasm32-unknown-unknown --bench codec_bench
+RUN_RUST_BENCH=0 RUN_GO_BENCH=0 RUN_WASM_BENCH=1 ./scripts/run_benchmarks.sh
+
 # regenerate Go fuzzy vectors and run Rust Go-compat test
 ./scripts/run_go_compat.sh
 ```

--- a/rsema1d/benches/codec_bench.rs
+++ b/rsema1d/benches/codec_bench.rs
@@ -1,49 +1,4 @@
-//! Benchmarks for the rsema1d codec: row extension (`encode`, `encode_in_place`),
-//! row proof generation, proof verification, verification context construction,
-//! and reconstruction from parity rows.
-//!
-//! ## Native (criterion)
-//!
-//! ```sh
-//! cargo bench -p rsema1d --bench codec_bench
-//! cargo bench -p rsema1d --bench codec_bench -- --save-baseline main
-//! # ...apply the change...
-//! cargo bench -p rsema1d --bench codec_bench -- --baseline main
-//! ```
-//!
-//! A fast sanity pass (each case runs once) is `-- --test`.
-//! `./scripts/run_benchmarks.sh` runs these together with the Go runner.
-//!
-//! ## wasm32-unknown-unknown
-//!
-//! The same code paths can be benchmarked as wasm, executed by Node through
-//! `wasm-bindgen-test-runner`, which `.cargo/config.toml` configures as the
-//! cargo runner for the target. Install `wasm-bindgen-cli` at exactly the
-//! `wasm-bindgen` version pinned in `Cargo.lock` (the nix devshell provides it):
-//!
-//! ```sh
-//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench
-//! # list cases, run a subset by name, run the ignored (128 MiB) cases
-//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- --list
-//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- encode_8mb
-//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- --ignored
-//! ```
-//!
-//! Always pass `--bench codec_bench`; without it cargo also hands the library
-//! to the runner. The wasm harness is the trimmed criterion port bundled with
-//! `wasm-bindgen-test`: there are no benchmark groups, throughput lines,
-//! `--save-baseline` or `--test`. Every (group, size) pair is therefore its
-//! own bench function so it can be selected by name (`--exact` and `--skip`
-//! also work). The 128 MiB cases are `#[ignore]`d: wasm runs single-threaded
-//! and the Reed-Solomon engine has no wasm SIMD backend, so each takes minutes.
-//!
-//! The runner stores the previous run in `target/wbg_benchmark.json` (relative
-//! to the current directory) and prints a change verdict against it on the
-//! next run. Set `WASM_BINDGEN_BENCH_RESULT=<path>` to use a dedicated file,
-//! e.g. run once on the baseline revision and once on the change with the same
-//! path. To run in a browser instead of Node, add
-//! `wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);` to the
-//! `wasm` module below and have `chromedriver` on `PATH`.
+//! Benchmarks for encoding, proofs, verification, and reconstruction.
 
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -53,7 +8,6 @@ use rsema1d::{
 
 const DATA_SEED: u64 = 0x5eed_5eed_5eed_5eed;
 
-/// `(name, k, n, row_size)`.
 type Config = (&'static str, usize, usize, usize);
 
 const ENCODE_CONFIGS: &[Config] = &[
@@ -86,208 +40,214 @@ fn generate_test_data(k: usize, row_size: usize) -> Vec<u8> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-mod native {
-    use std::time::Duration;
+use std::time::Duration;
 
-    use criterion::{
-        black_box, criterion_group, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
-        SamplingMode, Throughput,
-    };
+#[cfg(not(target_arch = "wasm32"))]
+use criterion::{
+    black_box, criterion_group, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
+    SamplingMode, Throughput,
+};
 
-    use super::*;
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy)]
+enum SamplingProfile {
+    SubMillisecond,
+    Milliseconds,
+    Subsecond,
+    Seconds,
+}
 
-    #[derive(Clone, Copy)]
-    enum SamplingProfile {
-        SubMillisecond,
-        Milliseconds,
-        Subsecond,
-        Seconds,
-    }
-
-    impl SamplingProfile {
-        fn for_bytes(bytes: usize) -> Self {
-            const MIB: usize = 1024 * 1024;
-            if bytes >= 64 * MIB {
-                SamplingProfile::Seconds
-            } else if bytes >= 4 * MIB {
-                SamplingProfile::Subsecond
-            } else {
-                SamplingProfile::Milliseconds
-            }
-        }
-
-        fn apply(self, group: &mut BenchmarkGroup<'_, WallTime>) {
-            let (sampling_mode, sample_size, warm_up_secs, measurement_secs) = match self {
-                SamplingProfile::SubMillisecond => (SamplingMode::Linear, 100, 3, 10),
-                SamplingProfile::Milliseconds => (SamplingMode::Linear, 100, 3, 45),
-                SamplingProfile::Subsecond => (SamplingMode::Flat, 60, 3, 45),
-                SamplingProfile::Seconds => (SamplingMode::Flat, 30, 5, 75),
-            };
-
-            group
-                .sampling_mode(sampling_mode)
-                .sample_size(sample_size)
-                .warm_up_time(Duration::from_secs(warm_up_secs))
-                .measurement_time(Duration::from_secs(measurement_secs));
+#[cfg(not(target_arch = "wasm32"))]
+impl SamplingProfile {
+    fn for_bytes(bytes: usize) -> Self {
+        const MIB: usize = 1024 * 1024;
+        if bytes >= 64 * MIB {
+            SamplingProfile::Seconds
+        } else if bytes >= 4 * MIB {
+            SamplingProfile::Subsecond
+        } else {
+            SamplingProfile::Milliseconds
         }
     }
 
-    fn bench_encode(c: &mut Criterion) {
-        let mut group = c.benchmark_group("encode");
+    fn apply(self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        let (sampling_mode, sample_size, warm_up_secs, measurement_secs) = match self {
+            SamplingProfile::SubMillisecond => (SamplingMode::Linear, 100, 3, 10),
+            SamplingProfile::Milliseconds => (SamplingMode::Linear, 100, 3, 45),
+            SamplingProfile::Subsecond => (SamplingMode::Flat, 60, 3, 45),
+            SamplingProfile::Seconds => (SamplingMode::Flat, 30, 5, 75),
+        };
 
-        for &(name, k, n, row_size) in ENCODE_CONFIGS {
-            let params = Parameters::new(k, n, row_size).unwrap();
-            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-            let total_bytes = k * row_size;
-
-            SamplingProfile::for_bytes(total_bytes).apply(&mut group);
-            group.throughput(Throughput::Bytes(total_bytes as u64));
-            group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
-                b.iter(|| encode(black_box(data), black_box(&params)).unwrap());
-            });
-        }
-
-        group.finish();
-    }
-
-    fn bench_encode_in_place(c: &mut Criterion) {
-        let mut group = c.benchmark_group("encode_in_place");
-
-        for &(name, k, n, row_size) in ENCODE_CONFIGS {
-            let params = Parameters::new(k, n, row_size).unwrap();
-            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-            let total_bytes = k * row_size;
-            let mut prefilled = vec![0u8; (k + n) * row_size];
-            prefilled[..k * row_size].copy_from_slice(data.as_row_major());
-            let mut extended = Some(RowMatrix::with_shape(prefilled, k + n, row_size).unwrap());
-
-            SamplingProfile::for_bytes(total_bytes).apply(&mut group);
-            group.throughput(Throughput::Bytes(total_bytes as u64));
-            group.bench_with_input(BenchmarkId::from_parameter(name), &params, |b, params| {
-                b.iter(|| {
-                    let buffer = extended.take().expect("buffer must be available");
-                    let (ext_data, _commitment, _rlc_orig) =
-                        encode_in_place(black_box(buffer), black_box(params)).unwrap();
-                    let rsema1d::ExtendedData { all_rows, .. } = ext_data;
-                    extended = Some(all_rows);
-                });
-            });
-        }
-
-        group.finish();
-    }
-
-    fn bench_proof_generation(c: &mut Criterion) {
-        let mut group = c.benchmark_group("proof_generation");
-        SamplingProfile::SubMillisecond.apply(&mut group);
-
-        for &(name, k, n, row_size) in COMMON_CONFIGS {
-            let params = Parameters::new(k, n, row_size).unwrap();
-            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-            let commitment = ExtendedData::generate(&data, &params).unwrap();
-
-            group.bench_with_input(
-                BenchmarkId::from_parameter(name),
-                &commitment,
-                |b, commitment| {
-                    b.iter(|| commitment.generate_row_proof(black_box(0)).unwrap());
-                },
-            );
-        }
-
-        group.finish();
-    }
-
-    fn bench_verification(c: &mut Criterion) {
-        let mut group = c.benchmark_group("verification");
-        SamplingProfile::SubMillisecond.apply(&mut group);
-
-        for &(name, k, n, row_size) in COMMON_CONFIGS {
-            let params = Parameters::new(k, n, row_size).unwrap();
-            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-            let commitment = ExtendedData::generate(&data, &params).unwrap();
-            let proof = commitment.generate_row_proof(0).unwrap();
-            let context = VerificationContext::new(commitment.rlc_original(), &params).unwrap();
-            let commitment_bytes = commitment.commitment();
-
-            group.bench_with_input(
-                BenchmarkId::from_parameter(name),
-                &(&proof, &commitment_bytes, &context),
-                |b, (proof, commitment_bytes, context)| {
-                    b.iter(|| {
-                        rsema1d::codec::verify_proof(
-                            black_box(proof),
-                            black_box(commitment_bytes),
-                            black_box(context),
-                        )
-                        .unwrap()
-                    });
-                },
-            );
-        }
-
-        group.finish();
-    }
-
-    fn bench_verification_context(c: &mut Criterion) {
-        let mut group = c.benchmark_group("verification_context");
-        SamplingProfile::Milliseconds.apply(&mut group);
-
-        for &(name, k, n, row_size) in CONTEXT_CONFIGS {
-            let params = Parameters::new(k, n, row_size).unwrap();
-            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-            let commitment = ExtendedData::generate(&data, &params).unwrap();
-            let rlcs = commitment.rlc_original().to_vec();
-
-            group.bench_with_input(BenchmarkId::from_parameter(name), &rlcs, |b, rlcs| {
-                b.iter(|| VerificationContext::new(black_box(rlcs), black_box(&params)).unwrap());
-            });
-        }
-
-        group.finish();
-    }
-
-    fn bench_reconstruct(c: &mut Criterion) {
-        let mut group = c.benchmark_group("reconstruct");
-
-        for &(name, k, n, row_size) in COMMON_CONFIGS {
-            let params = Parameters::new(k, n, row_size).unwrap();
-            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-            let extended = ExtendedData::generate(&data, &params).unwrap();
-
-            // Use parity rows only (indices k..2k) so reconstruction performs an
-            // actual Reed-Solomon decode instead of copying originals through.
-            let indices: Vec<usize> = (k..2 * k).collect();
-            let rows: Vec<&[u8]> = indices.iter().map(|&i| extended.row(i).unwrap()).collect();
-            let total_bytes = k * row_size;
-
-            SamplingProfile::for_bytes(total_bytes).apply(&mut group);
-            group.throughput(Throughput::Bytes(total_bytes as u64));
-            group.bench_function(BenchmarkId::from_parameter(name), |b| {
-                b.iter(|| {
-                    reconstruct(black_box(&rows), black_box(&indices), black_box(&params)).unwrap()
-                });
-            });
-        }
-
-        group.finish();
-    }
-
-    criterion_group! {
-        name = benches;
-        config = Criterion::default().noise_threshold(0.03);
-        targets =
-            bench_encode,
-            bench_encode_in_place,
-            bench_proof_generation,
-            bench_verification,
-            bench_verification_context,
-            bench_reconstruct
+        group
+            .sampling_mode(sampling_mode)
+            .sample_size(sample_size)
+            .warm_up_time(Duration::from_secs(warm_up_secs))
+            .measurement_time(Duration::from_secs(measurement_secs));
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-criterion::criterion_main!(native::benches);
+fn bench_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode");
+
+    for &(name, k, n, row_size) in ENCODE_CONFIGS {
+        let params = Parameters::new(k, n, row_size).unwrap();
+        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+        let total_bytes = k * row_size;
+
+        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
+            b.iter(|| encode(black_box(data), black_box(&params)).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_encode_in_place(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode_in_place");
+
+    for &(name, k, n, row_size) in ENCODE_CONFIGS {
+        let params = Parameters::new(k, n, row_size).unwrap();
+        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+        let total_bytes = k * row_size;
+        let mut prefilled = vec![0u8; (k + n) * row_size];
+        prefilled[..k * row_size].copy_from_slice(data.as_row_major());
+        let mut extended = Some(RowMatrix::with_shape(prefilled, k + n, row_size).unwrap());
+
+        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), &params, |b, params| {
+            b.iter(|| {
+                let buffer = extended.take().expect("buffer must be available");
+                let (ext_data, _commitment, _rlc_orig) =
+                    encode_in_place(black_box(buffer), black_box(params)).unwrap();
+                let rsema1d::ExtendedData { all_rows, .. } = ext_data;
+                extended = Some(all_rows);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_proof_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("proof_generation");
+    SamplingProfile::SubMillisecond.apply(&mut group);
+
+    for &(name, k, n, row_size) in COMMON_CONFIGS {
+        let params = Parameters::new(k, n, row_size).unwrap();
+        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+        let commitment = ExtendedData::generate(&data, &params).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &commitment,
+            |b, commitment| {
+                b.iter(|| commitment.generate_row_proof(black_box(0)).unwrap());
+            },
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_verification(c: &mut Criterion) {
+    let mut group = c.benchmark_group("verification");
+    SamplingProfile::SubMillisecond.apply(&mut group);
+
+    for &(name, k, n, row_size) in COMMON_CONFIGS {
+        let params = Parameters::new(k, n, row_size).unwrap();
+        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+        let commitment = ExtendedData::generate(&data, &params).unwrap();
+        let proof = commitment.generate_row_proof(0).unwrap();
+        let context = VerificationContext::new(commitment.rlc_original(), &params).unwrap();
+        let commitment_bytes = commitment.commitment();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(&proof, &commitment_bytes, &context),
+            |b, (proof, commitment_bytes, context)| {
+                b.iter(|| {
+                    rsema1d::codec::verify_proof(
+                        black_box(proof),
+                        black_box(commitment_bytes),
+                        black_box(context),
+                    )
+                    .unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_verification_context(c: &mut Criterion) {
+    let mut group = c.benchmark_group("verification_context");
+    SamplingProfile::Milliseconds.apply(&mut group);
+
+    for &(name, k, n, row_size) in CONTEXT_CONFIGS {
+        let params = Parameters::new(k, n, row_size).unwrap();
+        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+        let commitment = ExtendedData::generate(&data, &params).unwrap();
+        let rlcs = commitment.rlc_original().to_vec();
+
+        group.bench_with_input(BenchmarkId::from_parameter(name), &rlcs, |b, rlcs| {
+            b.iter(|| VerificationContext::new(black_box(rlcs), black_box(&params)).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn bench_reconstruct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reconstruct");
+
+    for &(name, k, n, row_size) in COMMON_CONFIGS {
+        let params = Parameters::new(k, n, row_size).unwrap();
+        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+        let extended = ExtendedData::generate(&data, &params).unwrap();
+
+        // Use parity rows only (indices k..2k) so reconstruction performs an
+        // actual Reed-Solomon decode instead of copying originals through.
+        let indices: Vec<usize> = (k..2 * k).collect();
+        let rows: Vec<&[u8]> = indices.iter().map(|&i| extended.row(i).unwrap()).collect();
+        let total_bytes = k * row_size;
+
+        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+            b.iter(|| {
+                reconstruct(black_box(&rows), black_box(&indices), black_box(&params)).unwrap()
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.03);
+    targets =
+        bench_encode,
+        bench_encode_in_place,
+        bench_proof_generation,
+        bench_verification,
+        bench_verification_context,
+        bench_reconstruct
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(benches);
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
@@ -298,7 +258,6 @@ mod wasm {
 
     use super::*;
 
-    /// Looks up `(k, n, row_size)` by name in one of the config tables.
     fn config(table: &[Config], name: &str) -> (usize, usize, usize) {
         table
             .iter()
@@ -307,16 +266,6 @@ mod wasm {
             .unwrap_or_else(|| panic!("unknown bench config {name}"))
     }
 
-    /// The bundled criterion's builder methods take `self` by value while the
-    /// bench macro hands out `&mut Criterion`; reconfigure in place.
-    fn configure(c: &mut Criterion, f: impl FnOnce(Criterion) -> Criterion) {
-        let configured = f(std::mem::take(c));
-        *c = configured;
-    }
-
-    /// Sampling profile by input size. Windows are shorter than the native
-    /// ones because wasm has neither threads nor a SIMD Reed-Solomon engine,
-    /// and the noise threshold is wider to absorb JIT and GC jitter.
     #[derive(Clone, Copy)]
     enum WasmProfile {
         Small,
@@ -342,12 +291,11 @@ mod wasm {
                 WasmProfile::Medium => (10, 2, 15),
                 WasmProfile::Heavy => (10, 3, 20),
             };
-            configure(c, |c| {
-                c.sample_size(sample_size)
-                    .warm_up_time(Duration::from_secs(warm_up_secs))
-                    .measurement_time(Duration::from_secs(measurement_secs))
-                    .noise_threshold(0.05)
-            });
+            *c = std::mem::take(c)
+                .sample_size(sample_size)
+                .warm_up_time(Duration::from_secs(warm_up_secs))
+                .measurement_time(Duration::from_secs(measurement_secs))
+                .noise_threshold(0.05);
         }
     }
 
@@ -448,8 +396,6 @@ mod wasm {
         });
     }
 
-    /// Declares one `#[wasm_bindgen_bench]` function per case so each can be
-    /// selected by name from the runner's filter.
     macro_rules! cases {
         ($case:ident: $( $( #[$attr:ident] )* $id:ident = $name:literal ),* $(,)?) => {
             $(
@@ -505,7 +451,5 @@ mod wasm {
     );
 }
 
-/// The wasm bench functions are discovered by `wasm-bindgen-test-runner`
-/// through their exports; the binary entry point is unused.
 #[cfg(target_arch = "wasm32")]
 fn main() {}

--- a/rsema1d/benches/codec_bench.rs
+++ b/rsema1d/benches/codec_bench.rs
@@ -1,9 +1,50 @@
-use std::time::Duration;
+//! Benchmarks for the rsema1d codec: row extension (`encode`, `encode_in_place`),
+//! row proof generation, proof verification, verification context construction,
+//! and reconstruction from parity rows.
+//!
+//! ## Native (criterion)
+//!
+//! ```sh
+//! cargo bench -p rsema1d --bench codec_bench
+//! cargo bench -p rsema1d --bench codec_bench -- --save-baseline main
+//! # ...apply the change...
+//! cargo bench -p rsema1d --bench codec_bench -- --baseline main
+//! ```
+//!
+//! A fast sanity pass (each case runs once) is `-- --test`.
+//! `./scripts/run_benchmarks.sh` runs these together with the Go runner.
+//!
+//! ## wasm32-unknown-unknown
+//!
+//! The same code paths can be benchmarked as wasm, executed by Node through
+//! `wasm-bindgen-test-runner`, which `.cargo/config.toml` configures as the
+//! cargo runner for the target. Install `wasm-bindgen-cli` at exactly the
+//! `wasm-bindgen` version pinned in `Cargo.lock` (the nix devshell provides it):
+//!
+//! ```sh
+//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench
+//! # list cases, run a subset by name, run the ignored (128 MiB) cases
+//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- --list
+//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- encode_8mb
+//! cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- --ignored
+//! ```
+//!
+//! Always pass `--bench codec_bench`; without it cargo also hands the library
+//! to the runner. The wasm harness is the trimmed criterion port bundled with
+//! `wasm-bindgen-test`: there are no benchmark groups, throughput lines,
+//! `--save-baseline` or `--test`. Every (group, size) pair is therefore its
+//! own bench function so it can be selected by name (`--exact` and `--skip`
+//! also work). The 128 MiB cases are `#[ignore]`d: wasm runs single-threaded
+//! and the Reed-Solomon engine has no wasm SIMD backend, so each takes minutes.
+//!
+//! The runner stores the previous run in `target/wbg_benchmark.json` (relative
+//! to the current directory) and prints a change verdict against it on the
+//! next run. Set `WASM_BINDGEN_BENCH_RESULT=<path>` to use a dedicated file,
+//! e.g. run once on the baseline revision and once on the change with the same
+//! path. To run in a browser instead of Node, add
+//! `wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);` to the
+//! `wasm` module below and have `chromedriver` on `PATH`.
 
-use criterion::{
-    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
-    Criterion, SamplingMode, Throughput,
-};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rsema1d::{
@@ -12,50 +53,10 @@ use rsema1d::{
 
 const DATA_SEED: u64 = 0x5eed_5eed_5eed_5eed;
 
-fn generate_test_data(k: usize, row_size: usize) -> Vec<u8> {
-    let mut rng = ChaCha8Rng::seed_from_u64(DATA_SEED);
-    let mut data = vec![0u8; k * row_size];
-    rng.fill_bytes(&mut data);
-    data
-}
+/// `(name, k, n, row_size)`.
+type Config = (&'static str, usize, usize, usize);
 
-#[derive(Clone, Copy)]
-enum SamplingProfile {
-    SubMillisecond,
-    Milliseconds,
-    Subsecond,
-    Seconds,
-}
-
-impl SamplingProfile {
-    fn for_bytes(bytes: usize) -> Self {
-        const MIB: usize = 1024 * 1024;
-        if bytes >= 64 * MIB {
-            SamplingProfile::Seconds
-        } else if bytes >= 4 * MIB {
-            SamplingProfile::Subsecond
-        } else {
-            SamplingProfile::Milliseconds
-        }
-    }
-
-    fn apply(self, group: &mut BenchmarkGroup<'_, WallTime>) {
-        let (sampling_mode, sample_size, warm_up_secs, measurement_secs) = match self {
-            SamplingProfile::SubMillisecond => (SamplingMode::Linear, 100, 3, 10),
-            SamplingProfile::Milliseconds => (SamplingMode::Linear, 100, 3, 45),
-            SamplingProfile::Subsecond => (SamplingMode::Flat, 60, 3, 45),
-            SamplingProfile::Seconds => (SamplingMode::Flat, 30, 5, 75),
-        };
-
-        group
-            .sampling_mode(sampling_mode)
-            .sample_size(sample_size)
-            .warm_up_time(Duration::from_secs(warm_up_secs))
-            .measurement_time(Duration::from_secs(measurement_secs));
-    }
-}
-
-const ENCODE_CONFIGS: &[(&str, usize, usize, usize)] = &[
+const ENCODE_CONFIGS: &[Config] = &[
     ("128KB_k1024_n3072", 1024, 3072, 128),
     ("1MB_k1024_n3072", 1024, 3072, 1024),
     ("1MB_k4096_n12288", 4096, 12288, 256),
@@ -64,83 +65,337 @@ const ENCODE_CONFIGS: &[(&str, usize, usize, usize)] = &[
     ("128MB_k8192_n24576", 8192, 24576, 16384),
 ];
 
-const COMMON_CONFIGS: &[(&str, usize, usize, usize)] = &[
+const COMMON_CONFIGS: &[Config] = &[
     ("1MB_k1024_n3072", 1024, 3072, 1024),
     ("8MB_k4096_n12288", 4096, 12288, 2048),
     ("128MB_k4096_n12288", 4096, 12288, 32768),
 ];
 
-fn bench_encode(c: &mut Criterion) {
-    let mut group = c.benchmark_group("encode");
+/// Context construction depends on k and n, not row_size.
+const CONTEXT_CONFIGS: &[Config] = &[
+    ("k1024_n3072", 1024, 3072, 1024),
+    ("k4096_n12288", 4096, 12288, 256),
+    ("k8192_n24576", 8192, 24576, 128),
+];
 
-    for &(name, k, n, row_size) in ENCODE_CONFIGS {
+fn generate_test_data(k: usize, row_size: usize) -> Vec<u8> {
+    let mut rng = ChaCha8Rng::seed_from_u64(DATA_SEED);
+    let mut data = vec![0u8; k * row_size];
+    rng.fill_bytes(&mut data);
+    data
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::time::Duration;
+
+    use criterion::{
+        black_box, criterion_group, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
+        SamplingMode, Throughput,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum SamplingProfile {
+        SubMillisecond,
+        Milliseconds,
+        Subsecond,
+        Seconds,
+    }
+
+    impl SamplingProfile {
+        fn for_bytes(bytes: usize) -> Self {
+            const MIB: usize = 1024 * 1024;
+            if bytes >= 64 * MIB {
+                SamplingProfile::Seconds
+            } else if bytes >= 4 * MIB {
+                SamplingProfile::Subsecond
+            } else {
+                SamplingProfile::Milliseconds
+            }
+        }
+
+        fn apply(self, group: &mut BenchmarkGroup<'_, WallTime>) {
+            let (sampling_mode, sample_size, warm_up_secs, measurement_secs) = match self {
+                SamplingProfile::SubMillisecond => (SamplingMode::Linear, 100, 3, 10),
+                SamplingProfile::Milliseconds => (SamplingMode::Linear, 100, 3, 45),
+                SamplingProfile::Subsecond => (SamplingMode::Flat, 60, 3, 45),
+                SamplingProfile::Seconds => (SamplingMode::Flat, 30, 5, 75),
+            };
+
+            group
+                .sampling_mode(sampling_mode)
+                .sample_size(sample_size)
+                .warm_up_time(Duration::from_secs(warm_up_secs))
+                .measurement_time(Duration::from_secs(measurement_secs));
+        }
+    }
+
+    fn bench_encode(c: &mut Criterion) {
+        let mut group = c.benchmark_group("encode");
+
+        for &(name, k, n, row_size) in ENCODE_CONFIGS {
+            let params = Parameters::new(k, n, row_size).unwrap();
+            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+            let total_bytes = k * row_size;
+
+            SamplingProfile::for_bytes(total_bytes).apply(&mut group);
+            group.throughput(Throughput::Bytes(total_bytes as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
+                b.iter(|| encode(black_box(data), black_box(&params)).unwrap());
+            });
+        }
+
+        group.finish();
+    }
+
+    fn bench_encode_in_place(c: &mut Criterion) {
+        let mut group = c.benchmark_group("encode_in_place");
+
+        for &(name, k, n, row_size) in ENCODE_CONFIGS {
+            let params = Parameters::new(k, n, row_size).unwrap();
+            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+            let total_bytes = k * row_size;
+            let mut prefilled = vec![0u8; (k + n) * row_size];
+            prefilled[..k * row_size].copy_from_slice(data.as_row_major());
+            let mut extended = Some(RowMatrix::with_shape(prefilled, k + n, row_size).unwrap());
+
+            SamplingProfile::for_bytes(total_bytes).apply(&mut group);
+            group.throughput(Throughput::Bytes(total_bytes as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(name), &params, |b, params| {
+                b.iter(|| {
+                    let buffer = extended.take().expect("buffer must be available");
+                    let (ext_data, _commitment, _rlc_orig) =
+                        encode_in_place(black_box(buffer), black_box(params)).unwrap();
+                    let rsema1d::ExtendedData { all_rows, .. } = ext_data;
+                    extended = Some(all_rows);
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    fn bench_proof_generation(c: &mut Criterion) {
+        let mut group = c.benchmark_group("proof_generation");
+        SamplingProfile::SubMillisecond.apply(&mut group);
+
+        for &(name, k, n, row_size) in COMMON_CONFIGS {
+            let params = Parameters::new(k, n, row_size).unwrap();
+            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+            let commitment = ExtendedData::generate(&data, &params).unwrap();
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter(name),
+                &commitment,
+                |b, commitment| {
+                    b.iter(|| commitment.generate_row_proof(black_box(0)).unwrap());
+                },
+            );
+        }
+
+        group.finish();
+    }
+
+    fn bench_verification(c: &mut Criterion) {
+        let mut group = c.benchmark_group("verification");
+        SamplingProfile::SubMillisecond.apply(&mut group);
+
+        for &(name, k, n, row_size) in COMMON_CONFIGS {
+            let params = Parameters::new(k, n, row_size).unwrap();
+            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+            let commitment = ExtendedData::generate(&data, &params).unwrap();
+            let proof = commitment.generate_row_proof(0).unwrap();
+            let context = VerificationContext::new(commitment.rlc_original(), &params).unwrap();
+            let commitment_bytes = commitment.commitment();
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter(name),
+                &(&proof, &commitment_bytes, &context),
+                |b, (proof, commitment_bytes, context)| {
+                    b.iter(|| {
+                        rsema1d::codec::verify_proof(
+                            black_box(proof),
+                            black_box(commitment_bytes),
+                            black_box(context),
+                        )
+                        .unwrap()
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+
+    fn bench_verification_context(c: &mut Criterion) {
+        let mut group = c.benchmark_group("verification_context");
+        SamplingProfile::Milliseconds.apply(&mut group);
+
+        for &(name, k, n, row_size) in CONTEXT_CONFIGS {
+            let params = Parameters::new(k, n, row_size).unwrap();
+            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+            let commitment = ExtendedData::generate(&data, &params).unwrap();
+            let rlcs = commitment.rlc_original().to_vec();
+
+            group.bench_with_input(BenchmarkId::from_parameter(name), &rlcs, |b, rlcs| {
+                b.iter(|| VerificationContext::new(black_box(rlcs), black_box(&params)).unwrap());
+            });
+        }
+
+        group.finish();
+    }
+
+    fn bench_reconstruct(c: &mut Criterion) {
+        let mut group = c.benchmark_group("reconstruct");
+
+        for &(name, k, n, row_size) in COMMON_CONFIGS {
+            let params = Parameters::new(k, n, row_size).unwrap();
+            let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
+            let extended = ExtendedData::generate(&data, &params).unwrap();
+
+            // Use parity rows only (indices k..2k) so reconstruction performs an
+            // actual Reed-Solomon decode instead of copying originals through.
+            let indices: Vec<usize> = (k..2 * k).collect();
+            let rows: Vec<&[u8]> = indices.iter().map(|&i| extended.row(i).unwrap()).collect();
+            let total_bytes = k * row_size;
+
+            SamplingProfile::for_bytes(total_bytes).apply(&mut group);
+            group.throughput(Throughput::Bytes(total_bytes as u64));
+            group.bench_function(BenchmarkId::from_parameter(name), |b| {
+                b.iter(|| {
+                    reconstruct(black_box(&rows), black_box(&indices), black_box(&params)).unwrap()
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    criterion_group! {
+        name = benches;
+        config = Criterion::default().noise_threshold(0.03);
+        targets =
+            bench_encode,
+            bench_encode_in_place,
+            bench_proof_generation,
+            bench_verification,
+            bench_verification_context,
+            bench_reconstruct
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(native::benches);
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use std::hint::black_box;
+    use std::time::Duration;
+
+    use wasm_bindgen_test::{wasm_bindgen_bench, Criterion};
+
+    use super::*;
+
+    /// Looks up `(k, n, row_size)` by name in one of the config tables.
+    fn config(table: &[Config], name: &str) -> (usize, usize, usize) {
+        table
+            .iter()
+            .find(|cfg| cfg.0 == name)
+            .map(|&(_, k, n, row_size)| (k, n, row_size))
+            .unwrap_or_else(|| panic!("unknown bench config {name}"))
+    }
+
+    /// The bundled criterion's builder methods take `self` by value while the
+    /// bench macro hands out `&mut Criterion`; reconfigure in place.
+    fn configure(c: &mut Criterion, f: impl FnOnce(Criterion) -> Criterion) {
+        let configured = f(std::mem::take(c));
+        *c = configured;
+    }
+
+    /// Sampling profile by input size. Windows are shorter than the native
+    /// ones because wasm has neither threads nor a SIMD Reed-Solomon engine,
+    /// and the noise threshold is wider to absorb JIT and GC jitter.
+    #[derive(Clone, Copy)]
+    enum WasmProfile {
+        Small,
+        Medium,
+        Heavy,
+    }
+
+    impl WasmProfile {
+        fn for_bytes(bytes: usize) -> Self {
+            const MIB: usize = 1024 * 1024;
+            if bytes >= 32 * MIB {
+                WasmProfile::Heavy
+            } else if bytes >= MIB {
+                WasmProfile::Medium
+            } else {
+                WasmProfile::Small
+            }
+        }
+
+        fn apply(self, c: &mut Criterion) {
+            let (sample_size, warm_up_secs, measurement_secs) = match self {
+                WasmProfile::Small => (50, 1, 5),
+                WasmProfile::Medium => (10, 2, 15),
+                WasmProfile::Heavy => (10, 3, 20),
+            };
+            configure(c, |c| {
+                c.sample_size(sample_size)
+                    .warm_up_time(Duration::from_secs(warm_up_secs))
+                    .measurement_time(Duration::from_secs(measurement_secs))
+                    .noise_threshold(0.05)
+            });
+        }
+    }
+
+    fn encode_case(c: &mut Criterion, name: &str) {
+        let (k, n, row_size) = config(ENCODE_CONFIGS, name);
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-        let total_bytes = k * row_size;
 
-        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
-        group.throughput(Throughput::Bytes(total_bytes as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(name), &data, |b, data| {
-            b.iter(|| encode(black_box(data), black_box(&params)).unwrap());
+        WasmProfile::for_bytes(k * row_size).apply(c);
+        c.bench_function(&format!("encode/{name}"), |b| {
+            b.iter(|| encode(black_box(&data), black_box(&params)).unwrap());
         });
     }
 
-    group.finish();
-}
-
-fn bench_encode_in_place(c: &mut Criterion) {
-    let mut group = c.benchmark_group("encode_in_place");
-
-    for &(name, k, n, row_size) in ENCODE_CONFIGS {
+    fn encode_in_place_case(c: &mut Criterion, name: &str) {
+        let (k, n, row_size) = config(ENCODE_CONFIGS, name);
         let params = Parameters::new(k, n, row_size).unwrap();
-        let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
-        let total_bytes = k * row_size;
+        let data = generate_test_data(k, row_size);
         let mut prefilled = vec![0u8; (k + n) * row_size];
-        prefilled[..k * row_size].copy_from_slice(data.as_row_major());
+        prefilled[..k * row_size].copy_from_slice(&data);
         let mut extended = Some(RowMatrix::with_shape(prefilled, k + n, row_size).unwrap());
 
-        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
-        group.throughput(Throughput::Bytes(total_bytes as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(name), &params, |b, params| {
+        WasmProfile::for_bytes(k * row_size).apply(c);
+        c.bench_function(&format!("encode_in_place/{name}"), |b| {
             b.iter(|| {
                 let buffer = extended.take().expect("buffer must be available");
                 let (ext_data, _commitment, _rlc_orig) =
-                    encode_in_place(black_box(buffer), black_box(params)).unwrap();
-                let rsema1d::ExtendedData { all_rows, .. } = ext_data;
+                    encode_in_place(black_box(buffer), black_box(&params)).unwrap();
+                let ExtendedData { all_rows, .. } = ext_data;
                 extended = Some(all_rows);
             });
         });
     }
 
-    group.finish();
-}
-
-fn bench_proof_generation(c: &mut Criterion) {
-    let mut group = c.benchmark_group("proof_generation");
-    SamplingProfile::SubMillisecond.apply(&mut group);
-
-    for &(name, k, n, row_size) in COMMON_CONFIGS {
+    fn proof_generation_case(c: &mut Criterion, name: &str) {
+        let (k, n, row_size) = config(COMMON_CONFIGS, name);
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
 
-        group.bench_with_input(
-            BenchmarkId::from_parameter(name),
-            &commitment,
-            |b, commitment| {
-                b.iter(|| commitment.generate_row_proof(black_box(0)).unwrap());
-            },
-        );
+        WasmProfile::Small.apply(c);
+        c.bench_function(&format!("proof_generation/{name}"), |b| {
+            b.iter(|| commitment.generate_row_proof(black_box(0)).unwrap());
+        });
     }
 
-    group.finish();
-}
-
-fn bench_verification(c: &mut Criterion) {
-    let mut group = c.benchmark_group("verification");
-    SamplingProfile::SubMillisecond.apply(&mut group);
-
-    for &(name, k, n, row_size) in COMMON_CONFIGS {
+    fn verification_case(c: &mut Criterion, name: &str) {
+        let (k, n, row_size) = config(COMMON_CONFIGS, name);
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
@@ -148,54 +403,34 @@ fn bench_verification(c: &mut Criterion) {
         let context = VerificationContext::new(commitment.rlc_original(), &params).unwrap();
         let commitment_bytes = commitment.commitment();
 
-        group.bench_with_input(
-            BenchmarkId::from_parameter(name),
-            &(&proof, &commitment_bytes, &context),
-            |b, (proof, commitment_bytes, context)| {
-                b.iter(|| {
-                    rsema1d::codec::verify_proof(
-                        black_box(proof),
-                        black_box(commitment_bytes),
-                        black_box(context),
-                    )
-                    .unwrap()
-                });
-            },
-        );
+        WasmProfile::Small.apply(c);
+        c.bench_function(&format!("verification/{name}"), |b| {
+            b.iter(|| {
+                rsema1d::codec::verify_proof(
+                    black_box(&proof),
+                    black_box(&commitment_bytes),
+                    black_box(&context),
+                )
+                .unwrap()
+            });
+        });
     }
 
-    group.finish();
-}
-
-fn bench_verification_context(c: &mut Criterion) {
-    let mut group = c.benchmark_group("verification_context");
-    SamplingProfile::Milliseconds.apply(&mut group);
-
-    // Context construction depends on k and n, not row_size.
-    let configs = [
-        ("k1024_n3072", 1024, 3072, 1024),
-        ("k4096_n12288", 4096, 12288, 256),
-        ("k8192_n24576", 8192, 24576, 128),
-    ];
-
-    for (name, k, n, row_size) in configs {
+    fn verification_context_case(c: &mut Criterion, name: &str) {
+        let (k, n, row_size) = config(CONTEXT_CONFIGS, name);
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let commitment = ExtendedData::generate(&data, &params).unwrap();
         let rlcs = commitment.rlc_original().to_vec();
 
-        group.bench_with_input(BenchmarkId::from_parameter(name), &rlcs, |b, rlcs| {
-            b.iter(|| VerificationContext::new(black_box(rlcs), black_box(&params)).unwrap());
+        WasmProfile::Small.apply(c);
+        c.bench_function(&format!("verification_context/{name}"), |b| {
+            b.iter(|| VerificationContext::new(black_box(&rlcs), black_box(&params)).unwrap());
         });
     }
 
-    group.finish();
-}
-
-fn bench_reconstruct(c: &mut Criterion) {
-    let mut group = c.benchmark_group("reconstruct");
-
-    for &(name, k, n, row_size) in COMMON_CONFIGS {
+    fn reconstruct_case(c: &mut Criterion, name: &str) {
+        let (k, n, row_size) = config(COMMON_CONFIGS, name);
         let params = Parameters::new(k, n, row_size).unwrap();
         let data = RowMatrix::with_shape(generate_test_data(k, row_size), k, row_size).unwrap();
         let extended = ExtendedData::generate(&data, &params).unwrap();
@@ -204,29 +439,73 @@ fn bench_reconstruct(c: &mut Criterion) {
         // actual Reed-Solomon decode instead of copying originals through.
         let indices: Vec<usize> = (k..2 * k).collect();
         let rows: Vec<&[u8]> = indices.iter().map(|&i| extended.row(i).unwrap()).collect();
-        let total_bytes = k * row_size;
 
-        SamplingProfile::for_bytes(total_bytes).apply(&mut group);
-        group.throughput(Throughput::Bytes(total_bytes as u64));
-        group.bench_function(BenchmarkId::from_parameter(name), |b| {
+        WasmProfile::for_bytes(k * row_size).apply(c);
+        c.bench_function(&format!("reconstruct/{name}"), |b| {
             b.iter(|| {
                 reconstruct(black_box(&rows), black_box(&indices), black_box(&params)).unwrap()
             });
         });
     }
 
-    group.finish();
+    /// Declares one `#[wasm_bindgen_bench]` function per case so each can be
+    /// selected by name from the runner's filter.
+    macro_rules! cases {
+        ($case:ident: $( $( #[$attr:ident] )* $id:ident = $name:literal ),* $(,)?) => {
+            $(
+                #[wasm_bindgen_bench]
+                $( #[$attr] )*
+                fn $id(c: &mut Criterion) {
+                    $case(c, $name);
+                }
+            )*
+        };
+    }
+
+    cases!(encode_case:
+        encode_128kb_k1024_n3072 = "128KB_k1024_n3072",
+        encode_1mb_k1024_n3072 = "1MB_k1024_n3072",
+        encode_1mb_k4096_n12288 = "1MB_k4096_n12288",
+        encode_8mb_k4096_n12288 = "8MB_k4096_n12288",
+        #[ignore] encode_128mb_k4096_n12288 = "128MB_k4096_n12288",
+        #[ignore] encode_128mb_k8192_n24576 = "128MB_k8192_n24576",
+    );
+
+    cases!(encode_in_place_case:
+        encode_in_place_128kb_k1024_n3072 = "128KB_k1024_n3072",
+        encode_in_place_1mb_k1024_n3072 = "1MB_k1024_n3072",
+        encode_in_place_1mb_k4096_n12288 = "1MB_k4096_n12288",
+        encode_in_place_8mb_k4096_n12288 = "8MB_k4096_n12288",
+        #[ignore] encode_in_place_128mb_k4096_n12288 = "128MB_k4096_n12288",
+        #[ignore] encode_in_place_128mb_k8192_n24576 = "128MB_k8192_n24576",
+    );
+
+    cases!(proof_generation_case:
+        proof_generation_1mb_k1024_n3072 = "1MB_k1024_n3072",
+        proof_generation_8mb_k4096_n12288 = "8MB_k4096_n12288",
+        #[ignore] proof_generation_128mb_k4096_n12288 = "128MB_k4096_n12288",
+    );
+
+    cases!(verification_case:
+        verification_1mb_k1024_n3072 = "1MB_k1024_n3072",
+        verification_8mb_k4096_n12288 = "8MB_k4096_n12288",
+        #[ignore] verification_128mb_k4096_n12288 = "128MB_k4096_n12288",
+    );
+
+    cases!(verification_context_case:
+        verification_context_k1024_n3072 = "k1024_n3072",
+        verification_context_k4096_n12288 = "k4096_n12288",
+        verification_context_k8192_n24576 = "k8192_n24576",
+    );
+
+    cases!(reconstruct_case:
+        reconstruct_1mb_k1024_n3072 = "1MB_k1024_n3072",
+        reconstruct_8mb_k4096_n12288 = "8MB_k4096_n12288",
+        #[ignore] reconstruct_128mb_k4096_n12288 = "128MB_k4096_n12288",
+    );
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().noise_threshold(0.03);
-    targets =
-        bench_encode,
-        bench_encode_in_place,
-        bench_proof_generation,
-        bench_verification,
-        bench_verification_context,
-        bench_reconstruct
-}
-criterion_main!(benches);
+/// The wasm bench functions are discovered by `wasm-bindgen-test-runner`
+/// through their exports; the binary entry point is unused.
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/rsema1d/scripts/run_benchmarks.sh
+++ b/rsema1d/scripts/run_benchmarks.sh
@@ -23,7 +23,7 @@ Environment variables:
                    needs wasm-bindgen-test-runner (wasm-bindgen-cli at the
                    wasm-bindgen version in Cargo.lock) and node on PATH
   WASM_BENCH_ARGS  extra runner arguments for the wasm bench, e.g. a name
-                   filter or "--ignored" for the 128 MiB cases (default: none)
+                   filter or "--include-ignored 128mb" (default: none)
   CARGO_TARGET_DIR Cargo target directory (default: monorepo ../target)
   GO_CACHE_DIR     Go build cache directory (default: /tmp/rsema1d-go-build-cache)
 EOF

--- a/rsema1d/scripts/run_benchmarks.sh
+++ b/rsema1d/scripts/run_benchmarks.sh
@@ -8,16 +8,22 @@ GO_DIR="${REPO_ROOT}/go"
 
 print_help() {
   cat <<'EOF'
-Run rsema1d benchmarks (Rust and/or Go).
+Run rsema1d benchmarks (Rust native, Rust wasm32, and/or Go).
 
 Usage:
   ./scripts/run_benchmarks.sh
   RUN_RUST_BENCH=0 ./scripts/run_benchmarks.sh   # Go only
   RUN_GO_BENCH=0 ./scripts/run_benchmarks.sh     # Rust only
+  RUN_RUST_BENCH=0 RUN_GO_BENCH=0 RUN_WASM_BENCH=1 ./scripts/run_benchmarks.sh   # wasm only
 
 Environment variables:
   RUN_RUST_BENCH   1 to run Rust Criterion bench, 0 to skip (default: 1)
   RUN_GO_BENCH     1 to run Go bench runner, 0 to skip (default: 1)
+  RUN_WASM_BENCH   1 to run the Rust bench as wasm32 in Node, 0 to skip (default: 0);
+                   needs wasm-bindgen-test-runner (wasm-bindgen-cli at the
+                   wasm-bindgen version in Cargo.lock) and node on PATH
+  WASM_BENCH_ARGS  extra runner arguments for the wasm bench, e.g. a name
+                   filter or "--ignored" for the 128 MiB cases (default: none)
   CARGO_TARGET_DIR Cargo target directory (default: monorepo ../target)
   GO_CACHE_DIR     Go build cache directory (default: /tmp/rsema1d-go-build-cache)
 EOF
@@ -39,6 +45,8 @@ esac
 
 RUN_RUST_BENCH="${RUN_RUST_BENCH:-1}"
 RUN_GO_BENCH="${RUN_GO_BENCH:-1}"
+RUN_WASM_BENCH="${RUN_WASM_BENCH:-0}"
+WASM_BENCH_ARGS="${WASM_BENCH_ARGS:-}"
 GO_CACHE_DIR="${GO_CACHE_DIR:-/tmp/rsema1d-go-build-cache}"
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${WORKSPACE_ROOT}/target}"
 
@@ -56,6 +64,7 @@ validate_binary_flag() {
 
 validate_binary_flag "RUN_RUST_BENCH" "${RUN_RUST_BENCH}"
 validate_binary_flag "RUN_GO_BENCH" "${RUN_GO_BENCH}"
+validate_binary_flag "RUN_WASM_BENCH" "${RUN_WASM_BENCH}"
 
 mkdir -p "${GO_CACHE_DIR}"
 mkdir -p "${CARGO_TARGET_DIR}" 2>/dev/null || true
@@ -63,14 +72,24 @@ mkdir -p "${CARGO_TARGET_DIR}" 2>/dev/null || true
 echo "Benchmark configuration:"
 echo "  RUN_RUST_BENCH=${RUN_RUST_BENCH} (set RUN_GO_BENCH=0 for Rust-only)"
 echo "  RUN_GO_BENCH=${RUN_GO_BENCH} (set RUN_RUST_BENCH=0 for Go-only)"
+echo "  RUN_WASM_BENCH=${RUN_WASM_BENCH} (wasm32 in Node; WASM_BENCH_ARGS='${WASM_BENCH_ARGS}')"
 echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
 echo "  GO_CACHE_DIR=${GO_CACHE_DIR}"
 
-if [ "${RUN_RUST_BENCH}" = "1" ]; then
+if [ "${RUN_RUST_BENCH}" = "1" ] || [ "${RUN_WASM_BENCH}" = "1" ]; then
   if ! command -v cargo >/dev/null 2>&1; then
     echo "error: cargo is not installed or not on PATH" >&2
     exit 1
   fi
+fi
+
+if [ "${RUN_WASM_BENCH}" = "1" ]; then
+  for tool in wasm-bindgen-test-runner node; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      echo "error: ${tool} is not installed or not on PATH (required for RUN_WASM_BENCH=1)" >&2
+      exit 1
+    fi
+  done
 fi
 
 if [ "${RUN_GO_BENCH}" = "1" ]; then
@@ -80,8 +99,8 @@ if [ "${RUN_GO_BENCH}" = "1" ]; then
   fi
 fi
 
-if [ "${RUN_RUST_BENCH}" != "1" ] && [ "${RUN_GO_BENCH}" != "1" ]; then
-  echo "error: nothing to run (set RUN_RUST_BENCH=1 and/or RUN_GO_BENCH=1)" >&2
+if [ "${RUN_RUST_BENCH}" != "1" ] && [ "${RUN_GO_BENCH}" != "1" ] && [ "${RUN_WASM_BENCH}" != "1" ]; then
+  echo "error: nothing to run (set RUN_RUST_BENCH=1, RUN_GO_BENCH=1 and/or RUN_WASM_BENCH=1)" >&2
   exit 1
 fi
 
@@ -95,6 +114,23 @@ if [ "${RUN_RUST_BENCH}" = "1" ]; then
   step=$((step + 1))
 else
   echo "[${step}] Skipping Rust benchmarks (RUN_RUST_BENCH=0)."
+  step=$((step + 1))
+fi
+
+if [ "${RUN_WASM_BENCH}" = "1" ]; then
+  echo "[${step}] Running Rust benchmarks as wasm32 in Node..."
+  (
+    cd "${REPO_ROOT}"
+    # The runner's default baseline path is relative to the current directory;
+    # keep it next to the other build products instead.
+    # shellcheck disable=SC2086
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}" \
+      WASM_BINDGEN_BENCH_RESULT="${CARGO_TARGET_DIR}/wbg_benchmark_rsema1d.json" \
+      cargo bench --target wasm32-unknown-unknown --bench codec_bench -- ${WASM_BENCH_ARGS}
+  )
+  step=$((step + 1))
+else
+  echo "[${step}] Skipping wasm32 benchmarks (RUN_WASM_BENCH=0)."
   step=$((step + 1))
 fi
 


### PR DESCRIPTION
## Summary

Adds benchmarks for the `wasm32-unknown-unknown` target to `rsema1d` and `celestia-fibre`. Until now both bench targets only built natively (`criterion` is a non-wasm dev-dependency), which is also why CI clippy runs them with `--lib` on wasm.

The wasm benches use the trimmed criterion port bundled with `wasm-bindgen-test` (bench support since wasm-bindgen 0.2.106; the workspace locks 0.2.108). They run in Node through `wasm-bindgen-test-runner`, print criterion-style output, and compare against a JSON baseline from the previous run. No wasi target or wasmtime is involved.

## Changes

- `.cargo/config.toml`: `wasm-bindgen-test-runner` is the cargo runner for wasm32. `wasm-pack` sets its own runner via env, so the existing `test-wasm` job is unaffected.
- `rsema1d/benches/codec_bench.rs`, `fibre/benches/fibre_bench.rs`: split into shared setup, a `native` module with the existing criterion code (unchanged), and a `wasm` module with one `#[wasm_bindgen_bench]` function per (group, size) so cases can be selected by name. The bundled criterion has no groups, throughput reporting, `iter_batched`, `--save-baseline` or `--test`, so the wasm side is written against `bench_function` + `iter`/`iter_custom`.
- The 32 MiB and 128 MiB cases are `#[ignore]`d on wasm: it runs single-threaded and `reed-solomon-simd` has no wasm SIMD engine, so each takes minutes. A full default run is ~2.5 min per crate.
- fibre's payment promise setup reads the clock through `web-time`, since `std::time::SystemTime::now()` panics on wasm32-unknown-unknown.
- `rsema1d/Cargo.toml`: the previously unused wasm32 dev-deps (`wasm-bindgen-test`, `getrandom/js`) are now used. `fibre/Cargo.toml` gains `wasm-bindgen-test` and `web-time` under wasm32 dev-deps.
- `rsema1d/scripts/run_benchmarks.sh`: `RUN_WASM_BENCH=1` and `WASM_BENCH_ARGS` toggles; README updated.

CI is intentionally untouched. Once this lands, the `--lib` special case for `rsema1d` in the clippy job could be collapsed to `--all-targets`; for `celestia-fibre` it cannot yet, because the crate's own test harness (`src/test_utils.rs`) does not compile for wasm32 independently of this PR.

## How to run

Prerequisites: `wasm-bindgen-cli` at exactly the `wasm-bindgen` version in `Cargo.lock` (0.2.108) and Node on `PATH`. The nix devshell provides both; otherwise:

```sh
cargo install wasm-bindgen-cli --version 0.2.108 --locked
```

Run a crate's bench (always pass `--bench`, otherwise cargo also hands the library to the runner):

```sh
cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench
cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench
```

Select cases, all after `--`:

```sh
# list cases
cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- --list
# substring filter
cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- encode_8mb
# exactly one case
cargo bench --target wasm32-unknown-unknown -p celestia-fibre --bench fibre_bench -- --exact wasm::payment_promise_sign
# the heavy (32 MiB / 128 MiB) cases, ignored by default
cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench -- --ignored
```

Via the rsema1d script:

```sh
RUN_RUST_BENCH=0 RUN_GO_BENCH=0 RUN_WASM_BENCH=1 ./rsema1d/scripts/run_benchmarks.sh
WASM_BENCH_ARGS="--ignored" RUN_RUST_BENCH=0 RUN_GO_BENCH=0 RUN_WASM_BENCH=1 ./rsema1d/scripts/run_benchmarks.sh
```

Compare two revisions: the runner stores the last run in `target/wbg_benchmark.json` (relative to the current directory) and prints a change verdict on the next run. Point both runs at one file, and use a separate file per crate:

```sh
export WASM_BINDGEN_BENCH_RESULT=$PWD/target/wasm-bench/rsema1d.json
git switch main      && cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench
git switch my-branch && cargo bench --target wasm32-unknown-unknown -p rsema1d --bench codec_bench
```

Example output:

```
verification_context/k1024_n3072
                        time:   [3.3095 ms 3.3136 ms 3.3177 ms]
                        change: [−0.0754% +0.1388% +0.3864%] (p = 0.26 > 0.05)
                        No change in performance detected.
```

To run in a browser instead of Node, add `wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);` inside the `wasm` module of the bench file and have `chromedriver` on `PATH`.

If your shell exports `RUSTFLAGS`, unset it for wasm builds: an env `RUSTFLAGS` replaces the wasm32 `rustflags` in `.cargo/config.toml`.

## Verification

- Native: `cargo clippy --all-targets --all-features -p rsema1d -p celestia-fibre -- -D warnings` clean; `cargo bench -- --test` passes for all 24 rsema1d and 20 fibre cases; `cargo fmt --check` clean.
- wasm: `cargo clippy --all-targets --target wasm32-unknown-unknown -p rsema1d` and `cargo clippy --bench fibre_bench --target wasm32-unknown-unknown -p celestia-fibre` clean with `-D warnings`.
- Full default wasm runs in Node: rsema1d 17 passed / 7 ignored in 165 s, fibre 18 passed / 2 ignored in 147 s. A second run of the same case reports a within-noise change verdict from the stored baseline.

Out of scope, noted while doing this: `fibre/src/client/upload.rs:60` calls `std::time::SystemTime::now()` in library code, which will panic on wasm32-unknown-unknown during an upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015z3ssuzxpVQc5GbzNGuiZh
