### PR TITLE
perf(fibre): tune client HTTP/2 flow control for shard uploads

### DIFF
--- a/fibre/src/transport/tls.rs
+++ b/fibre/src/transport/tls.rs
@@ -223,6 +223,12 @@ impl FibreH2TransportInner {
             .await
             .map_err(BoxError::from)?;
         let (sender, connection) = hyper::client::conn::http2::Builder::new(h2_executor())
+            // On a fast, low-latency link the default 64 KiB windows and 1 MiB
+            // send buffer throttle shard uploads while CPU and NIC sit idle.
+            // Adaptive windowing tunes the receive side to the BDP; the larger
+            // send buffer keeps the upload pipe full between WINDOW_UPDATEs.
+            .adaptive_window(true)
+            .max_send_buf_size(32 * 1024 * 1024)
             .handshake(TokioIo::new(tls))
             .await?;
         spawn_connection(connection);


### PR DESCRIPTION
Enable hyper's adaptive receive window and raise the per-stream send buffer from the 1 MiB default to 32 MiB on the client HTTP/2 connection. With the spec-default 64 KiB windows and 1 MiB send buffer, a low-latency link stalls between `WINDOW_UPDATE` frames while CPU and NIC sit idle. Adaptive windowing sizes the receive side to the bandwidth-delay product, and the larger send buffer keeps the upload pipe full while waiting for the server's window to grow.

Note that the 32 MiB send buffer is per stream. With many validators the buffered data can be large in aggregate, but it consists of shared row buffers from the encoded blob rather than copies.

## Benchmark data

Setup: 32 MiB blob uploaded to 4 mock validators over loopback with TLS, using the fibre-mock-server harness. Two release binaries were built, one with this change and one with main's defaults, and run alternately for 6 iterations of 6 timed uploads each, so machine drift affects both equally. Time is from upload start until every validator finished. The box was under load average 9 from a running devnet and other jobs, so spread is wide.

 ``` 

  ┌───────────────┬─────┬────────┬────────┬────────┬────────┬────────┬──────────────┬────────────┐
  │     build     │  n  │  min   │  p25   │ median │  p75   │  max   │ median MiB/s │ rounds won │
  ├───────────────┼─────┼────────┼────────┼────────┼────────┼────────┼──────────────┼────────────┤
  │ tuned         │ 36  │ 99 ms  │ 142 ms │ 187 ms │ 238 ms │ 365 ms │ 172          │ 4 of 6     │
  ├───────────────┼─────┼────────┼────────┼────────┼────────┼────────┼──────────────┼────────────┤
  │ main defaults │ 36  │ 119 ms │ 189 ms │ 227 ms │ 276 ms │ 511 ms │ 144          │ 2 of 6     │
  └───────────────┴─────┴────────┴────────┴────────┴────────┴────────┴──────────────┴────────────┘
```
