### PR TITLE
fix(fibre): reject invalid validator voting power

### DIFF
--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -94,13 +94,7 @@ fn make_validators(count: usize) -> (Vec<ed25519_dalek::SigningKey>, Vec<Validat
             let mut seed = [0u8; 32];
             seed[..8].copy_from_slice(&(i as u64 + 1).to_le_bytes());
             let key = ed25519_dalek::SigningKey::from_bytes(&seed);
-            let mut address = [0u8; 20];
-            address[..8].copy_from_slice(&(i as u64 + 1).to_le_bytes());
-            let info = ValidatorInfo {
-                address,
-                pubkey: key.verifying_key(),
-                voting_power: (i as i64 % 10) + 1,
-            };
+            let info = ValidatorInfo::try_new(key.verifying_key(), (i as u64 % 10) + 1).unwrap();
             (key, info)
         })
         .unzip()
@@ -205,7 +199,7 @@ fn bench_signature_set(c: &mut Criterion) {
         })
         .collect();
 
-    let set = ValidatorSet::new(validators.clone(), 1);
+    let set = ValidatorSet::try_new(validators.clone(), 1).unwrap();
     let threshold = Fraction::new(NonZeroU64::new(2).unwrap(), NonZeroU64::new(3).unwrap());
 
     let signature_set = set.new_signature_set(threshold, payload.clone());
