### PR TITLE
chore(node): unflaky `peer_discovery` test

### DIFF
--- a/node/src/p2p/swarm_manager.rs
+++ b/node/src/p2p/swarm_manager.rs
@@ -543,6 +543,15 @@ where
             } => {
                 self.on_peer_disconnected(&peer_id, connection_id);
             }
+            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                debug!("Outgoing connection to {peer_id:?} failed: {error}");
+            }
+            SwarmEvent::NewListenAddr { address, .. } => {
+                debug!("Listening on {address}");
+            }
+            SwarmEvent::ExpiredListenAddr { address, .. } => {
+                debug!("Stopped listening on {address}");
+            }
             _ => {}
         }
 

--- a/node/src/p2p/swarm_manager.rs
+++ b/node/src/p2p/swarm_manager.rs
@@ -543,15 +543,6 @@ where
             } => {
                 self.on_peer_disconnected(&peer_id, connection_id);
             }
-            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                debug!("Outgoing connection to {peer_id:?} failed: {error}");
-            }
-            SwarmEvent::NewListenAddr { address, .. } => {
-                debug!("Listening on {address}");
-            }
-            SwarmEvent::ExpiredListenAddr { address, .. } => {
-                debug!("Stopped listening on {address}");
-            }
             _ => {}
         }
 

--- a/node/src/test_utils.rs
+++ b/node/src/test_utils.rs
@@ -2,23 +2,25 @@
 
 use std::time::Duration;
 
+use blockstore::Blockstore;
 use celestia_proto::p2p::pb::{HeaderRequest, header_request::Data};
 use celestia_types::ExtendedHeader;
 use celestia_types::hash::Hash;
 use celestia_types::sample::Sample;
 use celestia_types::test_utils::ExtendedHeaderGenerator;
-use lumina_utils::time::timeout;
+use libp2p::Multiaddr;
+use lumina_utils::time::{sleep, timeout};
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::{
-    NodeBuilder,
+    Node, NodeBuilder,
     block_ranges::{BlockRange, BlockRanges},
     blockstore::InMemoryBlockstore,
     daser::DaserCmd,
     network::Network,
     p2p::{P2pCmd, P2pError},
     peer_tracker::PeerTrackerInfo,
-    store::{InMemoryStore, VerifiedExtendedHeaders},
+    store::{InMemoryStore, Store, VerifiedExtendedHeaders},
     utils::OneshotResultSender,
 };
 
