### PR TITLE
perf(fibre,rsema1d): hand rows to wire without copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4902,6 +4902,7 @@ dependencies = [
 name = "rsema1d"
 version = "1.1.0-rc.1"
 dependencies = [
+ "bytes",
  "criterion",
  "getrandom 0.2.17",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = "1.0.40"
 async-stream = "0.3.5"
 async-trait = "0.1.80"
 base64 = "0.22.1"
-bytes = { version = "1.7.1", default-features = false }
+bytes = { version = "1.10.1", default-features = false }
 cid = { version = "0.11.2", default-features = false }
 dotenvy = "0.15"
 futures = "0.3.30"

--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -308,6 +308,58 @@ fn bench_parse_download_response(c: &mut Criterion) {
     group.finish();
 }
 
+/// Upload path from row proof generation through protobuf encoding for one
+/// production-sized validator shard from a maximum-sized blob.
+fn bench_upload_shard_encode(c: &mut Criterion) {
+    use prost::Message;
+
+    let mut group = c.benchmark_group("upload_shard_encode");
+    group.measurement_time(CHEAP_MEASUREMENT);
+    group.noise_threshold(0.03);
+
+    let blob = EncodedBlob::new(
+        &generate_data(BlobConfig::v0().max_data_size),
+        BlobConfig::v0(),
+    )
+    .unwrap();
+    let rlcs = blob.rlc_coeffs().to_vec();
+    let shard = rows_per_shard();
+
+    let request = |proofs: &[rsema1d::RowInclusionProof]| {
+        let rows = proofs
+            .iter()
+            .map(|proof| proto::BlobRow {
+                index: proof.index as u32,
+                data: proof.row.clone(),
+                proof: proof.row_proof.iter().map(|hash| hash.to_vec()).collect(),
+            })
+            .collect();
+        let rlcs = rlcs.iter().flat_map(|rlc| rlc.to_bytes()).collect();
+
+        proto::UploadShardRequest {
+            promise: None,
+            shard: Some(proto::BlobShard { rows, rlcs }),
+        }
+    };
+    let wire_len = {
+        let proofs: Vec<_> = (0..shard).map(|i| blob.row(i).unwrap()).collect();
+        request(&proofs).encoded_len()
+    };
+    group.throughput(Throughput::Bytes(wire_len as u64));
+
+    group.bench_function(
+        BenchmarkId::new("proofs_build_encode", format!("shard_{shard}_rows_128MB")),
+        |b| {
+            b.iter(|| {
+                let proofs: Vec<_> = (0..shard).map(|i| blob.row(i).unwrap()).collect();
+                request(black_box(&proofs)).encode_to_vec()
+            });
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_blob_new,
@@ -315,6 +367,7 @@ criterion_group!(
     bench_payment_promise,
     bench_signature_set,
     bench_validator_assign,
-    bench_parse_download_response
+    bench_parse_download_response,
+    bench_upload_shard_encode
 );
 criterion_main!(benches);

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -446,7 +446,9 @@ mod tests {
             for row in 0..total_rows {
                 let mut proof = blob.row(row).unwrap();
                 if i == 0 {
-                    proof.row[0] ^= 1;
+                    let mut corrupted = proof.row.to_vec();
+                    corrupted[0] ^= 1;
+                    proof.row = corrupted.into();
                 }
                 proofs.push(proof);
             }
@@ -497,7 +499,7 @@ mod tests {
                     let proof = blob.row(index).unwrap();
                     rsema1d::RowProof {
                         index: proof.index,
-                        row: std::borrow::Cow::Owned(proof.row),
+                        row: std::borrow::Cow::Owned(proof.row.to_vec()),
                         row_proof: proof.row_proof,
                     }
                 })

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -564,7 +564,7 @@ mod tests {
                     let proof = blob.row(i).unwrap();
                     rsema1d::RowProof {
                         index: proof.index,
-                        row: std::borrow::Cow::Owned(proof.row),
+                        row: std::borrow::Cow::Owned(proof.row.to_vec()),
                         row_proof: proof.row_proof,
                     }
                 })

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -103,7 +103,7 @@ impl MockValidatorConnection {
             .rows
             .extend(proofs.into_iter().map(|proof| rsema1d::RowProof {
                 index: proof.index,
-                row: Cow::Owned(proof.row),
+                row: Cow::Owned(proof.row.to_vec()),
                 row_proof: proof.row_proof,
             }));
         entry.rlcs = rlcs;

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -70,7 +70,7 @@ pub(crate) fn blob_row_to_row_proof(
 
     Ok(rsema1d::RowProof {
         index: row.index as usize,
-        row: std::borrow::Cow::Owned(row.data),
+        row: std::borrow::Cow::Owned(row.data.into()),
         row_proof,
     })
 }
@@ -215,7 +215,7 @@ mod tests {
     fn row_proof_blob_row_roundtrip() {
         let proof = rsema1d::RowInclusionProof {
             index: 5,
-            row: vec![42u8; 64],
+            row: vec![42u8; 64].into(),
             row_proof: vec![[1u8; 32], [2u8; 32]],
             rlc_root: [3u8; 32],
         };
@@ -235,7 +235,7 @@ mod tests {
     fn blob_row_to_row_proof_invalid_hash_length() {
         let row = proto::BlobRow {
             index: 0,
-            data: vec![0u8; 64],
+            data: vec![0u8; 64].into(),
             proof: vec![vec![0u8; 31]], // wrong length
         };
         let result = blob_row_to_row_proof(row);
@@ -246,7 +246,7 @@ mod tests {
     fn build_upload_shard_includes_rlc_vector() {
         let proofs = vec![rsema1d::RowInclusionProof {
             index: 0,
-            row: vec![0u8; 64],
+            row: vec![0u8; 64].into(),
             row_proof: vec![[0u8; 32]],
             rlc_root: [0u8; 32],
         }];
@@ -263,7 +263,7 @@ mod tests {
             shard: Some(proto::BlobShard {
                 rows: vec![proto::BlobRow {
                     index: 3,
-                    data: vec![1u8; 64],
+                    data: vec![1u8; 64].into(),
                     proof: vec![vec![2u8; 32]],
                 }],
                 rlcs: vec![9u8; 32], // 2 RLC values

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -277,7 +277,10 @@ fn prost_build(fds: FileDescriptorSet) {
     config
         .include_file("mod.rs")
         .enable_type_names()
-        .bytes([".tendermint_celestia_mods.abci"])
+        .bytes([
+            ".tendermint_celestia_mods.abci",
+            ".celestia.fibre.v1.BlobRow.data",
+        ])
         .compile_fds(fds)
         .expect("prost failed");
 }
@@ -295,7 +298,10 @@ fn tonic_build(fds: FileDescriptorSet) {
         .use_arc_self(true)
         .compile_well_known_types(true)
         .skip_protoc_run()
-        .bytes([".tendermint_celestia_mods.abci"]);
+        .bytes([
+            ".tendermint_celestia_mods.abci",
+            ".celestia.fibre.v1.BlobRow.data",
+        ]);
 
     for (type_path, attr) in CUSTOM_TYPE_ATTRIBUTES {
         tonic_config = tonic_config.type_attribute(type_path, attr);

--- a/rsema1d/Cargo.toml
+++ b/rsema1d/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 reed-solomon-simd = "3.1.0"
+bytes.workspace = true
 sha2 = { version = "0.10.8", features = ["asm"] }
 thiserror = "1.0.69"
 rayon = "1.10"

--- a/rsema1d/src/codec/commitment.rs
+++ b/rsema1d/src/codec/commitment.rs
@@ -112,10 +112,12 @@ impl ExtendedData {
 
     /// Generate commitment from contiguous already-extended rows (K+N rows).
     pub fn generate_from_extended_rows(
-        extended_rows: RowMatrix,
+        mut extended_rows: RowMatrix,
         params: &Parameters,
     ) -> Result<Self> {
         extended_rows.extended_view(params)?;
+        // Share encoded rows with inclusion proofs.
+        extended_rows.freeze();
 
         let row_tree = build_row_tree(&extended_rows, params);
         let row_root = row_tree.root();
@@ -234,11 +236,14 @@ impl ExtendedData {
 
     /// Generate row inclusion proof for any row.
     pub fn generate_row_inclusion_proof(&self, index: usize) -> Result<RowInclusionProof> {
-        let row_proof = self.generate_row_proof(index)?;
+        if index >= self.params.total_rows() {
+            return Err(Error::InvalidIndex(index, self.params.total_rows()));
+        }
+        let tree_pos = map_index_to_tree_position(index, self.params.k);
         Ok(RowInclusionProof {
-            index: row_proof.index,
-            row: row_proof.row.into_owned(),
-            row_proof: row_proof.row_proof,
+            index,
+            row: self.all_rows.row_bytes(index)?,
+            row_proof: self.row_tree.generate_proof(tree_pos),
             rlc_root: self.rlc_root,
         })
     }
@@ -266,5 +271,21 @@ mod tests {
         );
         assert_eq!(ext_data.rlc_orig.len(), params.k);
         assert_eq!(ext_data.rlc_extended.len(), params.k + params.n);
+    }
+
+    #[test]
+    fn row_inclusion_proof_shares_matrix_storage() {
+        let params = Parameters::new(4, 4, 64).unwrap();
+        let rows = RowMatrix::with_shape(
+            vec![0; params.total_rows() * params.row_size],
+            params.total_rows(),
+            params.row_size,
+        )
+        .unwrap();
+        let ext_data = ExtendedData::generate_from_extended_rows(rows, &params).unwrap();
+
+        let proof = ext_data.generate_row_inclusion_proof(3).unwrap();
+
+        assert_eq!(proof.row.as_ptr(), ext_data.row(3).unwrap().as_ptr());
     }
 }

--- a/rsema1d/src/codec/mod.rs
+++ b/rsema1d/src/codec/mod.rs
@@ -538,7 +538,7 @@ mod tests {
             let row_proof = ext_data.generate_row_proof(i).unwrap();
             let manual = RowInclusionProof {
                 index: row_proof.index,
-                row: row_proof.row.into_owned(),
+                row: row_proof.row.into_owned().into(),
                 row_proof: row_proof.row_proof,
                 rlc_root: ext_data.rlc_root(),
             };
@@ -552,7 +552,9 @@ mod tests {
         assert!(verify_row_inclusion(&proof, &bad_commitment, &params).is_err());
 
         let mut bad_row = proof.clone();
-        bad_row.row[0] ^= 0x01;
+        let mut corrupted = bad_row.row.to_vec();
+        corrupted[0] ^= 0x01;
+        bad_row.row = corrupted.into();
         assert!(verify_row_inclusion(&bad_row, &commitment, &params).is_err());
 
         assert!(ext_data

--- a/rsema1d/src/codec/proof.rs
+++ b/rsema1d/src/codec/proof.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::borrow::Cow;
 
 /// Lightweight row proof (works for both original and extended rows).
@@ -29,8 +30,9 @@ pub struct StandaloneProof {
 pub struct RowInclusionProof {
     /// Row index within the extended data (0..K+N).
     pub index: usize,
-    /// The row bytes.
-    pub row: Vec<u8>,
+    /// The row bytes; a reference-counted slice of the encoded matrix when
+    /// produced by [`ExtendedData`](crate::ExtendedData).
+    pub row: Bytes,
     /// Merkle proof siblings for the row tree.
     pub row_proof: Vec<[u8; 32]>,
     /// The RLC Merkle root used in the commitment.

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -97,22 +97,12 @@ impl PartialEq for Storage {
 impl Eq for Storage {}
 
 /// Contiguous row-major byte matrix (rows × row_size).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RowMatrix {
     data: Storage,
     row_size: usize,
     rows: usize,
 }
-
-impl PartialEq for RowMatrix {
-    fn eq(&self, other: &Self) -> bool {
-        self.rows == other.rows
-            && self.row_size == other.row_size
-            && self.as_row_major() == other.as_row_major()
-    }
-}
-
-impl Eq for RowMatrix {}
 
 impl RowMatrix {
     fn checked_len(rows: usize, row_size: usize) -> Result<usize> {
@@ -335,6 +325,18 @@ mod tests {
             };
             assert!(message.contains("overflow"));
         }
+    }
+
+    #[test]
+    fn mutating_frozen_matrix_does_not_modify_shared_rows() {
+        let mut matrix = RowMatrix::with_shape(vec![0; 128], 2, 64).unwrap();
+        matrix.freeze();
+        let row = matrix.row_bytes(0).unwrap();
+
+        matrix.row_mut(0).unwrap()[0] = 1;
+
+        assert_eq!(row[0], 0);
+        assert_eq!(matrix.row(0).unwrap()[0], 1);
     }
 
     #[cfg(target_os = "linux")]

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -83,7 +83,7 @@ impl Clone for Storage {
                 clone.as_mut_slice().copy_from_slice(data);
                 clone
             }
-            Self::Shared(data) => Self::Shared(data.clone())
+            Self::Shared(data) => Self::Shared(data.clone()),
         }
     }
 }
@@ -361,10 +361,10 @@ mod tests {
     fn large_heap_clone_stays_heap() {
         let rows = HUGE_PAGE_THRESHOLD / 64;
         let matrix = RowMatrix::with_shape(vec![1u8; HUGE_PAGE_THRESHOLD], rows, 64).unwrap();
-        assert!(matches!(&matrix.data, RowStorage::Heap(_)));
+        assert!(matches!(&matrix.data, Storage::Heap(_)));
 
         let clone = matrix.clone();
-        assert!(matches!(&clone.data, RowStorage::Heap(_)));
+        assert!(matches!(&clone.data, Storage::Heap(_)));
         assert_eq!(clone, matrix);
     }
 }

--- a/rsema1d/src/codec/rows.rs
+++ b/rsema1d/src/codec/rows.rs
@@ -1,17 +1,19 @@
 use crate::error::{Error, Result};
 use crate::params::Parameters;
+use bytes::Bytes;
 use std::fmt;
 
 #[cfg(target_os = "linux")]
 const HUGE_PAGE_THRESHOLD: usize = 4 * 1024 * 1024;
 
-enum RowStorage {
+enum Storage {
     Heap(Vec<u8>),
     #[cfg(target_os = "linux")]
     Mapped(memmap2::MmapMut),
+    Shared(Bytes),
 }
 
-impl RowStorage {
+impl Storage {
     fn zeroed(len: usize) -> Self {
         #[cfg(target_os = "linux")]
         if len >= HUGE_PAGE_THRESHOLD {
@@ -29,14 +31,19 @@ impl RowStorage {
             Self::Heap(data) => data,
             #[cfg(target_os = "linux")]
             Self::Mapped(data) => data,
+            Self::Shared(data) => data,
         }
     }
 
     fn as_mut_slice(&mut self) -> &mut [u8] {
+        if let Self::Shared(data) = self {
+            *self = Self::Heap(Vec::from(std::mem::take(data)));
+        }
         match self {
             Self::Heap(data) => data,
             #[cfg(target_os = "linux")]
             Self::Mapped(data) => data,
+            Self::Shared(_) => unreachable!("converted to heap above"),
         }
     }
 
@@ -45,17 +52,28 @@ impl RowStorage {
             Self::Heap(data) => data,
             #[cfg(target_os = "linux")]
             Self::Mapped(data) => data.to_vec(),
+            Self::Shared(data) => Vec::from(data),
         }
+    }
+
+    fn freeze(&mut self) {
+        let data = std::mem::replace(self, Self::Heap(Vec::new()));
+        *self = match data {
+            Self::Heap(data) => Self::Shared(Bytes::from(data)),
+            #[cfg(target_os = "linux")]
+            Self::Mapped(data) => Self::Shared(Bytes::from_owner(data)),
+            Self::Shared(data) => Self::Shared(data),
+        };
     }
 }
 
-impl fmt::Debug for RowStorage {
+impl fmt::Debug for Storage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_slice().fmt(f)
     }
 }
 
-impl Clone for RowStorage {
+impl Clone for Storage {
     fn clone(&self) -> Self {
         match self {
             Self::Heap(data) => Self::Heap(data.clone()),
@@ -65,25 +83,36 @@ impl Clone for RowStorage {
                 clone.as_mut_slice().copy_from_slice(data);
                 clone
             }
+            Self::Shared(data) => Self::Shared(data.clone())
         }
     }
 }
 
-impl PartialEq for RowStorage {
+impl PartialEq for Storage {
     fn eq(&self, other: &Self) -> bool {
         self.as_slice() == other.as_slice()
     }
 }
 
-impl Eq for RowStorage {}
+impl Eq for Storage {}
 
 /// Contiguous row-major byte matrix (rows × row_size).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct RowMatrix {
-    data: RowStorage,
+    data: Storage,
     row_size: usize,
     rows: usize,
 }
+
+impl PartialEq for RowMatrix {
+    fn eq(&self, other: &Self) -> bool {
+        self.rows == other.rows
+            && self.row_size == other.row_size
+            && self.as_row_major() == other.as_row_major()
+    }
+}
+
+impl Eq for RowMatrix {}
 
 impl RowMatrix {
     fn checked_len(rows: usize, row_size: usize) -> Result<usize> {
@@ -110,7 +139,7 @@ impl RowMatrix {
             )));
         }
         Ok(Self {
-            data: RowStorage::Heap(data),
+            data: Storage::Heap(data),
             row_size,
             rows,
         })
@@ -123,7 +152,7 @@ impl RowMatrix {
         }
         let len = Self::checked_len(rows, row_size)?;
         Ok(Self {
-            data: RowStorage::zeroed(len),
+            data: Storage::zeroed(len),
             row_size,
             rows,
         })
@@ -145,15 +174,22 @@ impl RowMatrix {
     }
 
     /// Returns the underlying flat buffer as a mutable byte slice.
+    ///
+    /// If the matrix was frozen and rows are still shared, this copies the
+    /// buffer first.
     pub fn as_row_major_mut(&mut self) -> &mut [u8] {
         self.data.as_mut_slice()
     }
 
-    /// Consumes the matrix and returns a flat byte buffer.
+    /// Consumes the matrix and returns the underlying byte buffer.
     ///
     /// Heap storage is returned directly. Memory-mapped storage is copied into a new allocation.
     pub fn into_row_major(self) -> Vec<u8> {
         self.data.into_vec()
+    }
+
+    pub(crate) fn freeze(&mut self) {
+        self.data.freeze();
     }
 
     /// Returns the row at `index`, or an error if out of bounds.
@@ -162,6 +198,18 @@ impl RowMatrix {
             return Err(Error::InvalidIndex(index, self.rows));
         }
         Ok(self.row_unchecked(index))
+    }
+
+    pub(crate) fn row_bytes(&self, index: usize) -> Result<Bytes> {
+        if index >= self.rows {
+            return Err(Error::InvalidIndex(index, self.rows));
+        }
+        let start = index * self.row_size;
+        let end = start + self.row_size;
+        Ok(match &self.data {
+            Storage::Shared(b) => b.slice(start..end),
+            data => Bytes::copy_from_slice(&data.as_slice()[start..end]),
+        })
     }
 
     /// Returns a mutable reference to the row at `index`.
@@ -299,6 +347,11 @@ mod tests {
         let clone = matrix.clone();
         assert_eq!(clone, matrix);
         assert_eq!(clone.into_row_major(), matrix.as_row_major());
+
+        let ptr = matrix.as_row_major().as_ptr();
+        matrix.freeze();
+        assert!(matches!(matrix.data, Storage::Shared(_)));
+        assert_eq!(matrix.as_row_major().as_ptr(), ptr);
     }
 
     #[cfg(target_os = "linux")]

--- a/rsema1d/tests/go_fuzzy_compat.rs
+++ b/rsema1d/tests/go_fuzzy_compat.rs
@@ -410,7 +410,7 @@ fn go_fuzzy_vectors_match_rust() {
 
             let inclusion = RowInclusionProof {
                 index: inclusion_test.index,
-                row: row.clone(),
+                row: row.clone().into(),
                 row_proof: row_proof.clone(),
                 rlc_root: inclusion_rlc_root,
             };
@@ -435,7 +435,7 @@ fn go_fuzzy_vectors_match_rust() {
                 case.name, inclusion_test.index
             );
             assert_eq!(
-                rust_inclusion.row.as_slice(),
+                rust_inclusion.row.as_ref(),
                 row.as_slice(),
                 "{}: row inclusion row mismatch for index {}",
                 case.name,


### PR DESCRIPTION
## Summary

Avoid copying encoded blob rows while building Fibre upload shards.

After encoding, the row matrix is frozen into reference-counted `Bytes` storage. `RowInclusionProof` holds slices of that storage, and protobuf `BlobRow.data` also uses `Bytes`, so matrix → proof → request conversion shares the same allocation instead of copying every row.

Mutable matrix access retains copy-on-write behavior. The protobuf wire format is unchanged.

Re-stacking https://github.com/celestiaorg/lumina/pull/1006 on top of huge pages to have conflicts resolved and performance reported.


## Benchmarks

**fibre-client**

```
RUSTFLAGS="-C target-cpu=native" \
  cargo bench -p celestia-fibre \
  --bench fibre_bench -- 'blob_new/' --baseline hugepage

blob_new/128KB          time:   [7.1048 ms 7.1456 ms 7.1841 ms]
                        thrpt:  [17.400 MiB/s 17.493 MiB/s 17.594 MiB/s]
                 change:
                        time:   [-1.3652% -0.5347% +0.2313%] (p = 0.24 > 0.05)
                        thrpt:  [-0.2308% +0.5376% +1.3841%]
                        No change in performance detected.

blob_new/1MB            time:   [16.158 ms 16.196 ms 16.234 ms]
                        thrpt:  [61.600 MiB/s 61.744 MiB/s 61.890 MiB/s]
                 change:
                        time:   [-10.670% -8.3328% -6.1477%] (p = 0.00 < 0.05)
                        thrpt:  [+6.5503% +9.0903% +11.944%]
                        Performance has improved.
blob_new/8MB            time:   [16.459 ms 16.504 ms 16.552 ms]
                        thrpt:  [483.33 MiB/s 484.72 MiB/s 486.05 MiB/s]
                 change:
                        time:   [-28.706% -25.653% -22.762%] (p = 0.00 < 0.05)
                        thrpt:  [+29.470% +34.504% +40.264%]
                        Performance has improved.
blob_new/32MB           time:   [34.504 ms 34.594 ms 34.679 ms]
                        thrpt:  [922.76 MiB/s 925.02 MiB/s 927.42 MiB/s]
                 change:
                        time:   [-21.386% -10.702% -2.8773%] (p = 0.07 > 0.05)
                        thrpt:  [+2.9625% +11.985% +27.204%]
                        No change in performance detected.
blob_new/128MB          time:   [93.621 ms 93.870 ms 94.240 ms]
                        thrpt:  [1.3264 GiB/s 1.3316 GiB/s 1.3352 GiB/s]
                 change:
                        time:   [-0.0290% +0.4137% +0.9262%] (p = 0.14 > 0.05)
                        thrpt:  [-0.9177% -0.4120% +0.0290%]
```

**rsema1d**

```
RUSTFLAGS='-C target-cpu=native' \
cargo bench -p rsema1d --bench codec_bench -- \
  'encode_in_place/(8MB_k4096_n12288|128MB_k4096_n12288)$' --baseline hugepage
encode_in_place/8MB_k4096_n12288
                        time:   [11.601 ms 11.680 ms 11.759 ms]
                        thrpt:  [680.31 MiB/s 684.95 MiB/s 689.57 MiB/s]
                 change:
                        time:   [-0.6017% +0.4166% +1.3914%] (p = 0.39 > 0.05)
                        thrpt:  [-1.3723% -0.4148% +0.6054%]
                        No change in performance detected.
encode_in_place/128MB_k4096_n12288
                        time:   [55.516 ms 55.599 ms 55.685 ms]
                        thrpt:  [2.2448 GiB/s 2.2482 GiB/s 2.2516 GiB/s]
                 change:
                        time:   [-0.6105% -0.3999% -0.1772%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1775% +0.4015% +0.6142%]
                        Change within noise threshold.
```


## Conclusion
Even though performance improvement is not staggering, it is still worthy change for non-linux targets (such as wasm) or boxes without hugepage enabled