### PR TITLE
perf(proto): decode Fibre proofs and RLCs as `Bytes`

### DIFF
--- a/fibre/benches/fibre_bench.rs
+++ b/fibre/benches/fibre_bench.rs
@@ -43,6 +43,7 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, SamplingMode, Throughput, black_box, criterion_group,
     criterion_main,
 };
+use prost::bytes::Bytes;
 use rand::Rng;
 use rand::rngs::OsRng;
 
@@ -86,6 +87,16 @@ fn generate_data(len: usize) -> Vec<u8> {
     let mut data = vec![0u8; len];
     rng.fill(&mut data[..]);
     data
+}
+
+fn proof_hashes_as_bytes(hashes: &[[u8; 32]]) -> Vec<Bytes> {
+    let mut storage = Vec::with_capacity(hashes.len() * 32);
+    for hash in hashes {
+        storage.extend_from_slice(hash);
+    }
+
+    let mut storage = Bytes::from(storage);
+    (0..hashes.len()).map(|_| storage.split_to(32)).collect()
 }
 
 fn make_validators(count: usize) -> (Vec<ed25519_dalek::SigningKey>, Vec<ValidatorInfo>) {
@@ -284,7 +295,7 @@ fn bench_parse_download_response(c: &mut Criterion) {
             proto::BlobRow {
                 index: proof.index as u32,
                 data: proof.row,
-                proof: proof.row_proof.iter().map(|h| h.to_vec()).collect(),
+                proof: proof_hashes_as_bytes(&proof.row_proof),
             }
         })
         .collect();