@@ -61,6 +63,30 @@ pub fn test_node_builder() -> NodeBuilder<InMemoryBlockstore, InMemoryStore> {
 /// [`NodeBuilder`] with listen address and default values for the usage in tests.
 pub fn listening_test_node_builder() -> NodeBuilder<InMemoryBlockstore, InMemoryStore> {
     test_node_builder().listen(["/ip4/0.0.0.0/tcp/0".parse().unwrap()])
+}
+
+/// Wait until `node` reports at least one listening address and return them.
+///
+/// Listening on an unspecified address (e.g. `/ip4/0.0.0.0/tcp/0`) resolves the concrete
+/// per-interface addresses asynchronously, so [`Node::listeners`] can return an empty list
+/// right after the node started, even after it connected to a peer. Tests that pass the
+/// addresses as bootnodes to another node must use this instead of `listeners()` directly.
+pub async fn wait_listening<B, S>(node: &Node<B, S>) -> Vec<Multiaddr>
+where
+    B: Blockstore + 'static,
+    S: Store + 'static,
+{
+    timeout(Duration::from_secs(10), async {
+        loop {
+            let addrs = node.listeners().await.expect("node stopped");
+            if !addrs.is_empty() {
+                return addrs;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("node did not report any listening address in time")
 }
 
 /// Extends test header generator for easier insertion into the store

--- a/node/src/test_utils.rs
+++ b/node/src/test_utils.rs
@@ -65,13 +65,8 @@ pub fn listening_test_node_builder() -> NodeBuilder<InMemoryBlockstore, InMemory
     test_node_builder().listen(["/ip4/0.0.0.0/tcp/0".parse().unwrap()])
 }
 
-/// Wait until `node` reports at least one listening address and return them.
-///
-/// Listening on an unspecified address (e.g. `/ip4/0.0.0.0/tcp/0`) resolves the concrete
-/// per-interface addresses asynchronously, so [`Node::listeners`] can return an empty list
-/// right after the node started, even after it connected to a peer. Tests that pass the
-/// addresses as bootnodes to another node must use this instead of `listeners()` directly.
-pub async fn wait_listening<B, S>(node: &Node<B, S>) -> Vec<Multiaddr>
+/// Wait until the node reports at least one listening address.
+pub async fn wait_for_listeners<B, S>(node: &Node<B, S>) -> Vec<Multiaddr>
 where
     B: Blockstore + 'static,
     S: Store + 'static,

--- a/node/tests/header_ex.rs
+++ b/node/tests/header_ex.rs
@@ -9,7 +9,9 @@ use lumina_node::{
     blockstore::InMemoryBlockstore,
     node::{HeaderExError, Node, NodeError, P2pError},
     store::{InMemoryStore, Store, VerifiedExtendedHeaders},
-    test_utils::{gen_filled_store, listening_test_node_builder, test_node_builder},
+    test_utils::{
+        gen_filled_store, listening_test_node_builder, test_node_builder, wait_listening,
+    },
 };
 use tokio::time::{sleep, timeout};
 
@@ -68,9 +70,7 @@ async fn client_server() {
         .await
         .unwrap();
 
-    // give server a sec to breathe, otherwise occiasionally client has problems with connecting
-    sleep(Duration::from_millis(100)).await;
-    let server_addrs = server.listeners().await.unwrap();
+    let server_addrs = wait_listening(&server).await;
 
     // Client node
     let client = test_node_builder()
@@ -183,12 +183,9 @@ async fn head_selection_with_multiple_peers() {
             .unwrap(),
     );
 
-    // give server a sec to breathe, otherwise occiasionally client has problems with connecting
-    sleep(Duration::from_millis(100)).await;
-
     let mut server_addrs = vec![];
     for s in &servers {
-        server_addrs.extend_from_slice(&s.listeners().await.unwrap()[..]);
+        server_addrs.extend_from_slice(&wait_listening(s).await[..]);
     }
 
     // Client Node
@@ -208,9 +205,7 @@ async fn head_selection_with_multiple_peers() {
         .collect::<Vec<_>>();
     wait_peers_connected(&client, &server_ids).await;
 
-    // give client node a sec to breathe, otherwise occiasionally rogue node has problems with connecting
-    sleep(Duration::from_millis(100)).await;
-    let client_addr = client.listeners().await.unwrap();
+    let client_addr = wait_listening(&client).await;
 
     // Rogue node, connects to client so isn't trusted
     let rogue_node = listening_test_node_builder()
@@ -315,9 +310,7 @@ async fn replaced_header_server_store() {
         .await
         .unwrap();
 
-    // give server a sec to breathe, otherwise occiasionally client has problems with connecting
-    sleep(Duration::from_millis(100)).await;
-    let server_addrs = server.listeners().await.unwrap();
+    let server_addrs = wait_listening(&server).await;
 
     let client = listening_test_node_builder()
         .bootnodes(server_addrs)
@@ -370,9 +363,7 @@ async fn invalidated_header_server_store() {
         .await
         .unwrap();
 
-    // give server a sec to breathe, otherwise occiasionally client has problems with connecting
-    sleep(Duration::from_millis(100)).await;
-    let server_addrs = server.listeners().await.unwrap();
+    let server_addrs = wait_listening(&server).await;
 
     let client = listening_test_node_builder()
         .bootnodes(server_addrs)
@@ -435,9 +426,7 @@ async fn unverified_header_server_store() {
         .await
         .unwrap();
 
-    // give server a sec to breathe, otherwise occiasionally client has problems with connecting
-    sleep(Duration::from_millis(100)).await;
-    let server_addrs = server.listeners().await.unwrap();
+    let server_addrs = wait_listening(&server).await;
 
     let client = listening_test_node_builder()
         .bootnodes(server_addrs)

--- a/node/tests/header_ex.rs
+++ b/node/tests/header_ex.rs
@@ -10,7 +10,7 @@ use lumina_node::{
     node::{HeaderExError, Node, NodeError, P2pError},
     store::{InMemoryStore, Store, VerifiedExtendedHeaders},
     test_utils::{
-        gen_filled_store, listening_test_node_builder, test_node_builder, wait_listening,
+        gen_filled_store, listening_test_node_builder, test_node_builder, wait_for_listeners,
     },
 };
 use tokio::time::{sleep, timeout};
@@ -70,7 +70,7 @@ async fn client_server() {
         .await
         .unwrap();
 
-    let server_addrs = wait_listening(&server).await;
+    let server_addrs = wait_for_listeners(&server).await;
 
     // Client node
     let client = test_node_builder()
@@ -185,7 +185,7 @@ async fn head_selection_with_multiple_peers() {
 
     let mut server_addrs = vec![];
     for s in &servers {
-        server_addrs.extend_from_slice(&wait_listening(s).await[..]);
+        server_addrs.extend(wait_for_listeners(s).await);
     }
 
     // Client Node
@@ -205,7 +205,7 @@ async fn head_selection_with_multiple_peers() {
         .collect::<Vec<_>>();
     wait_peers_connected(&client, &server_ids).await;
 
-    let client_addr = wait_listening(&client).await;
+    let client_addr = wait_for_listeners(&client).await;
 
     // Rogue node, connects to client so isn't trusted
     let rogue_node = listening_test_node_builder()
@@ -310,7 +310,7 @@ async fn replaced_header_server_store() {
         .await
         .unwrap();
 
-    let server_addrs = wait_listening(&server).await;
+    let server_addrs = wait_for_listeners(&server).await;
 
     let client = listening_test_node_builder()
         .bootnodes(server_addrs)
@@ -363,7 +363,7 @@ async fn invalidated_header_server_store() {
         .await
         .unwrap();
 
-    let server_addrs = wait_listening(&server).await;
+    let server_addrs = wait_for_listeners(&server).await;
 
     let client = listening_test_node_builder()
         .bootnodes(server_addrs)
@@ -426,7 +426,7 @@ async fn unverified_header_server_store() {
         .await
         .unwrap();
 
-    let server_addrs = wait_listening(&server).await;
+    let server_addrs = wait_for_listeners(&server).await;
 
     let client = listening_test_node_builder()
         .bootnodes(server_addrs)

--- a/node/tests/node.rs
+++ b/node/tests/node.rs
@@ -12,6 +12,7 @@ use libp2p::{Multiaddr, SwarmBuilder, gossipsub, noise, ping, tcp, yamux};
 use lumina_node::store::{InMemoryStore, Store};
 use lumina_node::test_utils::{
     ExtendedHeaderGeneratorExt, gen_filled_store, listening_test_node_builder, test_node_builder,
+    wait_listening,
 };
 use rand::Rng;
 use tendermint_proto::Protobuf;
@@ -103,7 +104,11 @@ async fn peer_discovery() {
         .expect("node1 did not connect within 30s — is the devnet reachable? (docker compose -f ci/docker-compose.yml up)")
         .unwrap();
 
-    let node1_addrs = node1.listeners().await.unwrap();
+    // `wait_connected` does not imply the listening addresses are known yet:
+    // `/ip4/0.0.0.0/tcp/0` is expanded to concrete addresses asynchronously, and
+    // `listeners()` returns an empty list until then, which would leave node2
+    // without any bootnodes.
+    let node1_addrs = wait_listening(&node1).await;
 
     // Node2
     //
@@ -226,8 +231,7 @@ async fn stops_services_when_network_is_compromised() {
         .unwrap();
 
     // get the address to dial
-    sleep(Duration::from_millis(300)).await;
-    let listener_addr = node.listeners().await.unwrap()[0].clone();
+    let listener_addr = wait_listening(&node).await[0].clone();
 
     // spawn a proof broadcaster
     let befp_announce_tx = spawn_befp_announcer(listener_addr);

--- a/node/tests/node.rs
+++ b/node/tests/node.rs
@@ -12,7 +12,7 @@ use libp2p::{Multiaddr, SwarmBuilder, gossipsub, noise, ping, tcp, yamux};
 use lumina_node::store::{InMemoryStore, Store};
 use lumina_node::test_utils::{
     ExtendedHeaderGeneratorExt, gen_filled_store, listening_test_node_builder, test_node_builder,
-    wait_listening,
+    wait_for_listeners,
 };
 use rand::Rng;
 use tendermint_proto::Protobuf;
@@ -104,11 +104,7 @@ async fn peer_discovery() {
         .expect("node1 did not connect within 30s — is the devnet reachable? (docker compose -f ci/docker-compose.yml up)")
         .unwrap();
 
-    // `wait_connected` does not imply the listening addresses are known yet:
-    // `/ip4/0.0.0.0/tcp/0` is expanded to concrete addresses asynchronously, and
-    // `listeners()` returns an empty list until then, which would leave node2
-    // without any bootnodes.
-    let node1_addrs = wait_listening(&node1).await;
+    let node1_addrs = wait_for_listeners(&node1).await;
 
     // Node2
     //
@@ -231,7 +227,7 @@ async fn stops_services_when_network_is_compromised() {
         .unwrap();
 
     // get the address to dial
-    let listener_addr = wait_listening(&node).await[0].clone();
+    let listener_addr = wait_for_listeners(&node).await[0].clone();
 
     // spawn a proof broadcaster
     let befp_announce_tx = spawn_befp_announcer(listener_addr);


### PR DESCRIPTION
## Problem

`test (lumina-node, true)` has been failing on `peer_discovery` since 2026-08-31 (7 reruns fixed it, 5 more never-rerun failures with the same signature):

```
thread 'peer_discovery' panicked at node/tests/node.rs:119:10:
node2 did not connect to node1 within 30s: Elapsed(())
```

The `test-logs-lumina-node` artifact of a failing attempt (run 33870724138) shows node2 starting with **no bootnodes**: it logs `Can't run kademlia bootstrap: No known peers.` at start, never logs `Protect peer <node1> with 0 tag`, and then `All peers disconnected` every 10 s until the timeout. In the passing attempt node2 registers node1 as a bootnode 13 ms after starting.

Cause: the test reads `node1.listeners()` immediately after `node1.wait_connected()`. Listening on `/ip4/0.0.0.0/tcp/0` reports the concrete per-interface addresses asynchronously (libp2p-tcp expands them through if-watch), so `listeners()` can still be empty even though node1 already connected to the bridge. node2 is then built with `bootnodes([])` and never dials anything.

## Fix

- `test_utils::wait_listening(&node)`: polls `listeners()` until non-empty (10 s deadline).
- `peer_discovery` uses it for node1's addresses.
- The fixed `sleep(100 ms)` / `sleep(300 ms)` before `listeners()` in `header_ex.rs` and `stops_services_when_network_is_compromised` were covering the same race and are replaced by the helper.
- `swarm_manager` now logs `NewListenAddr`, `ExpiredListenAddr` and `OutgoingConnectionError` at debug level, so a recurrence is diagnosable from the log instead of from the absence of a line.
