### PR TITLE
chore(fibre): type safe config and client builder

### DIFF
--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -48,7 +48,7 @@ use rand::rngs::OsRng;
 
 use celestia_fibre::transport::proto_conv;
 use celestia_fibre::{
-    BlobConfig, EncodedBlob, FibreClientConfig, Fraction, PaymentPromise, ValidatorInfo,
+    BlobConfig, DEFAULT_PROTOCOL_PARAMS, EncodedBlob, Fraction, PaymentPromise, ValidatorInfo,
     ValidatorSet,
 };
 use celestia_proto::celestia::fibre::v1 as proto;
@@ -74,7 +74,7 @@ const HEAVY_WARM_UP: Duration = Duration::from_secs(5);
 
 /// Rows per shard, matching the protocol's min_rows_per_validator (148 for v0).
 fn rows_per_shard() -> usize {
-    FibreClientConfig::default().min_rows_per_validator
+    DEFAULT_PROTOCOL_PARAMS.min_rows_per_validator()
 }
 
 fn liveness() -> Fraction {
@@ -168,7 +168,7 @@ fn bench_payment_promise(c: &mut Criterion) {
     let signing_key = k256::ecdsa::SigningKey::random(&mut OsRng);
     let mut promise = PaymentPromise {
         chain_id: "private".into(),
-        height: 42,
+        height: NonZeroU64::new(42).unwrap(),
         namespace: Namespace::from_raw(&[0u8; 29]).unwrap(),
         upload_size: BlobConfig::v0().upload_size(1 << 20) as u32,
         blob_version: 0,

--- a/fibre/src/client/mod.rs
+++ b/fibre/src/client/mod.rs
@@ -132,7 +132,7 @@ impl FibreClient {
         ));
         let connector = crate::grpc_validator_client::GrpcValidatorConnector::new_with_io_connector(
             host_registry,
-            config.chain_id.clone(),
+            config.chain_id().to_owned(),
             io_connector,
         );
 
@@ -181,7 +181,9 @@ impl FibreClientBuilder {
 
     /// Builds the [`FibreClient`].
     pub fn build(self) -> Result<FibreClient, FibreError> {
-        let cfg = self.config.unwrap_or_default();
+        let cfg = self
+            .config
+            .ok_or_else(|| FibreError::Other("config is required".into()))?;
         let set_getter = self
             .set_getter
             .ok_or_else(|| FibreError::Other("set_getter is required".into()))?;
@@ -243,8 +245,10 @@ mod tests {
 
     #[tokio::test]
     async fn from_endpoint_with_valid_url() {
-        let result =
-            FibreClient::from_endpoint("http://localhost:9090", FibreClientConfig::default());
+        let result = FibreClient::from_endpoint(
+            "http://localhost:9090",
+            FibreClientConfig::new("test-chain").unwrap(),
+        );
         assert!(
             result.is_ok(),
             "from_endpoint with valid URL should succeed but got err: {}",
@@ -254,8 +258,10 @@ mod tests {
 
     #[tokio::test]
     async fn from_endpoint_with_invalid_url() {
-        let result =
-            FibreClient::from_endpoint("not a valid url \x00", FibreClientConfig::default());
+        let result = FibreClient::from_endpoint(
+            "not a valid url \x00",
+            FibreClientConfig::new("test-chain").unwrap(),
+        );
         assert!(
             result.is_err(),
             "from_endpoint with invalid URL should fail"
@@ -264,20 +270,39 @@ mod tests {
 
     #[tokio::test]
     async fn from_endpoint_sets_config_correctly() {
-        let config = FibreClientConfig {
-            chain_id: "test-123".to_string(),
-            ..Default::default()
-        };
+        let config = FibreClientConfig::new("test-123").unwrap();
 
         let client = FibreClient::from_endpoint("http://localhost:9090", config)
             .expect("from_endpoint should succeed");
 
-        assert_eq!(client.config().chain_id, "test-123");
+        assert_eq!(client.config().chain_id(), "test-123");
+    }
+
+    #[test]
+    fn builder_missing_config_returns_error() {
+        let result = FibreClient::builder()
+            .set_getter(DummySetGetter)
+            .connector(DummyConnector)
+            .build();
+
+        match result {
+            Err(FibreError::Other(msg)) => {
+                assert!(
+                    msg.contains("config"),
+                    "error should mention config, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected FibreError::Other mentioning config, got: {other}"),
+            Ok(_) => panic!("expected an error but build() succeeded"),
+        }
     }
 
     #[test]
     fn builder_missing_set_getter_returns_error() {
-        let result = FibreClient::builder().connector(DummyConnector).build();
+        let result = FibreClient::builder()
+            .config(FibreClientConfig::new("test-chain").unwrap())
+            .connector(DummyConnector)
+            .build();
 
         match result {
             Err(FibreError::Other(msg)) => {
@@ -293,7 +318,10 @@ mod tests {
 
     #[test]
     fn builder_missing_connector_returns_error() {
-        let result = FibreClient::builder().set_getter(DummySetGetter).build();
+        let result = FibreClient::builder()
+            .config(FibreClientConfig::new("test-chain").unwrap())
+            .set_getter(DummySetGetter)
+            .build();
 
         match result {
             Err(FibreError::Other(msg)) => {
@@ -310,6 +338,7 @@ mod tests {
     #[test]
     fn close_and_is_closed() {
         let client = FibreClient::builder()
+            .config(FibreClientConfig::new("test-chain").unwrap())
             .set_getter(DummySetGetter)
             .connector(DummyConnector)
             .build()

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -7,6 +7,7 @@
 //! The [`FibreClient::upload_and_prepare()`] method encodes a blob, uploads it to validators,
 //! and returns a `MsgPayForFibre` ready for broadcast by the caller.
 
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use celestia_proto::celestia::fibre::v1::MsgPayForFibre;
@@ -51,8 +52,10 @@ impl FibreClient {
         })?;
 
         let mut promise = PaymentPromise {
-            chain_id: self.cfg.chain_id.clone(),
-            height: val_set.height,
+            chain_id: self.cfg.chain_id().to_owned(),
+            height: NonZeroU64::new(val_set.height).ok_or_else(|| {
+                FibreError::InvalidPaymentPromise("height must be positive, got 0".into())
+            })?,
             namespace,
             upload_size: upload_size_u32,
             blob_version: blob.config().blob_version as u32,
@@ -331,7 +334,7 @@ mod tests {
         assert!(result.is_ok(), "upload should succeed: {:?}", result.err());
 
         let signed = result.unwrap();
-        assert_eq!(signed.promise.height, 42);
+        assert_eq!(signed.promise.height.get(), 42);
         assert_eq!(signed.promise.chain_id, "test-chain");
 
         let sig_count = signed

--- a/fibre/src/domain/config.rs
+++ b/fibre/src/domain/config.rs
@@ -5,6 +5,9 @@
 
 use std::num::NonZeroU64;
 
+use super::payment_promise::MAX_CHAIN_ID_SIZE;
+use crate::error::FibreError;
+
 /// Fraction represented as numerator/denominator.
 ///
 /// Both fields are non-zero: threshold math divides by each of them.
@@ -180,7 +183,7 @@ impl ProtocolParams {
 #[derive(Debug, Clone)]
 pub struct FibreClientConfig {
     /// Chain ID for domain separation in PaymentPromise signatures.
-    pub chain_id: String,
+    chain_id: String,
     /// Safety threshold (fraction of stake needed for safety, typically 2/3).
     pub safety_threshold: Fraction,
     /// Liveness threshold (fraction of stake for liveness, typically 1/3).
@@ -196,23 +199,44 @@ pub struct FibreClientConfig {
 }
 
 impl FibreClientConfig {
+    /// Creates a `FibreClientConfig` with the default protocol parameters.
+    pub fn new(chain_id: impl Into<String>) -> Result<Self, FibreError> {
+        Self::from_params(chain_id, &DEFAULT_PROTOCOL_PARAMS)
+    }
+
     /// Creates a `FibreClientConfig` from protocol parameters.
-    pub fn from_params(params: &ProtocolParams) -> Self {
-        Self {
-            chain_id: String::new(),
+    pub fn from_params(
+        chain_id: impl Into<String>,
+        params: &ProtocolParams,
+    ) -> Result<Self, FibreError> {
+        let chain_id = chain_id.into();
+        if chain_id.is_empty() {
+            return Err(FibreError::InvalidChainId(
+                "chain ID must not be empty".into(),
+            ));
+        }
+        if chain_id.len() > MAX_CHAIN_ID_SIZE {
+            return Err(FibreError::InvalidChainId(format!(
+                "chain ID length {} exceeds maximum {}",
+                chain_id.len(),
+                MAX_CHAIN_ID_SIZE
+            )));
+        }
+
+        Ok(Self {
+            chain_id,
             safety_threshold: params.safety_threshold,
             liveness_threshold: params.liveness_threshold,
             min_rows_per_validator: params.min_rows_per_validator(),
             max_message_size: params.max_message_size(),
             upload_concurrency: params.max_validator_count,
             download_concurrency: params.max_validator_count,
-        }
+        })
     }
-}
 
-impl Default for FibreClientConfig {
-    fn default() -> Self {
-        Self::from_params(&DEFAULT_PROTOCOL_PARAMS)
+    /// Returns the chain ID.
+    pub fn chain_id(&self) -> &str {
+        &self.chain_id
     }
 }
 
@@ -446,13 +470,28 @@ mod tests {
     }
 
     #[test]
-    fn fibre_client_config_default() {
-        let cfg = FibreClientConfig::default();
+    fn fibre_client_config_defaults() {
+        let cfg = FibreClientConfig::new("test-chain").unwrap();
+        assert_eq!(cfg.chain_id(), "test-chain");
         assert_eq!(cfg.safety_threshold, crate::test_utils::fraction(2, 3));
         assert_eq!(cfg.liveness_threshold, crate::test_utils::fraction(1, 3));
         assert_eq!(cfg.min_rows_per_validator, 148);
         assert_eq!(cfg.upload_concurrency, 100);
         assert_eq!(cfg.download_concurrency, 100);
+    }
+
+    #[test]
+    fn fibre_client_config_rejects_invalid_chain_id() {
+        assert!(matches!(
+            FibreClientConfig::new(""),
+            Err(FibreError::InvalidChainId(_))
+        ));
+
+        let too_long = "x".repeat(MAX_CHAIN_ID_SIZE + 1);
+        assert!(matches!(
+            FibreClientConfig::new(too_long),
+            Err(FibreError::InvalidChainId(_))
+        ));
     }
 
     #[test]

--- a/fibre/src/domain/error.rs
+++ b/fibre/src/domain/error.rs
@@ -82,6 +82,10 @@ pub enum FibreError {
     #[error("payment promise validation failed: {0}")]
     InvalidPaymentPromise(String),
 
+    /// The configured chain ID is invalid.
+    #[error("invalid chain ID: {0}")]
+    InvalidChainId(String),
+
     // -- Connection errors --
     /// No host address was found for a validator.
     #[error("host not found for validator {0}")]

--- a/fibre/src/domain/payment_promise.rs
+++ b/fibre/src/domain/payment_promise.rs
@@ -4,6 +4,7 @@
 //! The signer creates the promise, signs it with their secp256k1 key, and
 //! validators counter-sign to confirm they received and stored the data.
 
+use std::num::NonZeroU64;
 use std::time::SystemTime;
 
 use celestia_types::nmt::{NS_SIZE, Namespace};
@@ -25,7 +26,7 @@ const PUBKEY_SIZE: usize = 33;
 const SIGNATURE_SIZE: usize = 64;
 
 /// Maximum allowed chain ID length.
-const MAX_CHAIN_ID_SIZE: usize = 20;
+pub(crate) const MAX_CHAIN_ID_SIZE: usize = 20;
 
 /// Size of the Go time.Time MarshalBinary output for UTC times.
 const TIMESTAMP_BINARY_SIZE: usize = 15;
@@ -42,7 +43,7 @@ pub struct PaymentPromise {
     /// Chain identifier for domain separation.
     pub chain_id: String,
     /// Height used to determine the validator set.
-    pub height: u64,
+    pub height: NonZeroU64,
     /// The namespace the blob is associated with.
     pub namespace: Namespace,
     /// Upload size of the blob (with padding, without parity), matching `EncodedBlob::upload_size()`.
@@ -89,7 +90,7 @@ impl PaymentPromise {
         buf.extend_from_slice(&self.blob_version.to_be_bytes());
 
         // Append height (8 bytes, big-endian)
-        buf.extend_from_slice(&self.height.to_be_bytes());
+        buf.extend_from_slice(&self.height.get().to_be_bytes());
 
         // Append timestamp bytes (15 bytes)
         buf.extend_from_slice(&timestamp_bytes);
@@ -176,14 +177,6 @@ impl PaymentPromise {
             return Err(FibreError::InvalidPaymentPromise(
                 "creation timestamp must not be zero".into(),
             ));
-        }
-
-        // Height must be positive
-        if self.height == 0 {
-            return Err(FibreError::InvalidPaymentPromise(format!(
-                "height must be positive, got {}",
-                self.height
-            )));
         }
 
         // Signature must be present and correct size
@@ -356,7 +349,7 @@ mod tests {
 
         let promise = PaymentPromise {
             chain_id: "test-chain-1".to_string(),
-            height: 12345,
+            height: NonZeroU64::new(12345).unwrap(),
             namespace: Namespace::from_raw(&[0u8; NS_SIZE]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
@@ -431,7 +424,10 @@ mod tests {
         offset += 4;
 
         // Height (8 bytes BE)
-        assert_eq!(&stripped[offset..offset + 8], &promise.height.to_be_bytes());
+        assert_eq!(
+            &stripped[offset..offset + 8],
+            &promise.height.get().to_be_bytes()
+        );
         offset += 8;
 
         // Timestamp (15 bytes)
@@ -481,14 +477,6 @@ mod tests {
     fn validate_fails_with_zero_upload_size() {
         let (signing_key, mut promise) = make_test_promise();
         promise.upload_size = 0;
-        promise.sign(&signing_key).unwrap();
-        assert!(promise.validate().is_err());
-    }
-
-    #[test]
-    fn validate_fails_with_zero_height() {
-        let (signing_key, mut promise) = make_test_promise();
-        promise.height = 0;
         promise.sign(&signing_key).unwrap();
         assert!(promise.validate().is_err());
     }
@@ -600,7 +588,7 @@ mod tests {
 
         let mut promise = PaymentPromise {
             chain_id: "mocha-4".to_string(),
-            height: 100,
+            height: NonZeroU64::new(100).unwrap(),
             namespace: Namespace::from_raw(&[0u8; NS_SIZE]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
@@ -709,7 +697,7 @@ mod tests {
 
         let mut promise = PaymentPromise {
             chain_id: "mocha-4".to_string(),
-            height: 100,
+            height: NonZeroU64::new(100).unwrap(),
             namespace: Namespace::from_raw(&[0u8; NS_SIZE]).unwrap(),
             upload_size: 1024,
             blob_version: 0,
@@ -752,7 +740,7 @@ mod tests {
 
         let reconstructed = PaymentPromise {
             chain_id: decoded_proto.chain_id,
-            height: decoded_proto.height as u64,
+            height: NonZeroU64::new(decoded_proto.height as u64).unwrap(),
             namespace: Namespace::from_raw(&decoded_proto.namespace).unwrap(),
             upload_size: decoded_proto.blob_size,
             blob_version: decoded_proto.blob_version,

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -262,15 +262,14 @@ pub(crate) fn fraction(numerator: u64, denominator: u64) -> Fraction {
 
 /// Standard test client configuration.
 pub(crate) fn test_client_config(chain_id: &str) -> FibreClientConfig {
-    FibreClientConfig {
-        chain_id: chain_id.to_string(),
-        safety_threshold: fraction(2, 3),
-        liveness_threshold: fraction(1, 3),
-        min_rows_per_validator: 1,
-        max_message_size: 1 << 20,
-        upload_concurrency: 10,
-        download_concurrency: 10,
-    }
+    let mut config = FibreClientConfig::new(chain_id).unwrap();
+    config.safety_threshold = fraction(2, 3);
+    config.liveness_threshold = fraction(1, 3);
+    config.min_rows_per_validator = 1;
+    config.max_message_size = 1 << 20;
+    config.upload_concurrency = 10;
+    config.download_concurrency = 10;
+    config
 }
 
 /// Build a [`FibreClient`] from a validator set and connector with test config.

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -30,7 +30,7 @@ impl From<&PaymentPromise> for proto::PaymentPromise {
 
         proto::PaymentPromise {
             chain_id: pp.chain_id.clone(),
-            height: pp.height as i64,
+            height: pp.height.get() as i64,
             namespace: pp.namespace.as_bytes().to_vec(),
             blob_size: pp.upload_size,
             blob_version: pp.blob_version,
@@ -185,7 +185,7 @@ mod tests {
         let sk = SigningKey::random(&mut OsRng);
         let pp = PaymentPromise {
             chain_id: "test-chain".into(),
-            height: 42,
+            height: std::num::NonZeroU64::new(42).unwrap(),
             namespace: celestia_types::nmt::Namespace::from_raw(&[0u8; 29]).unwrap(),
             upload_size: 1024,
             blob_version: 0,


### PR DESCRIPTION
## Overview

It was possible to create client config with empty chain_id.

To prevent such errors `FibreClientConfig` does not implement `Default` anymore, and chain_id is explicitly required and checked. 
`FibreClientBuilder` now requires `.config` attribute to be Some at build time.

Another change is `PaymentPromise::height` to be NonZeroU64, so it is checked at the construction boundary and not during sending request. 


Inspired by: https://github.com/celestiaorg/lumina/pull/1021