@@ -246,7 +240,7 @@ fn bench_validator_assign(c: &mut Criterion) {
 
     for count in [10, 50, 100] {
         let (_, validators) = make_validators(count);
-        let set = ValidatorSet::new(validators, 1);
+        let set = ValidatorSet::try_new(validators, 1).unwrap();
 
         group.bench_with_input(BenchmarkId::new("assign", count), &set, |b, set| {
             b.iter(|| {

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -342,10 +342,7 @@ mod tests {
             make_validator(100, 3),
         ];
         let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 1).unwrap();
 
         let conns: Vec<Arc<MockValidatorConnection>> = validators
             .iter()
@@ -379,10 +376,7 @@ mod tests {
             make_validator(100, 5),
         ];
         let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 1).unwrap();
 
         let failing_conn_0 = Arc::new(MockValidatorConnection::new_failing(
             validators[0].0.clone(),
@@ -427,10 +421,7 @@ mod tests {
 
         let validators = [make_validator(100, 1), make_validator(100, 2)];
         let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 1).unwrap();
 
         let conns: Vec<Arc<MockValidatorConnection>> = validators
             .iter()
@@ -489,10 +480,7 @@ mod tests {
         let blob_id = blob.id().clone();
         let validators = [make_validator(100, 1), make_validator(100, 2)];
         let val_infos: Vec<_> = validators.iter().map(|(_, info)| info.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 1).unwrap();
         let response = DownloadResponse {
             rows: (0..cfg.total_rows())
                 .map(|index| {
@@ -540,10 +528,7 @@ mod tests {
         // Single validator that fails
         let validators = [make_validator(100, 1)];
         let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 1).unwrap();
 
         let failing_conn = Arc::new(MockValidatorConnection::new_failing(
             validators[0].0.clone(),
@@ -567,10 +552,7 @@ mod tests {
     async fn download_fails_when_client_closed() {
         let cfg = test_blob_config();
         let (key, val) = make_validator(100, 1);
-        let val_set = ValidatorSet {
-            validators: vec![val.clone()],
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(vec![val.clone()], 1).unwrap();
 
         let conn = Arc::new(MockValidatorConnection::new(key));
         let mut connector = MockConnector::new();
@@ -599,10 +581,7 @@ mod tests {
             make_validator(100, 30),
         ];
         let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 42,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 42).unwrap();
 
         let blob = EncodedBlob::new(&original_data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();
@@ -645,10 +624,7 @@ mod tests {
             make_validator(100, 3),
         ];
         let val_infos: Vec<_> = validators.iter().map(|(_, v)| v.clone()).collect();
-        let val_set = ValidatorSet {
-            validators: val_infos.clone(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos.clone(), 1).unwrap();
 
         let blob = EncodedBlob::new(&data, cfg.clone()).unwrap();
         let blob_id = blob.id().clone();

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -42,6 +42,11 @@ impl FibreClient {
 
         // 1. Get validator set
         let val_set = self.set_getter.head().await?;
+        if val_set.total_voting_power() <= 0 {
+            return Err(FibreError::InvalidData(
+                "validator set has no voting power".into(),
+            ));
+        }
 
         // 2. Create and sign payment promise
         let upload_size = blob.upload_size();
@@ -488,6 +493,48 @@ mod tests {
             FibreError::NotEnoughSignatures { .. } => {}
             other => panic!("expected NotEnoughSignatures, got: {other}"),
         }
+    }
+
+    #[tokio::test]
+    async fn upload_fails_on_empty_validator_set() {
+        let client = build_test_client(
+            ValidatorSet {
+                validators: vec![],
+                height: 1,
+            },
+            MockConnector::new(),
+            "test-chain",
+        );
+
+        let result = client
+            .upload(
+                &test_signing_key(),
+                Namespace::from_raw(&[0u8; 29]).unwrap(),
+                make_test_blob(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(FibreError::InvalidData(_))));
+    }
+
+    #[tokio::test]
+    async fn upload_fails_on_zero_voting_power_set() {
+        let validators = vec![make_validator(0, 1)];
+        let val_set = ValidatorSet {
+            validators: validators.iter().map(|(_, info)| info.clone()).collect(),
+            height: 1,
+        };
+        let client = build_test_client(val_set, make_connector(&validators), "test-chain");
+
+        let result = client
+            .upload(
+                &test_signing_key(),
+                Namespace::from_raw(&[0u8; 29]).unwrap(),
+                make_test_blob(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(FibreError::InvalidData(_))));
     }
 
     #[tokio::test]

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -42,12 +42,6 @@ impl FibreClient {
 
         // 1. Get validator set
         let val_set = self.set_getter.head().await?;
-        if val_set.total_voting_power() <= 0 {
-            return Err(FibreError::InvalidData(
-                "validator set has no voting power".into(),
-            ));
-        }
-
         // 2. Create and sign payment promise
         let upload_size = blob.upload_size();
         let upload_size_u32 = u32::try_from(upload_size).map_err(|_| FibreError::BlobTooLarge {
@@ -57,7 +51,7 @@ impl FibreClient {
 
         let mut promise = PaymentPromise {
             chain_id: self.cfg.chain_id.clone(),
-            height: val_set.height,
+            height: val_set.height(),
             namespace,
             upload_size: upload_size_u32,
             blob_version: blob.config().blob_version as u32,
@@ -180,7 +174,7 @@ impl FibreClient {
                 .map_err(|_| FibreError::Other("upload semaphore closed".into()))?;
 
             let connector = Arc::clone(&self.connector);
-            let validator = val_set.validators[val_idx].clone();
+            let validator = val_set.validators()[val_idx].clone();
             let promise = promise.clone();
             let blob = Arc::clone(blob);
 
@@ -213,7 +207,7 @@ impl FibreClient {
                 task_result = futures.next() => {
                     match task_result {
                         Some((val_idx, Some(Ok(signature)))) => {
-                            let validator = &val_set.validators[val_idx];
+                            let validator = &val_set.validators()[val_idx];
                             match sig_set.add(validator, &signature) {
                                 Ok(threshold_met) => {
                                     if threshold_met {
@@ -230,7 +224,7 @@ impl FibreClient {
                             }
                         }
                         Some((val_idx, Some(Err(e)))) => {
-                            let validator = &val_set.validators[val_idx];
+                            let validator = &val_set.validators()[val_idx];
                             tracing::warn!(
                                 validator = %validator.address_hex(),
                                 error = %e,
@@ -238,7 +232,7 @@ impl FibreClient {
                             );
                         }
                         Some((val_idx, None)) => {
-                            let validator = &val_set.validators[val_idx];
+                            let validator = &val_set.validators()[val_idx];
                             tracing::warn!(
                                 validator = %validator.address_hex(),
                                 "upload task dropped unexpectedly"
@@ -290,10 +284,7 @@ mod tests {
         let validators = vec![make_validator(100, 1)];
         let connector = make_connector(&validators);
 
-        let val_set = ValidatorSet {
-            validators: vec![val],
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(vec![val], 1).unwrap();
 
         let client = build_test_client(val_set, connector, "test-chain");
         client.close();
@@ -322,10 +313,7 @@ mod tests {
 
         let connector = make_connector(&validators);
 
-        let val_set = ValidatorSet {
-            validators: val_infos,
-            height: 42,
-        };
+        let val_set = ValidatorSet::try_new(val_infos, 42).unwrap();
 
         let sk = test_signing_key();
         let client = build_test_client(val_set, connector, "test-chain");
@@ -372,10 +360,7 @@ mod tests {
             connector.add(info.address, conn);
         }
 
-        let val_set = ValidatorSet {
-            validators: val_infos,
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(val_infos, 1).unwrap();
 
         let client = build_test_client(val_set, connector, "test-chain");
         let blob = make_test_blob();
@@ -419,10 +404,7 @@ mod tests {
             fail_addresses,
         };
 
-        let val_set = ValidatorSet {
-            validators: val_infos,
-            height: 10,
-        };
+        let val_set = ValidatorSet::try_new(val_infos, 10).unwrap();
 
         let client = build_test_client(val_set, failing_connector, "test-chain");
         let blob = make_test_blob();
@@ -475,10 +457,7 @@ mod tests {
             fail_addresses,
         };
 
-        let val_set = ValidatorSet {
-            validators: val_infos,
-            height: 10,
-        };
+        let val_set = ValidatorSet::try_new(val_infos, 10).unwrap();
 
         let client = build_test_client(val_set, failing_connector, "test-chain");
         let blob = make_test_blob();
@@ -496,35 +475,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_fails_on_empty_validator_set() {
-        let client = build_test_client(
-            ValidatorSet {
-                validators: vec![],
-                height: 1,
-            },
-            MockConnector::new(),
-            "test-chain",
-        );
-
-        let result = client
-            .upload(
-                &test_signing_key(),
-                Namespace::from_raw(&[0u8; 29]).unwrap(),
-                make_test_blob(),
-            )
-            .await;
-
-        assert!(matches!(result, Err(FibreError::InvalidData(_))));
-    }
-
-    #[tokio::test]
-    async fn upload_fails_on_zero_voting_power_set() {
-        let validators = vec![make_validator(0, 1)];
-        let val_set = ValidatorSet {
-            validators: validators.iter().map(|(_, info)| info.clone()).collect(),
-            height: 1,
+    async fn upload_requires_signature_when_fraction_rounds_to_zero() {
+        let validator = make_validator(1, 1);
+        let val_set = ValidatorSet::try_new(vec![validator.1.clone()], 1).unwrap();
+        let connector = FailingConnector {
+            inner: MockConnector::new(),
+            fail_addresses: vec![validator.1.address],
         };
-        let client = build_test_client(val_set, make_connector(&validators), "test-chain");
+        let client = build_test_client(val_set, connector, "test-chain");
 
         let result = client
             .upload(
@@ -534,7 +492,13 @@ mod tests {
             )
             .await;
 
-        assert!(matches!(result, Err(FibreError::InvalidData(_))));
+        assert!(matches!(
+            result,
+            Err(FibreError::NotEnoughSignatures {
+                collected: 0,
+                required: 1
+            })
+        ));
     }
 
     #[tokio::test]
@@ -543,10 +507,7 @@ mod tests {
         let validators = vec![make_validator(100, 1)];
         let connector = make_connector(&validators);
 
-        let val_set = ValidatorSet {
-            validators: vec![val],
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(vec![val], 1).unwrap();
 
         let client = build_test_client(val_set, connector, "test-chain");
         client.close();

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -7,7 +7,6 @@
 //! The [`FibreClient::upload_and_prepare()`] method encodes a blob, uploads it to validators,
 //! and returns a `MsgPayForFibre` ready for broadcast by the caller.
 
-use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use celestia_proto::celestia::fibre::v1::MsgPayForFibre;
@@ -88,6 +87,7 @@ impl FibreClient {
 
         // 1. Get validator set
         let val_set = self.set_getter.head().await?;
+
         // 2. Create and sign payment promise
         let upload_size = blob.upload_size();
         let upload_size_u32 = u32::try_from(upload_size).map_err(|_| FibreError::BlobTooLarge {
@@ -97,9 +97,7 @@ impl FibreClient {
 
         let mut promise = PaymentPromise {
             chain_id: self.cfg.chain_id().to_owned(),
-            height: NonZeroU64::new(val_set.height()).ok_or_else(|| {
-                FibreError::InvalidPaymentPromise("height must be positive, got 0".into())
-            })?,
+            height: val_set.height(),
             namespace,
             upload_size: upload_size_u32,
             blob_version: blob.config().blob_version as u32,

--- a/fibre/src/domain/error.rs
+++ b/fibre/src/domain/error.rs
@@ -63,9 +63,9 @@ pub enum FibreError {
     #[error("not enough voting power: collected {collected}, required {required}")]
     NotEnoughSignatures {
         /// Total voting power of collected signatures.
-        collected: i64,
+        collected: u64,
         /// Required voting power threshold.
-        required: i64,
+        required: u64,
     },
 
     /// A validator returned an invalid signature.

--- a/fibre/src/roundtrip_test.rs
+++ b/fibre/src/roundtrip_test.rs
@@ -28,10 +28,7 @@ async fn upload_then_download_roundtrip() {
 
     let connector = make_connector(&validators);
     let val_infos = validators.iter().map(|(_, v)| v.clone()).collect();
-    let val_set = crate::validator::ValidatorSet {
-        validators: val_infos,
-        height: 42,
-    };
+    let val_set = crate::validator::ValidatorSet::try_new(val_infos, 42).unwrap();
 
     let client = build_test_client(val_set, connector, "roundtrip-test");
 
@@ -105,10 +102,7 @@ async fn roundtrip_with_partial_validator_failure() {
     }
 
     let val_infos = all_validators.iter().map(|(_, v)| v.clone()).collect();
-    let val_set = crate::validator::ValidatorSet {
-        validators: val_infos,
-        height: 42,
-    };
+    let val_set = crate::validator::ValidatorSet::try_new(val_infos, 42).unwrap();
 
     let client = build_test_client(val_set, connector, "roundtrip-test");
 

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -232,19 +232,12 @@ impl ValidatorConnector for FailingConnector {
 }
 
 /// Create a validator with a deterministic ed25519 keypair.
-pub(crate) fn make_validator(power: i64, seed: u8) -> (Ed25519SigningKey, ValidatorInfo) {
+pub(crate) fn make_validator(power: u64, seed: u8) -> (Ed25519SigningKey, ValidatorInfo) {
     let mut key_bytes = [0u8; 32];
     key_bytes[0] = seed;
     let ed_key = Ed25519SigningKey::from_bytes(&key_bytes);
     let pubkey = ed_key.verifying_key();
-    (
-        ed_key,
-        ValidatorInfo {
-            address: [seed; 20],
-            pubkey,
-            voting_power: power,
-        },
-    )
+    (ed_key, ValidatorInfo::try_new(pubkey, power).unwrap())
 }
 
 /// Standard test blob configuration: K=4, N=4, min_row_size=64.

--- a/fibre/src/transport/grpc_validator_client.rs
+++ b/fibre/src/transport/grpc_validator_client.rs
@@ -156,6 +156,7 @@ mod tests {
 
     use crate::host_registry::Host;
     use crate::host_registry::HostRegistry;
+    use crate::test_utils::make_validator;
 
     struct MockHostRegistry {
         hosts: std::collections::HashMap<[u8; 20], Host>,
@@ -174,16 +175,9 @@ mod tests {
         }
     }
 
-    fn make_test_validator(seed: u8) -> ValidatorInfo {
-        let mut key_bytes = [0u8; 32];
-        key_bytes[0] = seed;
-        let sk = ed25519_dalek::SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo::try_new(sk.verifying_key(), 100).unwrap()
-    }
-
     #[tokio::test]
     async fn connector_caches_connections() {
-        let validator = make_test_validator(1);
+        let validator = make_validator(100, 1).1;
 
         let mut hosts = std::collections::HashMap::new();
         hosts.insert(validator.address, Host("http://127.0.0.1:9090".to_string()));
@@ -213,8 +207,8 @@ mod tests {
 
     #[tokio::test]
     async fn connector_creates_separate_connections_for_different_validators() {
-        let validator_a = make_test_validator(1);
-        let validator_b = make_test_validator(2);
+        let validator_a = make_validator(100, 1).1;
+        let validator_b = make_validator(100, 2).1;
 
         let mut hosts = std::collections::HashMap::new();
         hosts.insert(
@@ -249,7 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn connector_propagates_host_not_found_error() {
-        let validator = make_test_validator(42);
+        let validator = make_validator(100, 42).1;
 
         // Empty hosts map: every lookup will fail with HostNotFound.
         let registry = Arc::new(MockHostRegistry {

--- a/fibre/src/transport/grpc_validator_client.rs
+++ b/fibre/src/transport/grpc_validator_client.rs
@@ -178,11 +178,7 @@ mod tests {
         let mut key_bytes = [0u8; 32];
         key_bytes[0] = seed;
         let sk = ed25519_dalek::SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo {
-            address: [seed; 20],
-            pubkey: sk.verifying_key(),
-            voting_power: 100,
-        }
+        ValidatorInfo::try_new(sk.verifying_key(), 100).unwrap()
     }
 
     #[tokio::test]

--- a/fibre/src/transport/host_registry.rs
+++ b/fibre/src/transport/host_registry.rs
@@ -152,16 +152,11 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn make_validator(seed: u8, address: [u8; 20]) -> ValidatorInfo {
+    fn make_validator(seed: u8) -> ValidatorInfo {
         let mut key_bytes = [0u8; 32];
         key_bytes[0] = seed;
         let sk = ed25519_dalek::SigningKey::from_bytes(&key_bytes);
-        let pubkey = sk.verifying_key();
-        ValidatorInfo {
-            address,
-            pubkey,
-            voting_power: 1,
-        }
+        ValidatorInfo::try_new(sk.verifying_key(), 1).unwrap()
     }
 
     #[test]
@@ -256,14 +251,13 @@ mod tests {
 
     #[tokio::test]
     async fn map_registry_returns_host_when_present() {
-        let addr = [42u8; 20];
         let expected_host = Host("dns:///example.com:9090".to_string());
+        let validator = make_validator(1);
 
         let mut hosts = HashMap::new();
-        hosts.insert(addr, expected_host.clone());
+        hosts.insert(*validator.address(), expected_host.clone());
 
         let registry = MapRegistry { hosts };
-        let validator = make_validator(1, addr);
 
         let host = registry
             .get_host(&validator)
@@ -277,7 +271,7 @@ mod tests {
         let registry = MapRegistry {
             hosts: HashMap::new(),
         };
-        let validator = make_validator(1, [99u8; 20]);
+        let validator = make_validator(1);
 
         let result = registry.get_host(&validator).await;
         assert!(result.is_err(), "should return an error for missing host");
@@ -286,7 +280,7 @@ mod tests {
             FibreError::HostNotFound(addr_hex) => {
                 assert_eq!(
                     addr_hex,
-                    hex::encode_upper([99u8; 20]),
+                    validator.address_hex(),
                     "error should contain the hex-encoded address"
                 );
             }
@@ -303,17 +297,15 @@ mod tests {
 
         let registry = GrpcHostRegistry::new(client);
 
-        let addr = [7u8; 20];
         let expected_host = Host("dns:///cached-validator.example.com:9090".to_string());
+        let validator = make_validator(2);
 
         // Manually populate the cache.
         registry
             .cache
             .write()
             .await
-            .insert(addr, expected_host.clone());
-
-        let validator = make_validator(2, addr);
+            .insert(*validator.address(), expected_host.clone());
 
         // get_host should return the cached value without hitting the (unreachable) server.
         let host = registry

--- a/fibre/src/transport/host_registry.rs
+++ b/fibre/src/transport/host_registry.rs
@@ -150,14 +150,8 @@ fn encode_bech32_address(hrp: &str, addr: &[u8; 20]) -> Result<String, FibreErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::make_validator;
     use std::collections::HashMap;
-
-    fn make_validator(seed: u8) -> ValidatorInfo {
-        let mut key_bytes = [0u8; 32];
-        key_bytes[0] = seed;
-        let sk = ed25519_dalek::SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo::try_new(sk.verifying_key(), 1).unwrap()
-    }
 
     #[test]
     fn bech32_encode_decode_roundtrip() {
@@ -252,10 +246,10 @@ mod tests {
     #[tokio::test]
     async fn map_registry_returns_host_when_present() {
         let expected_host = Host("dns:///example.com:9090".to_string());
-        let validator = make_validator(1);
+        let validator = make_validator(1, 1).1;
 
         let mut hosts = HashMap::new();
-        hosts.insert(*validator.address(), expected_host.clone());
+        hosts.insert(validator.address, expected_host.clone());
 
         let registry = MapRegistry { hosts };
 
@@ -271,7 +265,7 @@ mod tests {
         let registry = MapRegistry {
             hosts: HashMap::new(),
         };
-        let validator = make_validator(1);
+        let validator = make_validator(1, 1).1;
 
         let result = registry.get_host(&validator).await;
         assert!(result.is_err(), "should return an error for missing host");
@@ -298,14 +292,14 @@ mod tests {
         let registry = GrpcHostRegistry::new(client);
 
         let expected_host = Host("dns:///cached-validator.example.com:9090".to_string());
-        let validator = make_validator(2);
+        let validator = make_validator(1, 2).1;
 
         // Manually populate the cache.
         registry
             .cache
             .write()
             .await
-            .insert(*validator.address(), expected_host.clone());
+            .insert(validator.address, expected_host.clone());
 
         // get_host should return the cached value without hitting the (unreachable) server.
         let host = registry

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -368,6 +368,24 @@ mod tests {
     }
 
     #[test]
+    fn validator_from_proto_negative_power() {
+        let mut secret = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut OsRng, &mut secret);
+        let pk = ed25519_dalek::SigningKey::from_bytes(&secret).verifying_key();
+
+        let proto_val = tendermint_proto::v0_38::types::Validator {
+            address: vec![0u8; 20],
+            pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
+                sum: Some(CryptoKeySum::Ed25519(pk.as_bytes().to_vec())),
+            }),
+            voting_power: -1,
+            proposer_priority: 0,
+        };
+
+        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+    }
+
+    #[test]
     fn validator_from_proto_missing_key() {
         let proto_val = tendermint_proto::v0_38::types::Validator {
             address: vec![],

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -177,6 +177,7 @@ pub(crate) fn timestamp_to_system_time(t: &Timestamp) -> Result<SystemTime, Fibr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::make_validator;
     use k256::ecdsa::SigningKey;
     use rand::rngs::OsRng;
 
@@ -347,21 +348,16 @@ mod tests {
         ed25519_dalek::VerifyingKey,
         tendermint_proto::v0_38::types::Validator,
     ) {
-        use sha2::{Digest, Sha256};
-
-        let mut secret = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut OsRng, &mut secret);
-        let pubkey = ed25519_dalek::SigningKey::from_bytes(&secret).verifying_key();
-        let address = Sha256::digest(pubkey.as_bytes())[..20].to_vec();
+        let info = make_validator(1, 7).1;
         let validator = tendermint_proto::v0_38::types::Validator {
-            address,
+            address: info.address().to_vec(),
             pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
-                sum: Some(CryptoKeySum::Ed25519(pubkey.as_bytes().to_vec())),
+                sum: Some(CryptoKeySum::Ed25519(info.public_key().as_bytes().to_vec())),
             }),
             voting_power,
             proposer_priority: 0,
         };
-        (pubkey, validator)
+        (*info.public_key(), validator)
     }
 
     #[test]
@@ -403,9 +399,36 @@ mod tests {
         };
 
         let set = ValidatorSet::try_from((&proto_set, 7)).unwrap();
-        assert_eq!(set.height(), 7);
+        assert_eq!(set.height().get(), 7);
         assert_eq!(set.total_voting_power(), 100);
         assert_eq!(set.validators().len(), 1);
+    }
+
+    #[test]
+    fn validator_set_from_proto_ignores_total_power() {
+        let (_, validator) = proto_validator(100);
+        let proto_set = tendermint_proto::v0_38::types::ValidatorSet {
+            validators: vec![validator.clone()],
+            proposer: Some(validator),
+            total_voting_power: 101,
+        };
+
+        let set = ValidatorSet::try_from((&proto_set, 7)).unwrap();
+        assert_eq!(set.total_voting_power(), 100);
+    }
+
+    #[test]
+    fn validator_set_from_proto_matches_proposer_by_address() {
+        let (_, validator) = proto_validator(100);
+        let mut proposer = validator.clone();
+        proposer.voting_power = 99;
+        let proto_set = tendermint_proto::v0_38::types::ValidatorSet {
+            validators: vec![validator],
+            proposer: Some(proposer),
+            total_voting_power: 0,
+        };
+
+        assert!(ValidatorSet::try_from((&proto_set, 7)).is_ok());
     }
 
     #[test]

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -17,7 +17,7 @@ use tendermint_proto::v0_38::crypto::public_key::Sum as CryptoKeySum;
 use crate::error::FibreError;
 use crate::payment_promise::PaymentPromise;
 #[cfg(test)]
-use crate::validator::ValidatorInfo;
+use crate::validator::{ValidatorInfo, ValidatorSet};
 use crate::validator_client::DownloadResponse;
 
 impl From<&PaymentPromise> for proto::PaymentPromise {
@@ -341,48 +341,89 @@ mod tests {
         assert_eq!(diff.as_nanos(), 0);
     }
 
-    #[test]
-    fn validator_from_proto_valid() {
-        // Generate a random ed25519 key using raw bytes
+    fn proto_validator(
+        voting_power: i64,
+    ) -> (
+        ed25519_dalek::VerifyingKey,
+        tendermint_proto::v0_38::types::Validator,
+    ) {
+        use sha2::{Digest, Sha256};
+
         let mut secret = [0u8; 32];
         rand::RngCore::fill_bytes(&mut OsRng, &mut secret);
-        let sk = ed25519_dalek::SigningKey::from_bytes(&secret);
-        let pk = sk.verifying_key();
-
-        let proto_val = tendermint_proto::v0_38::types::Validator {
-            address: vec![0u8; 20], // not used in conversion (derived from pubkey)
+        let pubkey = ed25519_dalek::SigningKey::from_bytes(&secret).verifying_key();
+        let address = Sha256::digest(pubkey.as_bytes())[..20].to_vec();
+        let validator = tendermint_proto::v0_38::types::Validator {
+            address,
             pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
-                sum: Some(CryptoKeySum::Ed25519(pk.as_bytes().to_vec())),
+                sum: Some(CryptoKeySum::Ed25519(pubkey.as_bytes().to_vec())),
             }),
-            voting_power: 100,
+            voting_power,
             proposer_priority: 0,
         };
+        (pubkey, validator)
+    }
+
+    #[test]
+    fn validator_from_proto_valid() {
+        let (pubkey, proto_val) = proto_validator(100);
 
         let info = ValidatorInfo::try_from(&proto_val).unwrap();
-        assert_eq!(info.pubkey, pk);
-        assert_eq!(info.voting_power, 100);
-        // Verify address is derived from pubkey
-        use sha2::{Digest, Sha256};
-        let expected_addr: [u8; 20] = Sha256::digest(pk.as_bytes())[..20].try_into().unwrap();
-        assert_eq!(info.address, expected_addr);
+        assert_eq!(info.public_key(), &pubkey);
+        assert_eq!(info.voting_power(), 100);
+        assert_eq!(info.address().as_slice(), proto_val.address);
     }
 
     #[test]
     fn validator_from_proto_negative_power() {
-        let mut secret = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut OsRng, &mut secret);
-        let pk = ed25519_dalek::SigningKey::from_bytes(&secret).verifying_key();
+        let (_, proto_val) = proto_validator(-1);
+        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+    }
 
-        let proto_val = tendermint_proto::v0_38::types::Validator {
-            address: vec![0u8; 20],
-            pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
-                sum: Some(CryptoKeySum::Ed25519(pk.as_bytes().to_vec())),
-            }),
-            voting_power: -1,
-            proposer_priority: 0,
+    #[test]
+    fn validator_from_proto_zero_power() {
+        let (_, proto_val) = proto_validator(0);
+        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+    }
+
+    #[test]
+    fn validator_from_proto_mismatched_address() {
+        let (_, mut proto_val) = proto_validator(1);
+        proto_val.address = vec![0; 20];
+        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+    }
+
+    #[test]
+    fn validator_set_from_proto_valid() {
+        let (_, validator) = proto_validator(100);
+        let proto_set = tendermint_proto::v0_38::types::ValidatorSet {
+            validators: vec![validator.clone()],
+            proposer: Some(validator),
+            total_voting_power: 100,
         };
 
-        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+        let set = ValidatorSet::try_from((&proto_set, 7)).unwrap();
+        assert_eq!(set.height(), 7);
+        assert_eq!(set.total_voting_power(), 100);
+        assert_eq!(set.validators().len(), 1);
+    }
+
+    #[test]
+    fn validator_set_from_proto_missing_proposer() {
+        let (_, validator) = proto_validator(100);
+        let proto_set = tendermint_proto::v0_38::types::ValidatorSet {
+            validators: vec![validator],
+            proposer: None,
+            total_voting_power: 100,
+        };
+
+        assert!(ValidatorSet::try_from((&proto_set, 7)).is_err());
+    }
+
+    #[test]
+    fn validator_set_from_proto_empty() {
+        let proto_set = tendermint_proto::v0_38::types::ValidatorSet::default();
+        assert!(ValidatorSet::try_from((&proto_set, 1)).is_err());
     }
 
     #[test]

--- a/fibre/src/validator/mod.rs
+++ b/fibre/src/validator/mod.rs
@@ -102,7 +102,11 @@ impl ValidatorSet {
         min_rows: usize,
         liveness_threshold: Fraction,
     ) -> ShardMap {
-        if self.validators.is_empty() || total_rows == 0 || min_rows == 0 {
+        if self.validators.is_empty()
+            || total_rows == 0
+            || min_rows == 0
+            || self.total_voting_power() <= 0
+        {
             return ShardMap::new(HashMap::new());
         }
 
@@ -128,7 +132,7 @@ impl ValidatorSet {
 
     /// Selects validators for shard download, ordered by priority.
     ///
-    /// Returns ordered `(validator_index, expected_rows)` pairs. Higher-stake
+    /// Returns ordered `(expected_rows, validator)` pairs. Higher-stake
     /// validators come first (priority group), followed by the tail group.
     /// Both groups are shuffled weighted by stake.
     pub fn select(
@@ -137,7 +141,7 @@ impl ValidatorSet {
         min_rows: usize,
         liveness_threshold: Fraction,
     ) -> Vec<(usize, &ValidatorInfo)> {
-        if self.validators.is_empty() {
+        if self.validators.is_empty() || self.total_voting_power() <= 0 {
             return Vec::new();
         }
 
@@ -274,6 +278,13 @@ impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
                 .expect("sha256 output is always 32 bytes")
         };
 
+        if proto_val.voting_power < 0 {
+            return Err(FibreError::InvalidData(format!(
+                "validator has negative voting power: {}",
+                proto_val.voting_power
+            )));
+        }
+
         Ok(ValidatorInfo {
             address,
             pubkey,
@@ -376,6 +387,13 @@ mod assignment_tests {
     fn zero_min_rows_returns_empty_map() {
         let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
         let map = set.assign([0u8; 32], 100, 50, 0, default_liveness());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn zero_voting_power_returns_empty_map() {
+        let set = ValidatorSet::new(vec![make_validator(0, 1), make_validator(0, 2)], 0);
+        let map = set.assign([0u8; 32], 100, 50, 10, default_liveness());
         assert!(map.is_empty());
     }
 
@@ -609,6 +627,13 @@ mod selection_tests {
     #[test]
     fn empty_validators_returns_empty() {
         let set = ValidatorSet::new(vec![], 0);
+        let selected = set.select(100, 10, default_liveness());
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn zero_voting_power_returns_empty() {
+        let set = ValidatorSet::new(vec![make_validator(0, 1), make_validator(0, 2)], 0);
         let selected = set.select(100, 10, default_liveness());
         assert!(selected.is_empty());
     }

--- a/fibre/src/validator/mod.rs
+++ b/fibre/src/validator/mod.rs
@@ -96,13 +96,15 @@ pub struct ValidatorSet {
     /// The validators in this set.
     validators: Vec<ValidatorInfo>,
     /// The block height at which this validator set is valid.
-    height: u64,
+    height: NonZeroU64,
     total_voting_power: u64,
 }
 
 impl ValidatorSet {
     /// Creates a validated validator set at the given height.
     pub fn try_new(validators: Vec<ValidatorInfo>, height: u64) -> Result<Self, FibreError> {
+        let height = NonZeroU64::new(height)
+            .ok_or_else(|| FibreError::InvalidData("validator set has zero height".into()))?;
         if validators.is_empty() {
             return Err(FibreError::InvalidData("validator set is empty".into()));
         }
@@ -116,9 +118,9 @@ impl ValidatorSet {
                     validator.address_hex()
                 )));
             }
-            total_voting_power = total_voting_power
-                .checked_add(validator.voting_power())
-                .ok_or_else(|| FibreError::InvalidData("validator voting power overflow".into()))?;
+            // Cannot overflow: each addend and the running total are capped at
+            // `MAX_TOTAL_VOTING_POWER`.
+            total_voting_power += validator.voting_power();
             if total_voting_power > MAX_TOTAL_VOTING_POWER {
                 return Err(FibreError::InvalidData(format!(
                     "total voting power {total_voting_power} exceeds maximum {MAX_TOTAL_VOTING_POWER}"
@@ -139,7 +141,7 @@ impl ValidatorSet {
     }
 
     /// Returns the height at which this validator set is valid.
-    pub fn height(&self) -> u64 {
+    pub fn height(&self) -> NonZeroU64 {
         self.height
     }
 
@@ -164,7 +166,7 @@ impl ValidatorSet {
                     * (liveness_threshold.denominator.get() as u128);
                 let den =
                     (total_voting_power as u128) * (liveness_threshold.numerator.get() as u128);
-                let rows = num.div_ceil(den).min(original_rows as u128) as usize;
+                let rows = usize::try_from(num.div_ceil(den)).unwrap_or(original_rows);
                 (rows.max(min_rows).min(original_rows), v)
             })
             .collect()
@@ -214,12 +216,16 @@ impl ValidatorSet {
         min_rows: usize,
         liveness_threshold: Fraction,
     ) -> Vec<(usize, &ValidatorInfo)> {
-        let mut rpv = self.rows_per_validator(original_rows, min_rows, liveness_threshold);
-
-        let total_voting_power = self.total_voting_power();
         let total_distributed_rows = (original_rows as u128)
             * (liveness_threshold.denominator.get() as u128)
             / (liveness_threshold.numerator.get() as u128);
+        if total_distributed_rows == 0 {
+            return Vec::new();
+        }
+
+        let mut rpv = self.rows_per_validator(original_rows, min_rows, liveness_threshold);
+
+        let total_voting_power = self.total_voting_power();
         let min_stake = ((min_rows as u128) * (total_voting_power as u128))
             .div_ceil(total_distributed_rows) as u64;
 
@@ -241,26 +247,19 @@ impl ValidatorSet {
 }
 
 #[cfg(test)]
-impl ValidatorSet {
-    fn new(validators: Vec<ValidatorInfo>, height: u64) -> Self {
-        Self::try_new(validators, height).unwrap()
-    }
-}
-
-#[cfg(test)]
 mod validation_tests {
     use super::*;
+    use crate::test_utils::make_validator;
     use ed25519_dalek::SigningKey;
-
-    fn validator(power: u64, seed: u8) -> ValidatorInfo {
-        let mut key_bytes = [0u8; 32];
-        key_bytes[0] = seed;
-        ValidatorInfo::try_new(SigningKey::from_bytes(&key_bytes).verifying_key(), power).unwrap()
-    }
 
     #[test]
     fn rejects_empty_set() {
-        assert!(ValidatorSet::try_new(vec![], 0).is_err());
+        assert!(ValidatorSet::try_new(vec![], 1).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_height() {
+        assert!(ValidatorSet::try_new(vec![make_validator(1, 1).1], 0).is_err());
     }
 
     #[test]
@@ -277,14 +276,17 @@ mod validation_tests {
 
     #[test]
     fn rejects_total_power_above_cometbft_limit() {
-        let validators = vec![validator(MAX_TOTAL_VOTING_POWER, 1), validator(1, 2)];
-        assert!(ValidatorSet::try_new(validators, 0).is_err());
+        let validators = vec![
+            make_validator(MAX_TOTAL_VOTING_POWER, 1).1,
+            make_validator(1, 2).1,
+        ];
+        assert!(ValidatorSet::try_new(validators, 1).is_err());
     }
 
     #[test]
     fn rejects_duplicate_validator() {
-        let validator = validator(1, 1);
-        assert!(ValidatorSet::try_new(vec![validator.clone(), validator], 0).is_err());
+        let validator = make_validator(1, 1).1;
+        assert!(ValidatorSet::try_new(vec![validator.clone(), validator], 1).is_err());
     }
 }
 
@@ -315,11 +317,6 @@ impl GrpcSetGetter {
         let height = u64::try_from(resp.height).map_err(|_| {
             FibreError::InvalidData(format!("validator set has invalid height {}", resp.height))
         })?;
-        if height == 0 {
-            return Err(FibreError::InvalidData(
-                "validator set has zero height".into(),
-            ));
-        }
 
         let proto_set = resp.validator_set.ok_or_else(|| {
             FibreError::InvalidData("ValidatorSetResponse missing validator_set".into())
@@ -338,7 +335,7 @@ impl SetGetter for GrpcSetGetter {
 
     async fn get_by_height(&self, height: u64) -> Result<ValidatorSet, FibreError> {
         if height == 0 {
-            return Err(FibreError::Other(
+            return Err(FibreError::InvalidData(
                 "get_by_height requires height > 0".into(),
             ));
         }
@@ -414,20 +411,6 @@ impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
             })?)
             .map_err(|e| FibreError::InvalidData(format!("invalid ed25519 key: {e}")))?;
 
-        let address = validator_address(&pubkey);
-
-        let proto_address: [u8; 20] = proto_val.address.as_slice().try_into().map_err(|_| {
-            FibreError::InvalidData(format!(
-                "validator address has invalid length {}, expected 20",
-                proto_val.address.len()
-            ))
-        })?;
-        if proto_address != address {
-            return Err(FibreError::InvalidData(
-                "validator address does not match public key".into(),
-            ));
-        }
-
         let voting_power = u64::try_from(proto_val.voting_power).map_err(|_| {
             FibreError::InvalidData(format!(
                 "validator has negative voting power: {}",
@@ -435,7 +418,14 @@ impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
             ))
         })?;
 
-        ValidatorInfo::try_new(pubkey, voting_power)
+        let info = ValidatorInfo::try_new(pubkey, voting_power)?;
+        if proto_val.address != info.address {
+            return Err(FibreError::InvalidData(
+                "validator address does not match public key".into(),
+            ));
+        }
+
+        Ok(info)
     }
 }
 
@@ -505,36 +495,25 @@ fn shuffle_by_stake(selected: &mut [(usize, &ValidatorInfo)], rng: &mut impl Rng
 #[cfg(test)]
 mod assignment_tests {
     use super::*;
-    use ed25519_dalek::SigningKey;
-
-    fn make_validator(power: u64, seed: u8) -> ValidatorInfo {
-        let mut key_bytes = [0u8; 32];
-        key_bytes[0] = seed;
-        let signing_key = SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo::try_new(signing_key.verifying_key(), power).unwrap()
-    }
-
-    fn default_liveness() -> Fraction {
-        crate::test_utils::fraction(1, 3)
-    }
+    use crate::test_utils::{fraction, make_validator};
 
     #[test]
     fn zero_total_rows_returns_empty_map() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
-        let map = set.assign([0u8; 32], 0, 50, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(100, 1).1], 1).unwrap();
+        let map = set.assign([0u8; 32], 0, 50, 10, fraction(1, 3));
         assert!(map.is_empty());
     }
 
     #[test]
     fn zero_min_rows_returns_empty_map() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
-        let map = set.assign([0u8; 32], 100, 50, 0, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(100, 1).1], 1).unwrap();
+        let map = set.assign([0u8; 32], 100, 50, 0, fraction(1, 3));
         assert!(map.is_empty());
     }
 
     #[test]
     fn single_validator_gets_original_rows() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
+        let set = ValidatorSet::try_new(vec![make_validator(100, 1).1], 1).unwrap();
         let commitment = [0u8; 32];
         let total_rows = 200;
         let original_rows = 100;
@@ -545,7 +524,7 @@ mod assignment_tests {
             total_rows,
             original_rows,
             min_rows,
-            default_liveness(),
+            fraction(1, 3),
         );
 
         assert_eq!(map.len(), 1);
@@ -554,8 +533,9 @@ mod assignment_tests {
 
     #[test]
     fn two_equal_stake_validators_get_equal_rows() {
-        let set = ValidatorSet::new(vec![make_validator(50, 1), make_validator(50, 2)], 0);
-        let map = set.assign([1u8; 32], 200, 100, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(50, 1).1, make_validator(50, 2).1], 1)
+            .unwrap();
+        let map = set.assign([1u8; 32], 200, 100, 10, fraction(1, 3));
 
         assert_eq!(map.len(), 2);
         assert_eq!(map.get(0).unwrap().len(), map.get(1).unwrap().len());
@@ -563,45 +543,48 @@ mod assignment_tests {
 
     #[test]
     fn rows_per_validator_respects_min_rows_floor() {
-        let set = ValidatorSet::new(vec![make_validator(1, 1), make_validator(999, 2)], 0);
-        let map = set.assign([2u8; 32], 200, 100, 50, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(1, 1).1, make_validator(999, 2).1], 1)
+            .unwrap();
+        let map = set.assign([2u8; 32], 200, 100, 50, fraction(1, 3));
         assert_eq!(map.get(0).unwrap().len(), 50);
     }
 
     #[test]
     fn rows_per_validator_respects_original_rows_ceiling() {
-        let set = ValidatorSet::new(vec![make_validator(1000, 1)], 0);
-        let map = set.assign([3u8; 32], 200, 100, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(1000, 1).1], 1).unwrap();
+        let map = set.assign([3u8; 32], 200, 100, 10, fraction(1, 3));
         assert_eq!(map.get(0).unwrap().len(), 100);
     }
 
     #[test]
     fn assignment_is_deterministic() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(50, 1),
-                make_validator(30, 2),
-                make_validator(20, 3),
+                make_validator(50, 1).1,
+                make_validator(30, 2).1,
+                make_validator(20, 3).1,
             ],
-            0,
-        );
-        let map1 = set.assign([42u8; 32], 200, 100, 10, default_liveness());
-        let map2 = set.assign([42u8; 32], 200, 100, 10, default_liveness());
+            1,
+        )
+        .unwrap();
+        let map1 = set.assign([42u8; 32], 200, 100, 10, fraction(1, 3));
+        let map2 = set.assign([42u8; 32], 200, 100, 10, fraction(1, 3));
         assert_eq!(map1, map2);
     }
 
     #[test]
     fn different_commitments_produce_different_assignments() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(50, 1),
-                make_validator(30, 2),
-                make_validator(20, 3),
+                make_validator(50, 1).1,
+                make_validator(30, 2).1,
+                make_validator(20, 3).1,
             ],
-            0,
-        );
-        let map1 = set.assign([1u8; 32], 200, 100, 10, default_liveness());
-        let map2 = set.assign([2u8; 32], 200, 100, 10, default_liveness());
+            1,
+        )
+        .unwrap();
+        let map1 = set.assign([1u8; 32], 200, 100, 10, fraction(1, 3));
+        let map2 = set.assign([2u8; 32], 200, 100, 10, fraction(1, 3));
 
         for i in 0..set.validators.len() {
             assert_eq!(map1.get(i).unwrap().len(), map2.get(i).unwrap().len());
@@ -611,24 +594,26 @@ mod assignment_tests {
 
     #[test]
     fn shard_map_verify_correct() {
-        let set = ValidatorSet::new(vec![make_validator(50, 1), make_validator(50, 2)], 0);
-        let map = set.assign([10u8; 32], 200, 100, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(50, 1).1, make_validator(50, 2).1], 1)
+            .unwrap();
+        let map = set.assign([10u8; 32], 200, 100, 10, fraction(1, 3));
         let row_indices_u32: Vec<u32> = map.get(0).unwrap().iter().map(|&r| r as u32).collect();
         assert!(map.verify(0, &row_indices_u32).is_ok());
     }
 
     #[test]
     fn shard_map_verify_wrong_count() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
-        let map = set.assign([11u8; 32], 200, 100, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(100, 1).1], 1).unwrap();
+        let map = set.assign([11u8; 32], 200, 100, 10, fraction(1, 3));
         assert!(map.verify(0, &[0, 1, 2]).is_err());
     }
 
     #[test]
     fn shard_map_verify_wrong_row() {
-        let set = ValidatorSet::new(vec![make_validator(50, 1), make_validator(50, 2)], 0);
+        let set = ValidatorSet::try_new(vec![make_validator(50, 1).1, make_validator(50, 2).1], 1)
+            .unwrap();
         let total_rows = 200;
-        let map = set.assign([12u8; 32], total_rows, 100, 10, default_liveness());
+        let map = set.assign([12u8; 32], total_rows, 100, 10, fraction(1, 3));
 
         let mut wrong_indices: Vec<u32> = map.get(0).unwrap().iter().map(|&r| r as u32).collect();
         wrong_indices[0] = (total_rows + 999) as u32;
@@ -637,22 +622,23 @@ mod assignment_tests {
 
     #[test]
     fn shard_map_verify_missing_validator() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
-        let map = set.assign([13u8; 32], 200, 100, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![make_validator(100, 1).1], 1).unwrap();
+        let map = set.assign([13u8; 32], 200, 100, 10, fraction(1, 3));
         assert!(map.verify(5, &[0]).is_err());
     }
 
     #[test]
     fn total_assigned_rows_across_validators() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(40, 1),
-                make_validator(35, 2),
-                make_validator(25, 3),
+                make_validator(40, 1).1,
+                make_validator(35, 2).1,
+                make_validator(25, 3).1,
             ],
-            0,
-        );
-        let map = set.assign([20u8; 32], 200, 100, 10, default_liveness());
+            1,
+        )
+        .unwrap();
+        let map = set.assign([20u8; 32], 200, 100, 10, fraction(1, 3));
 
         let total_assigned: usize = (0..set.validators.len())
             .map(|i| map.get(i).unwrap().len())
@@ -698,14 +684,15 @@ mod assignment_tests {
 
     #[test]
     fn cross_language_assign_matches_go() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(300, 1),
-                make_validator(200, 2),
-                make_validator(100, 3),
+                make_validator(300, 1).1,
+                make_validator(200, 2).1,
+                make_validator(100, 3).1,
             ],
-            0,
-        );
+            1,
+        )
+        .unwrap();
         let mut commitment = [0u8; 32];
         for (i, byte) in commitment.iter_mut().enumerate() {
             *byte = (i + 1) as u8;
@@ -720,16 +707,17 @@ mod assignment_tests {
 
     #[test]
     fn all_row_indices_within_bounds() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(50, 1),
-                make_validator(30, 2),
-                make_validator(20, 3),
+                make_validator(50, 1).1,
+                make_validator(30, 2).1,
+                make_validator(20, 3).1,
             ],
-            0,
-        );
+            1,
+        )
+        .unwrap();
         let total_rows = 200;
-        let map = set.assign([30u8; 32], total_rows, 100, 10, default_liveness());
+        let map = set.assign([30u8; 32], total_rows, 100, 10, fraction(1, 3));
 
         for i in 0..set.validators.len() {
             for &row_idx in map.get(i).unwrap() {
@@ -742,25 +730,14 @@ mod assignment_tests {
 #[cfg(test)]
 mod selection_tests {
     use super::*;
-    use ed25519_dalek::SigningKey;
-
-    fn make_validator(power: u64, seed: u8) -> ValidatorInfo {
-        let mut key_bytes = [0u8; 32];
-        key_bytes[0] = seed;
-        let signing_key = SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo::try_new(signing_key.verifying_key(), power).unwrap()
-    }
-
-    fn default_liveness() -> Fraction {
-        crate::test_utils::fraction(1, 3)
-    }
+    use crate::test_utils::{fraction, make_validator};
 
     #[test]
     fn single_validator_returns_one() {
-        let validator = make_validator(100, 1);
+        let validator = make_validator(100, 1).1;
         let expected_address = validator.address;
-        let set = ValidatorSet::new(vec![validator], 0);
-        let selected = set.select(100, 10, default_liveness());
+        let set = ValidatorSet::try_new(vec![validator], 1).unwrap();
+        let selected = set.select(100, 10, fraction(1, 3));
         assert_eq!(selected.len(), 1);
         assert!(selected[0].0 > 0);
         assert_eq!(selected[0].1.address, expected_address);
@@ -769,17 +746,17 @@ mod selection_tests {
     #[test]
     fn multiple_validators_returns_all() {
         let validators = vec![
-            make_validator(100, 1),
-            make_validator(100, 2),
-            make_validator(100, 3),
+            make_validator(100, 1).1,
+            make_validator(100, 2).1,
+            make_validator(100, 3).1,
         ];
         let mut expected: Vec<_> = validators
             .iter()
             .map(|validator| validator.address)
             .collect();
         expected.sort();
-        let set = ValidatorSet::new(validators, 0);
-        let selected = set.select(100, 10, default_liveness());
+        let set = ValidatorSet::try_new(validators, 1).unwrap();
+        let selected = set.select(100, 10, fraction(1, 3));
         assert_eq!(selected.len(), 3);
 
         let mut actual: Vec<_> = selected.iter().map(|(_, info)| info.address).collect();
@@ -789,39 +766,42 @@ mod selection_tests {
 
     #[test]
     fn split_idx_separates_groups_correctly() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(150, 1),
-                make_validator(100, 2),
-                make_validator(50, 3),
+                make_validator(150, 1).1,
+                make_validator(100, 2).1,
+                make_validator(50, 3).1,
             ],
-            0,
-        );
-        let selected = set.select(100, 10, default_liveness());
+            1,
+        )
+        .unwrap();
+        let selected = set.select(100, 10, fraction(1, 3));
         assert_eq!(selected.len(), 3);
     }
 
     #[test]
     fn split_idx_with_high_min_rows() {
-        let set = ValidatorSet::new((0..10).map(|i| make_validator(10, i as u8)).collect(), 0);
-        let selected = set.select(100, 50, default_liveness());
+        let set =
+            ValidatorSet::try_new((0..10).map(|i| make_validator(10, i as u8).1).collect(), 1)
+                .unwrap();
+        let selected = set.select(100, 50, fraction(1, 3));
         assert_eq!(selected.len(), 10);
     }
 
     #[test]
     fn all_validators_present_in_result() {
         let validators = vec![
-            make_validator(50, 1),
-            make_validator(30, 2),
-            make_validator(20, 3),
+            make_validator(50, 1).1,
+            make_validator(30, 2).1,
+            make_validator(20, 3).1,
         ];
         let mut expected: Vec<_> = validators
             .iter()
             .map(|validator| validator.address)
             .collect();
         expected.sort();
-        let set = ValidatorSet::new(validators, 0);
-        let selected = set.select(100, 10, default_liveness());
+        let set = ValidatorSet::try_new(validators, 1).unwrap();
+        let selected = set.select(100, 10, fraction(1, 3));
 
         assert_eq!(selected.len(), 3);
         let mut actual: Vec<_> = selected.iter().map(|(_, info)| info.address).collect();
@@ -836,16 +816,16 @@ mod selection_tests {
 
         for _ in 0..trials {
             let validators = vec![
-                make_validator(100, 1),
-                make_validator(10, 2),
-                make_validator(10, 3),
+                make_validator(100, 1).1,
+                make_validator(10, 2).1,
+                make_validator(10, 3).1,
             ];
             let addresses: Vec<_> = validators
                 .iter()
                 .map(|validator| validator.address)
                 .collect();
-            let set = ValidatorSet::new(validators, 0);
-            let selected = set.select(100, 10, default_liveness());
+            let set = ValidatorSet::try_new(validators, 1).unwrap();
+            let selected = set.select(100, 10, fraction(1, 3));
             let first = addresses
                 .iter()
                 .position(|address| address == &selected[0].1.address)
@@ -859,15 +839,16 @@ mod selection_tests {
 
     #[test]
     fn select_expected_rows_match_assign() {
-        let set = ValidatorSet::new(
+        let set = ValidatorSet::try_new(
             vec![
-                make_validator(300, 1),
-                make_validator(200, 2),
-                make_validator(100, 3),
+                make_validator(300, 1).1,
+                make_validator(200, 2).1,
+                make_validator(100, 3).1,
             ],
-            0,
-        );
-        let liveness = default_liveness();
+            1,
+        )
+        .unwrap();
+        let liveness = fraction(1, 3);
         let original_rows = 100;
         let min_rows = 10;
 

--- a/fibre/src/validator/mod.rs
+++ b/fibre/src/validator/mod.rs
@@ -3,7 +3,8 @@
 pub(crate) mod shard_map;
 pub(crate) mod signature_set;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU64;
 
 use chacha8rand::ChaCha8Rand;
 use ed25519_dalek::VerifyingKey as Ed25519PublicKey;
@@ -16,18 +17,55 @@ use celestia_grpc::GrpcClient;
 
 pub(crate) use shard_map::ShardMap;
 
+/// Maximum total voting power accepted by CometBFT.
+const MAX_TOTAL_VOTING_POWER: u64 = (i64::MAX / 8) as u64;
+
 /// A validator's identity and stake information.
 #[derive(Debug, Clone)]
 pub struct ValidatorInfo {
     /// The validator's consensus address (20-byte CometBFT address).
-    pub address: [u8; 20],
+    pub(crate) address: [u8; 20],
     /// The validator's ed25519 public key for signing.
-    pub pubkey: Ed25519PublicKey,
+    pub(crate) pubkey: Ed25519PublicKey,
     /// The validator's voting power (stake weight).
-    pub voting_power: i64,
+    voting_power: NonZeroU64,
 }
 
 impl ValidatorInfo {
+    /// Creates validator information from an ed25519 public key and voting power.
+    pub fn try_new(pubkey: Ed25519PublicKey, voting_power: u64) -> Result<Self, FibreError> {
+        let voting_power = NonZeroU64::new(voting_power)
+            .ok_or_else(|| FibreError::InvalidData("validator has zero voting power".into()))?;
+        if voting_power.get() > MAX_TOTAL_VOTING_POWER {
+            return Err(FibreError::InvalidData(format!(
+                "validator voting power {} exceeds maximum {MAX_TOTAL_VOTING_POWER}",
+                voting_power.get()
+            )));
+        }
+
+        let address = validator_address(&pubkey);
+        Ok(Self {
+            address,
+            pubkey,
+            voting_power,
+        })
+    }
+
+    /// Returns the validator's consensus address.
+    pub fn address(&self) -> &[u8; 20] {
+        &self.address
+    }
+
+    /// Returns the validator's ed25519 public key.
+    pub fn public_key(&self) -> &Ed25519PublicKey {
+        &self.pubkey
+    }
+
+    /// Returns the validator's voting power.
+    pub fn voting_power(&self) -> u64 {
+        self.voting_power.get()
+    }
+
     /// Returns the validator address as an uppercase hex string.
     pub fn address_hex(&self) -> String {
         hex::encode_upper(self.address)
@@ -56,20 +94,58 @@ impl std::hash::Hash for ValidatorInfo {
 #[derive(Debug, Clone)]
 pub struct ValidatorSet {
     /// The validators in this set.
-    pub validators: Vec<ValidatorInfo>,
+    validators: Vec<ValidatorInfo>,
     /// The block height at which this validator set is valid.
-    pub height: u64,
+    height: u64,
+    total_voting_power: u64,
 }
 
 impl ValidatorSet {
-    /// Creates a validator set at the given height.
-    pub fn new(validators: Vec<ValidatorInfo>, height: u64) -> Self {
-        Self { validators, height }
+    /// Creates a validated validator set at the given height.
+    pub fn try_new(validators: Vec<ValidatorInfo>, height: u64) -> Result<Self, FibreError> {
+        if validators.is_empty() {
+            return Err(FibreError::InvalidData("validator set is empty".into()));
+        }
+
+        let mut addresses = HashSet::with_capacity(validators.len());
+        let mut total_voting_power = 0u64;
+        for validator in &validators {
+            if !addresses.insert(validator.address) {
+                return Err(FibreError::InvalidData(format!(
+                    "validator set contains duplicate address {}",
+                    validator.address_hex()
+                )));
+            }
+            total_voting_power = total_voting_power
+                .checked_add(validator.voting_power())
+                .ok_or_else(|| FibreError::InvalidData("validator voting power overflow".into()))?;
+            if total_voting_power > MAX_TOTAL_VOTING_POWER {
+                return Err(FibreError::InvalidData(format!(
+                    "total voting power {total_voting_power} exceeds maximum {MAX_TOTAL_VOTING_POWER}"
+                )));
+            }
+        }
+
+        Ok(Self {
+            validators,
+            height,
+            total_voting_power,
+        })
+    }
+
+    /// Returns the validators in set order.
+    pub fn validators(&self) -> &[ValidatorInfo] {
+        &self.validators
+    }
+
+    /// Returns the height at which this validator set is valid.
+    pub fn height(&self) -> u64 {
+        self.height
     }
 
     /// Returns the total voting power of all validators in the set.
-    pub fn total_voting_power(&self) -> i64 {
-        self.validators.iter().map(|v| v.voting_power).sum()
+    pub fn total_voting_power(&self) -> u64 {
+        self.total_voting_power
     }
 
     /// Computes the number of rows each validator should store based on stake.
@@ -83,11 +159,12 @@ impl ValidatorSet {
         self.validators
             .iter()
             .map(|v| {
-                let num = (original_rows as i64)
-                    * v.voting_power
-                    * (liveness_threshold.denominator.get() as i64);
-                let den = total_voting_power * (liveness_threshold.numerator.get() as i64);
-                let rows = ((num + den - 1) / den) as usize;
+                let num = (original_rows as u128)
+                    * (v.voting_power() as u128)
+                    * (liveness_threshold.denominator.get() as u128);
+                let den =
+                    (total_voting_power as u128) * (liveness_threshold.numerator.get() as u128);
+                let rows = num.div_ceil(den).min(original_rows as u128) as usize;
                 (rows.max(min_rows).min(original_rows), v)
             })
             .collect()
@@ -102,11 +179,7 @@ impl ValidatorSet {
         min_rows: usize,
         liveness_threshold: Fraction,
     ) -> ShardMap {
-        if self.validators.is_empty()
-            || total_rows == 0
-            || min_rows == 0
-            || self.total_voting_power() <= 0
-        {
+        if total_rows == 0 || min_rows == 0 {
             return ShardMap::new(HashMap::new());
         }
 
@@ -141,24 +214,20 @@ impl ValidatorSet {
         min_rows: usize,
         liveness_threshold: Fraction,
     ) -> Vec<(usize, &ValidatorInfo)> {
-        if self.validators.is_empty() || self.total_voting_power() <= 0 {
-            return Vec::new();
-        }
-
         let mut rpv = self.rows_per_validator(original_rows, min_rows, liveness_threshold);
 
         let total_voting_power = self.total_voting_power();
-        let total_distributed_rows = (original_rows as i64)
-            * (liveness_threshold.denominator.get() as i64)
-            / (liveness_threshold.numerator.get() as i64);
-        let min_stake = ((min_rows as i64) * total_voting_power + total_distributed_rows - 1)
-            / total_distributed_rows;
+        let total_distributed_rows = (original_rows as u128)
+            * (liveness_threshold.denominator.get() as u128)
+            / (liveness_threshold.numerator.get() as u128);
+        let min_stake = ((min_rows as u128) * (total_voting_power as u128))
+            .div_ceil(total_distributed_rows) as u64;
 
-        let mut accumulated: i64 = 0;
+        let mut accumulated: u128 = 0;
         let mut split_idx = self.validators.len();
         for (i, validator) in self.validators.iter().enumerate() {
-            accumulated += validator.voting_power.max(min_stake);
-            if accumulated > total_voting_power {
+            accumulated += validator.voting_power().max(min_stake) as u128;
+            if accumulated > total_voting_power as u128 {
                 split_idx = i;
                 break;
             }
@@ -168,6 +237,54 @@ impl ValidatorSet {
         shuffle_by_stake(&mut rpv[..split_idx], &mut rng);
         shuffle_by_stake(&mut rpv[split_idx..], &mut rng);
         rpv
+    }
+}
+
+#[cfg(test)]
+impl ValidatorSet {
+    fn new(validators: Vec<ValidatorInfo>, height: u64) -> Self {
+        Self::try_new(validators, height).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn validator(power: u64, seed: u8) -> ValidatorInfo {
+        let mut key_bytes = [0u8; 32];
+        key_bytes[0] = seed;
+        ValidatorInfo::try_new(SigningKey::from_bytes(&key_bytes).verifying_key(), power).unwrap()
+    }
+
+    #[test]
+    fn rejects_empty_set() {
+        assert!(ValidatorSet::try_new(vec![], 0).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_power() {
+        let key = SigningKey::from_bytes(&[1; 32]);
+        assert!(ValidatorInfo::try_new(key.verifying_key(), 0).is_err());
+    }
+
+    #[test]
+    fn rejects_power_above_cometbft_limit() {
+        let key = SigningKey::from_bytes(&[1; 32]);
+        assert!(ValidatorInfo::try_new(key.verifying_key(), MAX_TOTAL_VOTING_POWER + 1).is_err());
+    }
+
+    #[test]
+    fn rejects_total_power_above_cometbft_limit() {
+        let validators = vec![validator(MAX_TOTAL_VOTING_POWER, 1), validator(1, 2)];
+        assert!(ValidatorSet::try_new(validators, 0).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_validator() {
+        let validator = validator(1, 1);
+        assert!(ValidatorSet::try_new(vec![validator.clone(), validator], 0).is_err());
     }
 }
 
@@ -195,10 +312,17 @@ impl GrpcSetGetter {
     async fn get_by_height_inner(&self, height: i64) -> Result<ValidatorSet, FibreError> {
         let resp = self.client.get_fibre_validator_set(height).await?;
 
-        let height = resp.height as u64;
+        let height = u64::try_from(resp.height).map_err(|_| {
+            FibreError::InvalidData(format!("validator set has invalid height {}", resp.height))
+        })?;
+        if height == 0 {
+            return Err(FibreError::InvalidData(
+                "validator set has zero height".into(),
+            ));
+        }
 
         let proto_set = resp.validator_set.ok_or_else(|| {
-            FibreError::Other("ValidatorSetResponse missing validator_set".into())
+            FibreError::InvalidData("ValidatorSetResponse missing validator_set".into())
         })?;
 
         (&proto_set, height).try_into()
@@ -218,7 +342,9 @@ impl SetGetter for GrpcSetGetter {
                 "get_by_height requires height > 0".into(),
             ));
         }
-        self.get_by_height_inner(height as i64).await
+        let height = i64::try_from(height)
+            .map_err(|_| FibreError::InvalidData("validator set height exceeds i64::MAX".into()))?;
+        self.get_by_height_inner(height).await
     }
 }
 
@@ -234,7 +360,24 @@ impl TryFrom<(&tendermint_proto::v0_38::types::ValidatorSet, u64)> for Validator
             .map(ValidatorInfo::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(ValidatorSet { validators, height })
+        let set = ValidatorSet::try_new(validators, height)?;
+
+        let proposer = proto_set
+            .proposer
+            .as_ref()
+            .ok_or_else(|| FibreError::InvalidData("validator set is missing proposer".into()))?;
+        let proposer = ValidatorInfo::try_from(proposer)?;
+        if !set
+            .validators
+            .iter()
+            .any(|validator| validator.address == proposer.address)
+        {
+            return Err(FibreError::InvalidData(
+                "validator set proposer is not in validator set".into(),
+            ));
+        }
+
+        Ok(set)
     }
 }
 
@@ -250,13 +393,15 @@ impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
             Some(pk) => match &pk.sum {
                 Some(CryptoKeySum::Ed25519(bytes)) => bytes.clone(),
                 _ => {
-                    return Err(FibreError::Other(
+                    return Err(FibreError::InvalidData(
                         "expected ed25519 public key for validator".into(),
                     ));
                 }
             },
             None => {
-                return Err(FibreError::Other("validator missing public key".into()));
+                return Err(FibreError::InvalidData(
+                    "validator missing public key".into(),
+                ));
             }
         };
 
@@ -267,30 +412,38 @@ impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
                     pubkey_bytes.len()
                 ))
             })?)
-            .map_err(|e| FibreError::Other(format!("invalid ed25519 key: {e}")))?;
+            .map_err(|e| FibreError::InvalidData(format!("invalid ed25519 key: {e}")))?;
 
-        // CometBFT address = first 20 bytes of SHA-256(pubkey)
-        let address: [u8; 20] = {
-            use sha2::{Digest, Sha256};
-            let hash = Sha256::digest(pubkey.as_bytes());
-            hash[..20]
-                .try_into()
-                .expect("sha256 output is always 32 bytes")
-        };
+        let address = validator_address(&pubkey);
 
-        if proto_val.voting_power < 0 {
-            return Err(FibreError::InvalidData(format!(
-                "validator has negative voting power: {}",
-                proto_val.voting_power
-            )));
+        let proto_address: [u8; 20] = proto_val.address.as_slice().try_into().map_err(|_| {
+            FibreError::InvalidData(format!(
+                "validator address has invalid length {}, expected 20",
+                proto_val.address.len()
+            ))
+        })?;
+        if proto_address != address {
+            return Err(FibreError::InvalidData(
+                "validator address does not match public key".into(),
+            ));
         }
 
-        Ok(ValidatorInfo {
-            address,
-            pubkey,
-            voting_power: proto_val.voting_power,
-        })
+        let voting_power = u64::try_from(proto_val.voting_power).map_err(|_| {
+            FibreError::InvalidData(format!(
+                "validator has negative voting power: {}",
+                proto_val.voting_power
+            ))
+        })?;
+
+        ValidatorInfo::try_new(pubkey, voting_power)
     }
+}
+
+fn validator_address(pubkey: &Ed25519PublicKey) -> [u8; 20] {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(pubkey.as_bytes())[..20]
+        .try_into()
+        .expect("sha256 output is always 32 bytes")
 }
 
 fn go_shuffle<T>(rng: &mut ChaCha8Rand, slice: &mut [T]) {
@@ -331,16 +484,16 @@ fn shuffle_by_stake(selected: &mut [(usize, &ValidatorInfo)], rng: &mut impl Rng
     }
 
     for i in 0..n - 1 {
-        let total_weight: i64 = selected[i..].iter().map(|(_, val)| val.voting_power).sum();
-        if total_weight <= 0 {
-            break;
-        }
+        let total_weight: u64 = selected[i..]
+            .iter()
+            .map(|(_, val)| val.voting_power())
+            .sum();
 
         let point = rng.gen_range(0..total_weight);
 
-        let mut cumul: i64 = 0;
+        let mut cumul: u64 = 0;
         for j in i..n {
-            cumul += selected[j].1.voting_power;
+            cumul += selected[j].1.voting_power();
             if point < cumul {
                 selected.swap(i, j);
                 break;
@@ -354,26 +507,15 @@ mod assignment_tests {
     use super::*;
     use ed25519_dalek::SigningKey;
 
-    fn make_validator(power: i64, seed: u8) -> ValidatorInfo {
+    fn make_validator(power: u64, seed: u8) -> ValidatorInfo {
         let mut key_bytes = [0u8; 32];
         key_bytes[0] = seed;
         let signing_key = SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo {
-            address: [seed; 20],
-            pubkey: signing_key.verifying_key(),
-            voting_power: power,
-        }
+        ValidatorInfo::try_new(signing_key.verifying_key(), power).unwrap()
     }
 
     fn default_liveness() -> Fraction {
         crate::test_utils::fraction(1, 3)
-    }
-
-    #[test]
-    fn empty_validators_returns_empty_map() {
-        let set = ValidatorSet::new(vec![], 0);
-        let map = set.assign([0u8; 32], 100, 50, 10, default_liveness());
-        assert!(map.is_empty());
     }
 
     #[test]
@@ -387,13 +529,6 @@ mod assignment_tests {
     fn zero_min_rows_returns_empty_map() {
         let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
         let map = set.assign([0u8; 32], 100, 50, 0, default_liveness());
-        assert!(map.is_empty());
-    }
-
-    #[test]
-    fn zero_voting_power_returns_empty_map() {
-        let set = ValidatorSet::new(vec![make_validator(0, 1), make_validator(0, 2)], 0);
-        let map = set.assign([0u8; 32], 100, 50, 10, default_liveness());
         assert!(map.is_empty());
     }
 
@@ -609,15 +744,11 @@ mod selection_tests {
     use super::*;
     use ed25519_dalek::SigningKey;
 
-    fn make_validator(power: i64, seed: u8) -> ValidatorInfo {
+    fn make_validator(power: u64, seed: u8) -> ValidatorInfo {
         let mut key_bytes = [0u8; 32];
         key_bytes[0] = seed;
         let signing_key = SigningKey::from_bytes(&key_bytes);
-        ValidatorInfo {
-            address: [seed; 20],
-            pubkey: signing_key.verifying_key(),
-            voting_power: power,
-        }
+        ValidatorInfo::try_new(signing_key.verifying_key(), power).unwrap()
     }
 
     fn default_liveness() -> Fraction {
@@ -625,44 +756,35 @@ mod selection_tests {
     }
 
     #[test]
-    fn empty_validators_returns_empty() {
-        let set = ValidatorSet::new(vec![], 0);
-        let selected = set.select(100, 10, default_liveness());
-        assert!(selected.is_empty());
-    }
-
-    #[test]
-    fn zero_voting_power_returns_empty() {
-        let set = ValidatorSet::new(vec![make_validator(0, 1), make_validator(0, 2)], 0);
-        let selected = set.select(100, 10, default_liveness());
-        assert!(selected.is_empty());
-    }
-
-    #[test]
     fn single_validator_returns_one() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
+        let validator = make_validator(100, 1);
+        let expected_address = validator.address;
+        let set = ValidatorSet::new(vec![validator], 0);
         let selected = set.select(100, 10, default_liveness());
         assert_eq!(selected.len(), 1);
         assert!(selected[0].0 > 0);
-        assert_eq!(selected[0].1.address, [1u8; 20]);
+        assert_eq!(selected[0].1.address, expected_address);
     }
 
     #[test]
     fn multiple_validators_returns_all() {
-        let set = ValidatorSet::new(
-            vec![
-                make_validator(100, 1),
-                make_validator(100, 2),
-                make_validator(100, 3),
-            ],
-            0,
-        );
+        let validators = vec![
+            make_validator(100, 1),
+            make_validator(100, 2),
+            make_validator(100, 3),
+        ];
+        let mut expected: Vec<_> = validators
+            .iter()
+            .map(|validator| validator.address)
+            .collect();
+        expected.sort();
+        let set = ValidatorSet::new(validators, 0);
         let selected = set.select(100, 10, default_liveness());
         assert_eq!(selected.len(), 3);
 
-        let mut seeds: Vec<u8> = selected.iter().map(|(_, info)| info.address[0]).collect();
-        seeds.sort();
-        assert_eq!(seeds, vec![1, 2, 3]);
+        let mut actual: Vec<_> = selected.iter().map(|(_, info)| info.address).collect();
+        actual.sort();
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -688,20 +810,23 @@ mod selection_tests {
 
     #[test]
     fn all_validators_present_in_result() {
-        let set = ValidatorSet::new(
-            vec![
-                make_validator(50, 1),
-                make_validator(30, 2),
-                make_validator(20, 3),
-            ],
-            0,
-        );
+        let validators = vec![
+            make_validator(50, 1),
+            make_validator(30, 2),
+            make_validator(20, 3),
+        ];
+        let mut expected: Vec<_> = validators
+            .iter()
+            .map(|validator| validator.address)
+            .collect();
+        expected.sort();
+        let set = ValidatorSet::new(validators, 0);
         let selected = set.select(100, 10, default_liveness());
 
         assert_eq!(selected.len(), 3);
-        let mut seeds: Vec<u8> = selected.iter().map(|(_, info)| info.address[0]).collect();
-        seeds.sort();
-        assert_eq!(seeds, vec![1, 2, 3]);
+        let mut actual: Vec<_> = selected.iter().map(|(_, info)| info.address).collect();
+        actual.sort();
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -710,17 +835,22 @@ mod selection_tests {
         let trials = 1000;
 
         for _ in 0..trials {
-            let set = ValidatorSet::new(
-                vec![
-                    make_validator(100, 1),
-                    make_validator(10, 2),
-                    make_validator(10, 3),
-                ],
-                0,
-            );
+            let validators = vec![
+                make_validator(100, 1),
+                make_validator(10, 2),
+                make_validator(10, 3),
+            ];
+            let addresses: Vec<_> = validators
+                .iter()
+                .map(|validator| validator.address)
+                .collect();
+            let set = ValidatorSet::new(validators, 0);
             let selected = set.select(100, 10, default_liveness());
-            // address[0] is the seed: 1, 2, or 3
-            first_position_counts[selected[0].1.address[0] as usize - 1] += 1;
+            let first = addresses
+                .iter()
+                .position(|address| address == &selected[0].1.address)
+                .unwrap();
+            first_position_counts[first] += 1;
         }
 
         assert!(first_position_counts[0] > first_position_counts[1]);

--- a/fibre/src/validator/signature_set.rs
+++ b/fibre/src/validator/signature_set.rs
@@ -294,6 +294,17 @@ mod tests {
     }
 
     #[test]
+    fn threshold_uses_floor_and_inclusive_comparison() {
+        let (sk1, v1) = make_validator(33);
+        let (_sk2, v2) = make_validator(17);
+        let data = b"floor test";
+        let ss = SignatureSet::new(vec![v1.clone(), v2], fraction(2, 3), data.to_vec());
+
+        let met = ss.add(&v1, &sign(&sk1, data)).unwrap();
+        assert!(met, "33 >= floor(50 * 2/3) = 33");
+    }
+
+    #[test]
     fn duplicate_add_is_idempotent() {
         // Adding the same validator twice does NOT double-count voting power.
         // The signature map entry is overwritten but voting_power stays the same.

--- a/fibre/src/validator/signature_set.rs
+++ b/fibre/src/validator/signature_set.rs
@@ -21,7 +21,7 @@ pub struct SignatureSet {
     /// The bytes that each validator must have signed.
     required_bytes_signed: Vec<u8>,
     /// Minimum accumulated voting power to consider the threshold met.
-    min_required_voting_power: i64,
+    min_required_voting_power: u64,
     /// Ordered validator list (determines output ordering).
     validators: Vec<ValidatorInfo>,
     /// Mutable state protected by a mutex.
@@ -31,7 +31,7 @@ pub struct SignatureSet {
 /// Mutable interior of [`SignatureSet`], protected by a [`Mutex`].
 struct SignatureSetInner {
     /// Accumulated voting power from accepted signatures.
-    voting_power: i64,
+    voting_power: u64,
     /// Map from validator address to their signature bytes.
     signatures: HashMap<[u8; 20], Vec<u8>>,
 }
@@ -44,15 +44,17 @@ impl SignatureSet {
     /// * `validators` - The full ordered validator list.
     /// * `target_voting_power` - Fraction of total voting power required (e.g. 2/3).
     /// * `required_bytes_signed` - The exact bytes each signature must cover.
-    pub fn new(
+    fn new(
         validators: Vec<ValidatorInfo>,
         target_voting_power: Fraction,
         required_bytes_signed: Vec<u8>,
     ) -> Self {
-        let total_voting_power: i64 = validators.iter().map(|v| v.voting_power).sum();
-        let min_required_voting_power = total_voting_power
-            * target_voting_power.numerator.get() as i64
-            / target_voting_power.denominator.get() as i64;
+        let total_voting_power: u64 = validators.iter().map(ValidatorInfo::voting_power).sum();
+        let min_required_voting_power = (total_voting_power as u128)
+            * (target_voting_power.numerator.get() as u128)
+            / (target_voting_power.denominator.get() as u128);
+        let min_required_voting_power =
+            u64::try_from(min_required_voting_power.max(1)).unwrap_or(u64::MAX);
 
         let capacity = validators.len();
         Self {
@@ -91,7 +93,7 @@ impl SignatureSet {
         let mut inner = self.inner.lock().expect("SignatureSet mutex poisoned");
         // Only count voting power once per validator (idempotent on duplicates).
         if !inner.signatures.contains_key(&validator.address) {
-            inner.voting_power += validator.voting_power;
+            inner.voting_power += validator.voting_power();
         }
         inner
             .signatures
@@ -149,22 +151,14 @@ mod tests {
     use rand::RngCore;
 
     /// Helper: generate a ValidatorInfo with a fresh ed25519 keypair.
-    fn make_validator(voting_power: i64) -> (SigningKey, ValidatorInfo) {
+    fn make_validator(voting_power: u64) -> (SigningKey, ValidatorInfo) {
         let mut secret = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut secret);
         let signing_key = SigningKey::from_bytes(&secret);
         let pubkey = signing_key.verifying_key();
-        // Derive a deterministic 20-byte address from the public key bytes.
-        let pk_bytes = pubkey.to_bytes();
-        let mut address = [0u8; 20];
-        address.copy_from_slice(&pk_bytes[..20]);
         (
             signing_key,
-            ValidatorInfo {
-                address,
-                pubkey,
-                voting_power,
-            },
+            ValidatorInfo::try_new(pubkey, voting_power).unwrap(),
         )
     }
 
@@ -302,6 +296,22 @@ mod tests {
 
         let met = ss.add(&v1, &sign(&sk1, data)).unwrap();
         assert!(met, "33 >= floor(50 * 2/3) = 33");
+    }
+
+    #[test]
+    fn threshold_always_requires_voting_power() {
+        let (sk, validator) = make_validator(1);
+        let data = b"minimum threshold";
+        let ss = SignatureSet::new(vec![validator.clone()], fraction(2, 3), data.to_vec());
+
+        assert!(matches!(
+            ss.signatures(),
+            Err(FibreError::NotEnoughSignatures {
+                collected: 0,
+                required: 1
+            })
+        ));
+        assert!(ss.add(&validator, &sign(&sk, data)).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Overview

- Voting power is now `NonZeroU64`; zero, negative protobuf values, and values above CometBFT’s maximum are rejected.
- `ValidatorSet::try_new` enforces non-empty sets, unique addresses, and checked total voting power.
- Protobuf remains wire-compatible with int64; validation happens at the protobuf-to-domain boundary, including address/public-key and proposer validation.
- Public construction is fallible, with private invariant-bearing fields and read-only accessors.
- Voting-power arithmetic uses unsigned/wider types.
- Signature thresholds can never round down to zero, so an upload always requires at least one signature.


## Perf impact

Measured on the Ryzen 9 3950X, release mode, pinned to one CPU, comparing main (1f348a6) with PR head (5cf6bb9):

```
   Operation                                       main                         PR                      Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━
   Convert 10 validators                        35.6 µs                    40.2 µs                     +4.6 µs
  ──────────────────────────  ──────────────────────────  ─────────────────────────  ──────────────────────────
   Convert 50 validators                       177.3 µs                   185.1 µs                     +7.8 µs
  ──────────────────────────  ──────────────────────────  ─────────────────────────  ──────────────────────────
   Convert 100 validators                      353.8 µs                   367.7 µs                    +14.0 µs
  ──────────────────────────  ──────────────────────────  ─────────────────────────  ──────────────────────────
   Select 100 validators                        4.75 µs                    4.96 µs             +0.21 µs / 4.5%
  ──────────────────────────  ──────────────────────────  ─────────────────────────  ──────────────────────────
   Verify/add one signature                     33.0 µs                    34.5 µs       approximately +1.5 µs
  ──────────────────────────  ──────────────────────────  ─────────────────────────  ──────────────────────────
   Assign shards               approximately 100–118 µs    approximately unchanged    no consistent regression
  ──────────────────────────  ──────────────────────────  ─────────────────────────  ──────────────────────────
   Collect 100 signatures          approximately 3.3 ms    approximately unchanged     within run-to-run noise
```

The conversion overhead comes from duplicate detection, checked totals, address validation, and proposer validation in fibre/src/validator/mod.rs:105. The small selection regression is likely the wider u128 stake arithmetic fibre/src/validator/mod.rs:158.