@@ -294,7 +305,10 @@ fn bench_parse_download_response(c: &mut Criterion) {
         .flat_map(|rlc| rlc.to_bytes())
         .collect();
     let response = proto::DownloadShardResponse {
-        shard: Some(proto::BlobShard { rows, rlcs }),
+        shard: Some(proto::BlobShard {
+            rows,
+            rlcs: rlcs.into(),
+        }),
     };
 
     group.bench_function(format!("shard_{shard}_rows_1MB"), |b| {
@@ -331,14 +345,17 @@ fn bench_upload_shard_encode(c: &mut Criterion) {
             .map(|proof| proto::BlobRow {
                 index: proof.index as u32,
                 data: proof.row.clone(),
-                proof: proof.row_proof.iter().map(|hash| hash.to_vec()).collect(),
+                proof: proof_hashes_as_bytes(&proof.row_proof),
             })
             .collect();
-        let rlcs = rlcs.iter().flat_map(|rlc| rlc.to_bytes()).collect();
+        let rlcs: Vec<u8> = rlcs.iter().flat_map(|rlc| rlc.to_bytes()).collect();
 
         proto::UploadShardRequest {
             promise: None,
-            shard: Some(proto::BlobShard { rows, rlcs }),
+            shard: Some(proto::BlobShard {
+                rows,
+                rlcs: rlcs.into(),
+            }),
         }
     };
     let wire_len = {

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use celestia_proto::celestia::fibre::v1 as proto;
 use celestia_proto::cosmos::crypto::secp256k1::PubKey as ProtoPubKey;
+use prost::bytes::Bytes;
 use tendermint_proto::google::protobuf::Timestamp;
 #[cfg(test)]
 use tendermint_proto::v0_38::crypto::public_key::Sum as CryptoKeySum;
@@ -19,6 +20,16 @@ use crate::payment_promise::PaymentPromise;
 #[cfg(test)]
 use crate::validator::ValidatorInfo;
 use crate::validator_client::DownloadResponse;
+
+fn proof_hashes_as_bytes(hashes: &[[u8; 32]]) -> Vec<Bytes> {
+    let mut storage = Vec::with_capacity(hashes.len() * 32);
+    for hash in hashes {
+        storage.extend_from_slice(hash);
+    }
+
+    let mut storage = Bytes::from(storage);
+    (0..hashes.len()).map(|_| storage.split_to(32)).collect()
+}
 
 impl From<&PaymentPromise> for proto::PaymentPromise {
     fn from(pp: &PaymentPromise) -> Self {
@@ -47,7 +58,7 @@ pub(crate) fn row_proof_to_blob_row(proof: &rsema1d::RowInclusionProof) -> proto
     proto::BlobRow {
         index: proof.index as u32,
         data: proof.row.clone(),
-        proof: proof.row_proof.iter().map(|h| h.to_vec()).collect(),
+        proof: proof_hashes_as_bytes(&proof.row_proof),
     }
 }
 
@@ -60,7 +71,7 @@ pub(crate) fn blob_row_to_row_proof(
         .into_iter()
         .map(|h| {
             let len = h.len();
-            h.try_into().map_err(|_| {
+            h.as_ref().try_into().map_err(|_| {
                 FibreError::InvalidData(
                     format!("proof hash has invalid length {len}, expected 32",),
                 )
@@ -91,7 +102,10 @@ pub(crate) fn build_upload_shard(
         rlcs.extend_from_slice(&rlc.to_bytes());
     }
 
-    proto::BlobShard { rows, rlcs }
+    proto::BlobShard {
+        rows,
+        rlcs: rlcs.into(),
+    }
 }
 
 /// Parse a proto [`proto::DownloadShardResponse`] into a [`DownloadResponse`].
@@ -236,7 +250,7 @@ mod tests {
         let row = proto::BlobRow {
             index: 0,
             data: vec![0u8; 64].into(),
-            proof: vec![vec![0u8; 31]], // wrong length
+            proof: vec![vec![0u8; 31].into()], // wrong length
         };
         let result = blob_row_to_row_proof(row);
         assert!(result.is_err());
@@ -264,9 +278,9 @@ mod tests {
                 rows: vec![proto::BlobRow {
                     index: 3,
                     data: vec![1u8; 64].into(),
-                    proof: vec![vec![2u8; 32]],
+                    proof: vec![vec![2u8; 32].into()],
                 }],
-                rlcs: vec![9u8; 32], // 2 RLC values
+                rlcs: vec![9u8; 32].into(), // 2 RLC values
             }),
         };
 
@@ -287,7 +301,10 @@ mod tests {
     fn parse_download_response_invalid_rlc_length() {
         for rlcs in [vec![], vec![1u8; 15]] {
             let resp = proto::DownloadShardResponse {
-                shard: Some(proto::BlobShard { rows: vec![], rlcs }),
+                shard: Some(proto::BlobShard {
+                    rows: vec![],
+                    rlcs: rlcs.into(),
+                }),
             };
             assert!(parse_download_response(resp).is_err());
         }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -280,6 +280,8 @@ fn prost_build(fds: FileDescriptorSet) {
         .bytes([
             ".tendermint_celestia_mods.abci",
             ".celestia.fibre.v1.BlobRow.data",
+            ".celestia.fibre.v1.BlobRow.proof",
+            ".celestia.fibre.v1.BlobShard.rlcs",
         ])
         .compile_fds(fds)
         .expect("prost failed");
@@ -301,6 +303,8 @@ fn tonic_build(fds: FileDescriptorSet) {
         .bytes([
             ".tendermint_celestia_mods.abci",
             ".celestia.fibre.v1.BlobRow.data",
+            ".celestia.fibre.v1.BlobRow.proof",
+            ".celestia.fibre.v1.BlobShard.rlcs",
         ]);
 
     for (type_path, attr) in CUSTOM_TYPE_ATTRIBUTES {


### PR DESCRIPTION
## Overview

To reduce allocation and speed up mock server on fibre-eval branch.

Speeds up download of blobs as side effect.

## Summary

- Generate `BlobRow.proof` and `BlobShard.rlcs` as `bytes::Bytes`.
- Preserve the existing protobuf schema and wire format; only the generated Rust field types change.
- Store each row's proof hashes in one shared backing allocation and slice it into 32-byte Bytes values.
- Update Fibre conversions, tests, and benchmarks for the generated types.

The shared proof allocation is important for uploads. Constructing an independent Bytes allocation for every 32-byte proof hash caused a substantial upload regression in earlier measurements.

The refreshed raw-decode harness confirms the expected effect on the exact current main: for a 4,987,155-byte upload request, median decode fell from 138.2 µs to 81.9 µs (40.8% faster), and allocation calls fell from 2,222 to 149 (93.3% fewer).


## Benchmarks

Compared against clean main at b1215d21c0c7c82442fe32d7f308b846bdf8e6be.

Command:

```
      RAYON_NUM_THREADS=16 cargo bench --offline --locked \
        -p celestia-fibre --bench fibre_bench -- \
        shard_148_rows \
        --sample-size 50 \
        --warm-up-time 2 \
        --measurement-time 8 \
        --noplot
```

Separate target directories were used for main and the branch so their generated protobuf artifacts could not collide.

```
   Benchmark                                                             main        branch    Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━
   parse_download_response/shard_148_rows_1MB                       89.130 µs     86.952 µs    -2.44%
  ──────────────────────────────────────────────────────────────  ────────────  ────────────  ────────
   upload_shard_encode/proofs_build_encode/shard_148_rows_128MB    230.972 µs    232.055 µs    +0.47%
```

The upload confidence intervals overlap:

- main: 226.133–236.103 µs
- branch: 228.346–236.013 µs

This indicates no meaningful upload regression from the shared-allocation implementation.

### Raw protobuf decoding

A supplementary allocation-counting harness decoded a production-shaped 4,987,155-byte `UploadShardRequest` from Bytes:

- 148 rows
- 32 KiB per row
- 14 proof hashes per row
- 65,536-byte RLC vector
- median of five runs; each run used 21 batches of 400 decodes

```
   Metric                        main     branch    Change
  ━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━
   Decode time               138.2 µs    81.9 µs    -40.8%
  ────────────────────────  ──────────  ─────────  ────────
   Allocations per decode       2,222        149    -93.3%
```

The raw decoder harness was temporary and is not part of this commit.