### PR TITLE
refactor(fibre): reduce string interpolation on error origination sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,6 @@ name = "celestia-fibre"
 version = "1.1.0-rc.1"
 dependencies = [
  "async-trait",
- "bech32",
  "celestia-grpc",
  "celestia-proto",
  "celestia-types",

--- a/client/src/fibre.rs
+++ b/client/src/fibre.rs
@@ -97,10 +97,7 @@ impl FibreApi {
 /// Convert a [`FibreError`] into the client [`Error`] type.
 fn fibre_err(e: FibreError) -> Error {
     match e {
-        FibreError::Grpc(status) => Error::Grpc(celestia_grpc::Error::from(*status)),
         FibreError::GrpcClient(grpc_err) => Error::Grpc(grpc_err),
-        #[cfg(not(target_arch = "wasm32"))]
-        FibreError::Transport(t) => Error::Grpc(celestia_grpc::Error::from(t)),
         other => Error::Fibre(other),
     }
 }

--- a/fibre/CHANGELOG.md
+++ b/fibre/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [**breaking**] replace free-form `FibreError` messages with typed error variants and change `FibreIoConnector::connect` to return `std::io::Error`
 - [**breaking**] split the Fibre blob lifecycle into upload-ready `EncodedBlob`, private reconstruction state, and decoded `Blob`
 - remove the public manual-reconstruction API (`Blob::empty` and `Blob::set_row`); use `FibreClient::download` instead
 

--- a/fibre/Cargo.toml
+++ b/fibre/Cargo.toml
@@ -45,7 +45,6 @@ thiserror.workspace = true
 tracing.workspace = true
 hex.workspace = true
 async-trait.workspace = true
-bech32 = "0.11"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["net"] }

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -15,7 +15,7 @@ use crate::blob::{Blob, BlobID, BlobReconstruction, ShardVerifier, VerifiedRows}
 use crate::client::FibreClient;
 #[cfg(test)]
 use crate::config::BlobConfig;
-use crate::error::FibreError;
+use crate::error::{FibreError, ShardError};
 use crate::validator::ValidatorSet;
 
 /// Options for configuring blob download behavior.
@@ -39,9 +39,12 @@ impl FibreClient {
     /// # Errors
     ///
     /// - [`FibreError::ClientClosed`] if the client has been closed.
+    /// - [`FibreError::Cancelled`] if the operation is cancelled while in progress.
     /// - [`FibreError::NotFound`] if no validator returned any rows.
     /// - [`FibreError::NotEnoughShards`] if too few unique rows were collected.
-    /// - Any error from reconstruction (commitment mismatch, encoding, etc.).
+    /// - [`FibreError::UnsupportedBlobVersion`] if the blob ID version is unsupported.
+    /// - [`FibreError::Encoding`] or [`FibreError::InvalidBlobHeader`] if reconstruction fails.
+    /// - Any error returned while retrieving the validator set.
     pub async fn download(&self, id: &BlobID, opts: DownloadOptions) -> Result<Blob, FibreError> {
         if self.cancel_token.is_cancelled() {
             return Err(FibreError::ClientClosed);
@@ -136,8 +139,7 @@ impl FibreClient {
 
             tokio::select! {
                 result = self.download_semaphore.clone().acquire_owned(), if need_more => {
-                    let global_permit = result
-                        .map_err(|_| FibreError::Other("global semaphore closed".into()))?;
+                    let global_permit = result.expect("client semaphores are never closed");
                     let val_idx = cur_idx;
                     cur_idx += 1;
                     let (rows, info) = selected[val_idx];
@@ -157,10 +159,7 @@ impl FibreClient {
                             _ = task_cancel.cancelled() => Err(FibreError::Cancelled),
                             result = async {
                                 let conn = connector.connect(&validator).await?;
-                                let shard = conn.download_shard(&blob_id).await?;
-                                if shard.rows.is_empty() {
-                                    return Err(FibreError::EmptyShardResponse);
-                                }
+                                let shard = non_empty_shard(conn.download_shard(&blob_id).await?)?;
                                 // Verify here so the heavy crypto runs off the
                                 // select! loop and per-task instead of serially.
                                 verifier
@@ -234,17 +233,27 @@ impl FibreClient {
     }
 }
 
+fn non_empty_shard(
+    shard: crate::validator_client::DownloadResponse,
+) -> Result<crate::validator_client::DownloadResponse, FibreError> {
+    if shard.rows.is_empty() {
+        return Err(ShardError::Empty.into());
+    }
+    Ok(shard)
+}
+
 #[cfg(test)]
 mod tests {
     use std::future::pending;
     use std::sync::Arc;
 
+    use super::non_empty_shard;
     use tokio::sync::Barrier;
     use tokio_util::sync::CancellationToken;
 
     use crate::blob::{BlobID, BlobReconstruction, EncodedBlob};
     use crate::config::BlobConfig;
-    use crate::error::FibreError;
+    use crate::error::{FibreError, ShardError};
     use crate::payment_promise::PaymentPromise;
     use crate::test_utils::{
         MockConnector, MockValidatorConnection, build_test_client, make_validator, test_blob_config,
@@ -253,6 +262,17 @@ mod tests {
     use crate::validator_client::{
         DownloadResponse, UploadResponse, ValidatorConnection, ValidatorConnector,
     };
+
+    #[test]
+    fn empty_shard_response_is_typed() {
+        assert!(matches!(
+            non_empty_shard(DownloadResponse {
+                rows: Vec::new(),
+                rlcs: Vec::new(),
+            }),
+            Err(FibreError::InvalidShard(ShardError::Empty))
+        ));
+    }
 
     struct CoordinatedConnector {
         fast_address: [u8; 20],
@@ -278,7 +298,7 @@ mod tests {
             } else if validator.address == self.blocked_address {
                 None
             } else {
-                return Err(FibreError::HostNotFound(validator.address_hex()));
+                return Err(FibreError::HostNotFound(validator.address));
             };
 
             Ok(Arc::new(CoordinatedConnection {
@@ -297,7 +317,9 @@ mod tests {
             _rows: &[rsema1d::RowInclusionProof],
             _rlc_coeffs: &[rsema1d::GF128],
         ) -> Result<UploadResponse, FibreError> {
-            Err(FibreError::Other("upload not supported".into()))
+            Err(FibreError::GrpcClient(
+                tonic::Status::unimplemented("upload not supported").into(),
+            ))
         }
 
         async fn download_shard(&self, _blob_id: &BlobID) -> Result<DownloadResponse, FibreError> {

--- a/fibre/src/client/download.rs
+++ b/fibre/src/client/download.rs
@@ -159,7 +159,10 @@ impl FibreClient {
                             _ = task_cancel.cancelled() => Err(FibreError::Cancelled),
                             result = async {
                                 let conn = connector.connect(&validator).await?;
-                                let shard = non_empty_shard(conn.download_shard(&blob_id).await?)?;
+                                let shard = conn.download_shard(&blob_id).await?;
+                                if shard.rows.is_empty() {
+                                    return Err(ShardError::Empty.into());
+                                }
                                 // Verify here so the heavy crypto runs off the
                                 // select! loop and per-task instead of serially.
                                 verifier
@@ -233,27 +236,17 @@ impl FibreClient {
     }
 }
 
-fn non_empty_shard(
-    shard: crate::validator_client::DownloadResponse,
-) -> Result<crate::validator_client::DownloadResponse, FibreError> {
-    if shard.rows.is_empty() {
-        return Err(ShardError::Empty.into());
-    }
-    Ok(shard)
-}
-
 #[cfg(test)]
 mod tests {
     use std::future::pending;
     use std::sync::Arc;
 
-    use super::non_empty_shard;
     use tokio::sync::Barrier;
     use tokio_util::sync::CancellationToken;
 
     use crate::blob::{BlobID, BlobReconstruction, EncodedBlob};
     use crate::config::BlobConfig;
-    use crate::error::{FibreError, ShardError};
+    use crate::error::FibreError;
     use crate::payment_promise::PaymentPromise;
     use crate::test_utils::{
         MockConnector, MockValidatorConnection, build_test_client, make_validator, test_blob_config,
@@ -262,17 +255,6 @@ mod tests {
     use crate::validator_client::{
         DownloadResponse, UploadResponse, ValidatorConnection, ValidatorConnector,
     };
-
-    #[test]
-    fn empty_shard_response_is_typed() {
-        assert!(matches!(
-            non_empty_shard(DownloadResponse {
-                rows: Vec::new(),
-                rlcs: Vec::new(),
-            }),
-            Err(FibreError::InvalidShard(ShardError::Empty))
-        ));
-    }
 
     struct CoordinatedConnector {
         fast_address: [u8; 20],
@@ -639,7 +621,7 @@ mod tests {
         let cfg = test_blob_config();
         let data: Vec<u8> = (0u8..=149).collect();
 
-        // 3 validators; validator 0 returns NotFound (no proofs stored)
+        // 3 validators; validator 0 returns an empty shard
         let validators = [
             make_validator(100, 1),
             make_validator(100, 2),
@@ -652,8 +634,9 @@ mod tests {
         let blob_id = blob.id().clone();
         let total_rows = cfg.total_rows();
 
-        // Validator 0 has an empty store (returns NotFound)
+        // Validator 0 has an empty shard response
         let empty_conn = Arc::new(MockValidatorConnection::new(validators[0].0.clone()));
+        empty_conn.store_proofs(blob_id.commitment(), Vec::new(), Vec::new());
 
         // Validators 1 and 2 have proofs
         let good_conns: Vec<Arc<MockValidatorConnection>> = validators[1..]

--- a/fibre/src/client/mod.rs
+++ b/fibre/src/client/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::FibreClientConfig;
-use crate::error::FibreError;
+use crate::error::{FibreClientBuilderError, FibreError};
 use crate::validator::SetGetter;
 use crate::validator_client::ValidatorConnector;
 
@@ -80,8 +80,7 @@ impl FibreClient {
         {
             let grpc_client = celestia_grpc::GrpcClient::builder()
                 .endpoint(endpoint)
-                .build()
-                .map_err(|e| FibreError::Other(format!("failed to build GrpcClient: {e}")))?;
+                .build()?;
             Self::from_grpc_client(grpc_client, config)
         }
     }
@@ -94,8 +93,7 @@ impl FibreClient {
     ) -> Result<Self, FibreError> {
         let grpc_client = celestia_grpc::GrpcClient::builder()
             .endpoint(endpoint)
-            .build()
-            .map_err(|e| FibreError::Other(format!("failed to build GrpcClient: {e}")))?;
+            .build()?;
 
         Self::from_grpc_client_with_io_connector(grpc_client, config, io_connector)
     }
@@ -181,15 +179,13 @@ impl FibreClientBuilder {
 
     /// Builds the [`FibreClient`].
     pub fn build(self) -> Result<FibreClient, FibreError> {
-        let cfg = self
-            .config
-            .ok_or_else(|| FibreError::Other("config is required".into()))?;
+        let cfg = self.config.ok_or(FibreClientBuilderError::MissingConfig)?;
         let set_getter = self
             .set_getter
-            .ok_or_else(|| FibreError::Other("set_getter is required".into()))?;
+            .ok_or(FibreClientBuilderError::MissingSetGetter)?;
         let connector = self
             .connector
-            .ok_or_else(|| FibreError::Other("connector is required".into()))?;
+            .ok_or(FibreClientBuilderError::MissingConnector)?;
 
         Ok(FibreClient {
             upload_semaphore: Arc::new(tokio::sync::Semaphore::new(cfg.upload_concurrency)),
@@ -262,10 +258,7 @@ mod tests {
             "not a valid url \x00",
             FibreClientConfig::new("test-chain").unwrap(),
         );
-        assert!(
-            result.is_err(),
-            "from_endpoint with invalid URL should fail"
-        );
+        assert!(matches!(result, Err(FibreError::GrpcClientBuilder(_))));
     }
 
     #[tokio::test]
@@ -285,16 +278,10 @@ mod tests {
             .connector(DummyConnector)
             .build();
 
-        match result {
-            Err(FibreError::Other(msg)) => {
-                assert!(
-                    msg.contains("config"),
-                    "error should mention config, got: {msg}"
-                );
-            }
-            Err(other) => panic!("expected FibreError::Other mentioning config, got: {other}"),
-            Ok(_) => panic!("expected an error but build() succeeded"),
-        }
+        assert!(matches!(
+            result,
+            Err(FibreError::Builder(FibreClientBuilderError::MissingConfig))
+        ));
     }
 
     #[test]
@@ -304,16 +291,12 @@ mod tests {
             .connector(DummyConnector)
             .build();
 
-        match result {
-            Err(FibreError::Other(msg)) => {
-                assert!(
-                    msg.contains("set_getter"),
-                    "error should mention set_getter, got: {msg}"
-                );
-            }
-            Err(other) => panic!("expected FibreError::Other mentioning set_getter, got: {other}"),
-            Ok(_) => panic!("expected an error but build() succeeded"),
-        }
+        assert!(matches!(
+            result,
+            Err(FibreError::Builder(
+                FibreClientBuilderError::MissingSetGetter
+            ))
+        ));
     }
 
     #[test]
@@ -323,16 +306,12 @@ mod tests {
             .set_getter(DummySetGetter)
             .build();
 
-        match result {
-            Err(FibreError::Other(msg)) => {
-                assert!(
-                    msg.contains("connector"),
-                    "error should mention connector, got: {msg}"
-                );
-            }
-            Err(other) => panic!("expected FibreError::Other mentioning connector, got: {other}"),
-            Ok(_) => panic!("expected an error but build() succeeded"),
-        }
+        assert!(matches!(
+            result,
+            Err(FibreError::Builder(
+                FibreClientBuilderError::MissingConnector
+            ))
+        ));
     }
 
     #[test]

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -21,7 +21,7 @@ use crate::client::task::{TaskSet, spawn_task};
 use crate::blob::EncodedBlob;
 use crate::client::FibreClient;
 use crate::config::BlobConfig;
-use crate::error::FibreError;
+use crate::error::{FibreError, ValidatorSetError};
 use crate::payment_promise::{PaymentPromise, SignedPaymentPromise};
 use crate::validator::signature_set::SignatureSet;
 use crate::validator::{ShardMap, ValidatorSet};
@@ -59,6 +59,15 @@ impl FibreClient {
     ///
     /// Returns a [`SignedPaymentPromise`] once enough validator signatures
     /// have been collected to meet the safety threshold.
+    ///
+    /// # Errors
+    ///
+    /// - [`FibreError::ClientClosed`] if the client has been closed.
+    /// - [`FibreError::BlobTooLarge`] if the upload size does not fit the wire format.
+    /// - [`FibreError::InvalidValidatorSet`] if the validator set height is zero.
+    /// - [`FibreError::InvalidPaymentPromise`] if the payment promise cannot be signed.
+    /// - [`FibreError::NotEnoughSignatures`] if the voting-power threshold is not met.
+    /// - Any error returned while retrieving the validator set or contacting validators.
     pub async fn upload(
         &self,
         signing_key: &k256::ecdsa::SigningKey,
@@ -76,6 +85,10 @@ impl FibreClient {
     /// The signed payment promise is returned once enough validator signatures
     /// have been collected to meet the safety threshold. The completion handle
     /// can then be awaited to drain every validator upload started for the blob.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`FibreClient::upload`].
     pub async fn upload_with_completion(
         &self,
         signing_key: &k256::ecdsa::SigningKey,
@@ -98,9 +111,7 @@ impl FibreClient {
 
         let mut promise = PaymentPromise {
             chain_id: self.cfg.chain_id().to_owned(),
-            height: NonZeroU64::new(val_set.height).ok_or_else(|| {
-                FibreError::InvalidPaymentPromise("height must be positive, got 0".into())
-            })?,
+            height: NonZeroU64::new(val_set.height).ok_or(ValidatorSetError::ZeroHeight)?,
             namespace,
             upload_size: upload_size_u32,
             blob_version: blob.config().blob_version as u32,
@@ -225,7 +236,7 @@ impl FibreClient {
                 .clone()
                 .acquire_owned()
                 .await
-                .map_err(|_| FibreError::Other("upload semaphore closed".into()))?;
+                .expect("client semaphores are never closed");
 
             let connector = Arc::clone(&self.connector);
             let validator = val_set.validators[val_idx].clone();

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -62,11 +62,12 @@ impl FibreClient {
     /// # Errors
     ///
     /// - [`FibreError::ClientClosed`] if the client has been closed.
+    /// - [`FibreError::Cancelled`] if the client is closed while the upload is in progress.
     /// - [`FibreError::BlobTooLarge`] if the upload size does not fit the wire format.
     /// - [`FibreError::InvalidValidatorSet`] if the validator set height is zero.
     /// - [`FibreError::InvalidPaymentPromise`] if the payment promise cannot be signed.
     /// - [`FibreError::NotEnoughSignatures`] if the voting-power threshold is not met.
-    /// - Any error returned while retrieving the validator set or contacting validators.
+    /// - Any error returned while retrieving the validator set.
     pub async fn upload(
         &self,
         signing_key: &k256::ecdsa::SigningKey,

--- a/fibre/src/domain/blob.rs
+++ b/fibre/src/domain/blob.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use crate::blob_header::BlobHeaderV0;
 use crate::config::BlobConfig;
-use crate::error::FibreError;
+use crate::error::{BlobIdError, FibreError, ShardError};
 
 /// A 32-byte SHA-256 commitment hash. Re-exports rsema1d's Commitment type.
 pub type Commitment = rsema1d::Commitment;
@@ -72,11 +72,7 @@ impl BlobID {
     /// Returns an error if the slice is not exactly `BLOB_ID_SIZE` bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, FibreError> {
         if bytes.len() != BLOB_ID_SIZE {
-            return Err(FibreError::InvalidBlobId(format!(
-                "blob ID must be {} bytes, got {}",
-                BLOB_ID_SIZE,
-                bytes.len()
-            )));
+            return Err(BlobIdError::Length(bytes.len()).into());
         }
         let mut id = [0u8; BLOB_ID_SIZE];
         id.copy_from_slice(bytes);
@@ -85,8 +81,7 @@ impl BlobID {
 
     /// Construct a BlobID from a hex-encoded string.
     pub fn from_hex(s: &str) -> Result<Self, FibreError> {
-        let bytes = hex::decode(s)
-            .map_err(|e| FibreError::InvalidBlobId(format!("decoding hex: {}", e)))?;
+        let bytes = hex::decode(s).map_err(BlobIdError::Hex)?;
         Self::from_bytes(&bytes)
     }
 }
@@ -371,9 +366,7 @@ impl ShardVerifier {
         for proof in rows {
             let index = proof.index;
             if index >= total_rows {
-                return Err(FibreError::InvalidData(format!(
-                    "row index {index} out of bounds (total rows: {total_rows})"
-                )));
+                return Err(ShardError::RowIndexOutOfBounds { index, total_rows }.into());
             }
             if seen[index] || already_stored.get(index).copied().unwrap_or(false) {
                 continue;
@@ -389,9 +382,11 @@ impl ShardVerifier {
         let row_size = needed[0].row.len();
         let max_row_size = self.cfg.row_size(self.cfg.max_data_size);
         if row_size == 0 || row_size > max_row_size {
-            return Err(FibreError::InvalidData(format!(
-                "row size {row_size} out of bounds (max {max_row_size})"
-            )));
+            return Err(ShardError::RowSizeOutOfBounds {
+                row_size,
+                max_row_size,
+            }
+            .into());
         }
 
         let (context, verified) = {
@@ -399,9 +394,7 @@ impl ShardVerifier {
             match cache.as_ref() {
                 Some((cached_rlcs, context)) => {
                     if cached_rlcs != rlcs {
-                        return Err(FibreError::InvalidData(
-                            "rlc vector does not match the verified one".into(),
-                        ));
+                        return Err(ShardError::RlcVectorMismatch.into());
                     }
                     (Arc::clone(context), 0)
                 }
@@ -466,8 +459,22 @@ mod tests {
 
     #[test]
     fn blob_id_from_bytes_wrong_length() {
-        assert!(BlobID::from_bytes(&[0u8; 10]).is_err());
-        assert!(BlobID::from_bytes(&[0u8; 34]).is_err());
+        assert!(matches!(
+            BlobID::from_bytes(&[0u8; 10]),
+            Err(FibreError::InvalidBlobId(BlobIdError::Length(10)))
+        ));
+        assert!(matches!(
+            BlobID::from_bytes(&[0u8; 34]),
+            Err(FibreError::InvalidBlobId(BlobIdError::Length(34)))
+        ));
+    }
+
+    #[test]
+    fn blob_id_from_hex_rejects_invalid_hex() {
+        assert!(matches!(
+            BlobID::from_hex("not hex"),
+            Err(FibreError::InvalidBlobId(BlobIdError::Hex(_)))
+        ));
     }
 
     #[test]
@@ -663,7 +670,10 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(matches!(err, FibreError::InvalidData(_)), "got {err}");
+        assert!(matches!(
+            err,
+            FibreError::InvalidShard(ShardError::RowSizeOutOfBounds { .. })
+        ));
     }
 
     #[tokio::test]
@@ -681,7 +691,10 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(matches!(err, FibreError::InvalidData(_)), "got {err}");
+        assert!(matches!(
+            err,
+            FibreError::InvalidShard(ShardError::RowIndexOutOfBounds { .. })
+        ));
     }
 
     #[tokio::test]
@@ -798,7 +811,10 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(matches!(err, FibreError::InvalidData(_)), "got {err}");
+        assert!(matches!(
+            err,
+            FibreError::InvalidShard(ShardError::RlcVectorMismatch)
+        ));
         assert_eq!(
             fresh_reconstruction
                 .stored_rows_bitmap()

--- a/fibre/src/domain/blob_header.rs
+++ b/fibre/src/domain/blob_header.rs
@@ -3,7 +3,7 @@
 //! The blob header is prepended to the original data before splitting into rows.
 
 use crate::config::BlobConfig;
-use crate::error::FibreError;
+use crate::error::{BlobHeaderError, FibreError};
 
 /// Length of the version field in bytes.
 const BLOB_VERSION_LEN: usize = 1;
@@ -62,15 +62,11 @@ impl BlobHeaderV0 {
         cfg: &BlobConfig,
     ) -> Result<(Self, Vec<u8>), FibreError> {
         if rows.is_empty() {
-            return Err(FibreError::Other("no rows to decode".into()));
+            return Err(BlobHeaderError::NoRows.into());
         }
 
         if rows[0].len() < Self::HEADER_SIZE {
-            return Err(FibreError::Other(format!(
-                "first row too small: need at least {} bytes for header, got {}",
-                Self::HEADER_SIZE,
-                rows[0].len()
-            )));
+            return Err(BlobHeaderError::FirstRowTooSmall(rows[0].len()).into());
         }
 
         // Decode header from first row
@@ -78,15 +74,14 @@ impl BlobHeaderV0 {
 
         // Validate blob size is within reasonable bounds
         if header.data_size == 0 {
-            return Err(FibreError::Other(
-                "invalid blob size in header: must be greater than 0".into(),
-            ));
+            return Err(BlobHeaderError::ZeroDataSize.into());
         }
         if header.data_size as usize > cfg.max_data_size {
-            return Err(FibreError::Other(format!(
-                "blob size in header ({} bytes) exceeds maximum allowed size ({} bytes)",
-                header.data_size, cfg.max_data_size
-            )));
+            return Err(BlobHeaderError::DataSizeExceedsMax {
+                size: header.data_size,
+                max: cfg.max_data_size,
+            }
+            .into());
         }
 
         let data_size = header.data_size as usize;
@@ -112,10 +107,11 @@ impl BlobHeaderV0 {
         }
 
         if offset != data_size {
-            return Err(FibreError::Other(format!(
-                "data size mismatch: copied {} bytes, expected {}",
-                offset, data_size
-            )));
+            return Err(BlobHeaderError::DataSizeMismatch {
+                copied: offset,
+                expected: data_size,
+            }
+            .into());
         }
 
         Ok((header, data))
@@ -175,7 +171,22 @@ mod tests {
     fn decode_empty_rows() {
         let cfg = test_blob_config();
         let rows: &[&[u8]] = &[];
-        assert!(BlobHeaderV0::decode_from_rows(rows, &cfg).is_err());
+        assert!(matches!(
+            BlobHeaderV0::decode_from_rows(rows, &cfg),
+            Err(FibreError::InvalidBlobHeader(BlobHeaderError::NoRows))
+        ));
+    }
+
+    #[test]
+    fn decode_first_row_too_small() {
+        let cfg = test_blob_config();
+        let row = [0u8; BlobHeaderV0::HEADER_SIZE - 1];
+        assert!(matches!(
+            BlobHeaderV0::decode_from_rows(&[&row], &cfg),
+            Err(FibreError::InvalidBlobHeader(
+                BlobHeaderError::FirstRowTooSmall(4)
+            ))
+        ));
     }
 
     #[test]
@@ -183,6 +194,41 @@ mod tests {
         let cfg = test_blob_config();
         let mut row = vec![0u8; 64];
         row[1..5].copy_from_slice(&0u32.to_be_bytes());
-        assert!(BlobHeaderV0::decode_from_rows(&[row.as_slice()], &cfg).is_err());
+        assert!(matches!(
+            BlobHeaderV0::decode_from_rows(&[row.as_slice()], &cfg),
+            Err(FibreError::InvalidBlobHeader(BlobHeaderError::ZeroDataSize))
+        ));
+    }
+
+    #[test]
+    fn decode_data_size_exceeds_max() {
+        let cfg = test_blob_config();
+        let mut row = vec![0u8; 64];
+        row[1..5].copy_from_slice(&1025u32.to_be_bytes());
+        assert!(matches!(
+            BlobHeaderV0::decode_from_rows(&[row.as_slice()], &cfg),
+            Err(FibreError::InvalidBlobHeader(
+                BlobHeaderError::DataSizeExceedsMax {
+                    size: 1025,
+                    max: 1024
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn decode_data_size_mismatch() {
+        let cfg = test_blob_config();
+        let mut row = vec![0u8; BlobHeaderV0::HEADER_SIZE];
+        row[1..5].copy_from_slice(&1u32.to_be_bytes());
+        assert!(matches!(
+            BlobHeaderV0::decode_from_rows(&[row.as_slice()], &cfg),
+            Err(FibreError::InvalidBlobHeader(
+                BlobHeaderError::DataSizeMismatch {
+                    copied: 0,
+                    expected: 1
+                }
+            ))
+        ));
     }
 }

--- a/fibre/src/domain/config.rs
+++ b/fibre/src/domain/config.rs
@@ -5,7 +5,11 @@
 
 use std::num::NonZeroU64;
 
+#[cfg(test)]
 use super::payment_promise::MAX_CHAIN_ID_SIZE;
+use super::payment_promise::validate_chain_id;
+#[cfg(test)]
+use crate::error::ChainIdError;
 use crate::error::FibreError;
 
 /// Fraction represented as numerator/denominator.
@@ -182,18 +186,7 @@ impl FibreClientConfig {
         params: &ProtocolParams,
     ) -> Result<Self, FibreError> {
         let chain_id = chain_id.into();
-        if chain_id.is_empty() {
-            return Err(FibreError::InvalidChainId(
-                "chain ID must not be empty".into(),
-            ));
-        }
-        if chain_id.len() > MAX_CHAIN_ID_SIZE {
-            return Err(FibreError::InvalidChainId(format!(
-                "chain ID length {} exceeds maximum {}",
-                chain_id.len(),
-                MAX_CHAIN_ID_SIZE
-            )));
-        }
+        validate_chain_id(&chain_id)?;
 
         Ok(Self {
             chain_id,
@@ -450,13 +443,15 @@ mod tests {
     fn fibre_client_config_rejects_invalid_chain_id() {
         assert!(matches!(
             FibreClientConfig::new(""),
-            Err(FibreError::InvalidChainId(_))
+            Err(FibreError::InvalidChainId(ChainIdError::Empty))
         ));
 
         let too_long = "x".repeat(MAX_CHAIN_ID_SIZE + 1);
         assert!(matches!(
             FibreClientConfig::new(too_long),
-            Err(FibreError::InvalidChainId(_))
+            Err(FibreError::InvalidChainId(ChainIdError::TooLong(
+                len
+            ))) if len == MAX_CHAIN_ID_SIZE + 1
         ));
     }
 

--- a/fibre/src/domain/config.rs
+++ b/fibre/src/domain/config.rs
@@ -5,12 +5,18 @@
 
 use std::num::NonZeroU64;
 
-#[cfg(test)]
-use super::payment_promise::MAX_CHAIN_ID_SIZE;
-use super::payment_promise::validate_chain_id;
-#[cfg(test)]
-use crate::error::ChainIdError;
 use crate::error::FibreError;
+
+/// Maximum allowed chain ID length.
+pub(crate) const MAX_CHAIN_ID_SIZE: usize = 20;
+
+pub(crate) fn validate_chain_id(chain_id: &str) -> Result<(), FibreError> {
+    let len = chain_id.len();
+    if len == 0 || len > MAX_CHAIN_ID_SIZE {
+        return Err(FibreError::InvalidChainId { len });
+    }
+    Ok(())
+}
 
 /// Fraction represented as numerator/denominator.
 ///
@@ -443,15 +449,13 @@ mod tests {
     fn fibre_client_config_rejects_invalid_chain_id() {
         assert!(matches!(
             FibreClientConfig::new(""),
-            Err(FibreError::InvalidChainId(ChainIdError::Empty))
+            Err(FibreError::InvalidChainId { len: 0 })
         ));
 
         let too_long = "x".repeat(MAX_CHAIN_ID_SIZE + 1);
         assert!(matches!(
             FibreClientConfig::new(too_long),
-            Err(FibreError::InvalidChainId(ChainIdError::TooLong(
-                len
-            ))) if len == MAX_CHAIN_ID_SIZE + 1
+            Err(FibreError::InvalidChainId { len }) if len == MAX_CHAIN_ID_SIZE + 1
         ));
     }
 

--- a/fibre/src/domain/error.rs
+++ b/fibre/src/domain/error.rs
@@ -4,7 +4,8 @@ use thiserror::Error;
 
 use super::blob::BLOB_ID_SIZE;
 use super::blob_header::BlobHeaderV0;
-use super::payment_promise::{MAX_CHAIN_ID_SIZE, SIGNATURE_SIZE};
+use super::config::MAX_CHAIN_ID_SIZE;
+use super::payment_promise::SIGNATURE_SIZE;
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
@@ -57,21 +58,7 @@ pub enum ShardError {
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-pub enum ChainIdError {
-    #[error("chain ID must not be empty")]
-    Empty,
-    #[error(
-        "chain ID length {0} exceeds maximum {max}",
-        max = MAX_CHAIN_ID_SIZE
-    )]
-    TooLong(usize),
-}
-
-#[allow(missing_docs)]
-#[derive(Debug, Error)]
 pub enum PaymentPromiseError {
-    #[error(transparent)]
-    ChainId(#[from] ChainIdError),
     #[error("upload size must be positive")]
     ZeroUploadSize,
     #[error("creation timestamp must not be zero")]
@@ -212,9 +199,15 @@ pub enum FibreError {
     #[error("payment promise validation failed: {0}")]
     InvalidPaymentPromise(#[from] PaymentPromiseError),
 
-    /// The configured chain ID is invalid.
-    #[error("invalid chain ID: {0}")]
-    InvalidChainId(#[from] ChainIdError),
+    /// The chain ID length is outside the supported range.
+    #[error(
+        "invalid chain ID length {len}; expected 1..={max}",
+        max = MAX_CHAIN_ID_SIZE
+    )]
+    InvalidChainId {
+        /// Actual chain ID length in bytes.
+        len: usize,
+    },
 
     /// The Fibre client builder is missing a required value.
     #[error("client builder error: {0}")]

--- a/fibre/src/domain/error.rs
+++ b/fibre/src/domain/error.rs
@@ -2,10 +2,126 @@
 
 use thiserror::Error;
 
+use super::blob::BLOB_ID_SIZE;
+use super::blob_header::BlobHeaderV0;
+use super::payment_promise::{MAX_CHAIN_ID_SIZE, SIGNATURE_SIZE};
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum BlobIdError {
+    #[error("blob ID must be {expected} bytes, got {0}", expected = BLOB_ID_SIZE)]
+    Length(usize),
+    #[error("blob ID is not valid hex: {0}")]
+    Hex(#[from] hex::FromHexError),
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum BlobHeaderError {
+    #[error("no rows to decode")]
+    NoRows,
+    #[error(
+        "first row too small: need at least {expected} bytes for header, got {0}",
+        expected = BlobHeaderV0::HEADER_SIZE
+    )]
+    FirstRowTooSmall(usize),
+    #[error("blob size in header must be greater than 0")]
+    ZeroDataSize,
+    #[error("blob size in header ({size} bytes) exceeds maximum allowed size ({max} bytes)")]
+    DataSizeExceedsMax { size: u32, max: usize },
+    #[error("data size mismatch: copied {copied} bytes, expected {expected}")]
+    DataSizeMismatch { copied: usize, expected: usize },
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum ShardError {
+    #[error("empty shard response from validator")]
+    Empty,
+    #[error("download response is missing shard")]
+    MissingShard,
+    #[error("proof hash has invalid length {0}, expected 32")]
+    ProofHashLength(usize),
+    #[error("rlc vector has invalid length {0}, expected a non-zero multiple of 16")]
+    RlcVectorLength(usize),
+    #[error("row index {index} out of bounds (total rows: {total_rows})")]
+    RowIndexOutOfBounds { index: usize, total_rows: usize },
+    #[error("row size {row_size} out of bounds (max {max_row_size})")]
+    RowSizeOutOfBounds {
+        row_size: usize,
+        max_row_size: usize,
+    },
+    #[error("rlc vector does not match the verified one")]
+    RlcVectorMismatch,
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum ChainIdError {
+    #[error("chain ID must not be empty")]
+    Empty,
+    #[error(
+        "chain ID length {0} exceeds maximum {max}",
+        max = MAX_CHAIN_ID_SIZE
+    )]
+    TooLong(usize),
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum PaymentPromiseError {
+    #[error(transparent)]
+    ChainId(#[from] ChainIdError),
+    #[error("upload size must be positive")]
+    ZeroUploadSize,
+    #[error("creation timestamp must not be zero")]
+    ZeroTimestamp,
+    #[error("creation timestamp is before Unix epoch")]
+    TimestampBeforeEpoch(#[source] std::time::SystemTimeError),
+    #[error("signature must be present")]
+    MissingSignature,
+    #[error(
+        "signature must be {expected} bytes, got {0}",
+        expected = SIGNATURE_SIZE
+    )]
+    SignatureLength(usize),
+    #[error("invalid signature format: {0}")]
+    SignatureFormat(#[source] k256::ecdsa::Error),
+    #[error("signature verification failed: {0}")]
+    SignatureVerification(#[source] k256::ecdsa::Error),
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum ValidatorSetError {
+    #[error("validator set response is missing validator_set")]
+    Missing,
+    #[error("validator set height must be greater than 0")]
+    ZeroHeight,
+    #[error("validator is missing a public key")]
+    MissingPublicKey,
+    #[error("expected ed25519 public key for validator")]
+    UnsupportedPublicKeyType,
+    #[error("ed25519 key has invalid length {0}, expected 32")]
+    PublicKeyLength(usize),
+    #[error("invalid ed25519 key: {0}")]
+    InvalidPublicKey(#[source] ed25519_dalek::SignatureError),
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum FibreClientBuilderError {
+    #[error("config is required")]
+    MissingConfig,
+    #[error("set_getter is required")]
+    MissingSetGetter,
+    #[error("connector is required")]
+    MissingConnector,
+}
+
 /// All errors that can occur in the Fibre client library.
 #[derive(Debug, Error)]
 pub enum FibreError {
-    // -- Blob errors --
     /// The blob data provided was empty.
     #[error("blob data is empty")]
     EmptyBlobData,
@@ -19,28 +135,18 @@ pub enum FibreError {
         max: usize,
     },
 
-    /// The computed commitment does not match the expected commitment.
-    #[error("commitment mismatch: expected {expected}, got {actual}")]
-    CommitmentMismatch {
-        /// The expected commitment (hex-encoded).
-        expected: String,
-        /// The actual commitment (hex-encoded).
-        actual: String,
-    },
-
     /// The blob version is not supported by this client.
     #[error("unsupported blob version: {0}")]
     UnsupportedBlobVersion(u8),
 
     /// The blob ID is invalid.
     #[error("invalid blob ID: {0}")]
-    InvalidBlobId(String),
+    InvalidBlobId(#[from] BlobIdError),
 
-    /// Invalid or malformed data encountered during processing.
-    #[error("invalid data: {0}")]
-    InvalidData(String),
+    /// The blob header is invalid.
+    #[error("invalid blob header: {0}")]
+    InvalidBlobHeader(#[from] BlobHeaderError),
 
-    // -- Download errors --
     /// No shards were found for the requested blob.
     #[error("blob not found: no shards retrieved")]
     NotFound,
@@ -54,11 +160,10 @@ pub enum FibreError {
         need: usize,
     },
 
-    /// A validator returned an empty shard response.
-    #[error("empty shard response from validator")]
-    EmptyShardResponse,
+    /// A validator returned an invalid shard.
+    #[error("invalid shard: {0}")]
+    InvalidShard(#[from] ShardError),
 
-    // -- Upload errors --
     /// Not enough validator signatures were collected to meet the voting power threshold.
     #[error("not enough voting power: collected {collected}, required {required}")]
     NotEnoughSignatures {
@@ -69,27 +174,59 @@ pub enum FibreError {
     },
 
     /// A validator returned an invalid signature.
-    #[error("invalid validator signature from {validator}: {reason}")]
+    #[error(
+        "invalid validator signature from {}: {source}",
+        hex::encode_upper(.validator)
+    )]
     InvalidValidatorSignature {
-        /// Hex-encoded validator address.
-        validator: String,
-        /// Reason the signature is invalid.
-        reason: String,
+        /// Validator consensus address.
+        validator: [u8; 20],
+        /// Signature parsing or verification failure.
+        #[source]
+        source: ed25519_dalek::SignatureError,
     },
 
-    // -- PaymentPromise errors --
     /// The payment promise failed validation.
     #[error("payment promise validation failed: {0}")]
-    InvalidPaymentPromise(String),
+    InvalidPaymentPromise(#[from] PaymentPromiseError),
 
     /// The configured chain ID is invalid.
     #[error("invalid chain ID: {0}")]
-    InvalidChainId(String),
+    InvalidChainId(#[from] ChainIdError),
 
-    // -- Connection errors --
+    /// The Fibre client builder is missing a required value.
+    #[error("client builder error: {0}")]
+    Builder(#[from] FibreClientBuilderError),
+
+    /// WASM transports require an explicit byte-stream connector.
+    #[error("a Fibre I/O connector is required on WASM")]
+    IoConnectorRequired,
+
+    /// The validator set is invalid.
+    #[error("invalid validator set: {0}")]
+    InvalidValidatorSet(#[from] ValidatorSetError),
+
+    /// The validator consensus address is invalid.
+    #[error("invalid validator consensus address: {0}")]
+    InvalidValidatorAddress(#[source] celestia_types::Error),
+
     /// No host address was found for a validator.
-    #[error("host not found for validator {0}")]
-    HostNotFound(String),
+    #[error("host not found for validator {}", hex::encode_upper(.0))]
+    HostNotFound([u8; 20]),
+
+    /// A Fibre endpoint could not be parsed.
+    #[error("invalid Fibre endpoint '{endpoint}': {source}")]
+    InvalidEndpoint {
+        /// Endpoint string that failed to parse.
+        endpoint: String,
+        /// URI parsing error.
+        #[source]
+        source: http::uri::InvalidUri,
+    },
+
+    /// A Fibre endpoint has no host component.
+    #[error("Fibre endpoint '{0}' has no host")]
+    EndpointMissingHost(http::Uri),
 
     /// The client has been closed and can no longer process requests.
     #[error("client is closed")]
@@ -99,56 +236,17 @@ pub enum FibreError {
     #[error("operation cancelled")]
     Cancelled,
 
-    /// WASM transports require an explicit byte-stream connector.
-    #[error("a Fibre I/O connector is required on WASM")]
-    IoConnectorRequired,
-
-    // -- Wrapped errors --
-    /// A gRPC status error from tonic (per-validator connections).
-    #[error("gRPC error: {0}")]
-    Grpc(Box<tonic::Status>),
-
     /// An error from the GrpcClient (consensus node queries).
     #[error("grpc client error: {0}")]
     GrpcClient(#[from] celestia_grpc::Error),
 
+    /// An error while building a gRPC client.
+    #[error("failed to build gRPC client: {0}")]
+    GrpcClientBuilder(#[from] celestia_grpc::GrpcClientBuilderError),
+
     /// An error from the rsema1d erasure coding library.
     #[error("encoding error: {0}")]
     Encoding(#[from] rsema1d::Error),
-
-    /// A tonic transport error (connection failure, TLS, etc.).
-    #[cfg(not(target_arch = "wasm32"))]
-    #[error("transport error: {0}")]
-    Transport(#[from] tonic::transport::Error),
-
-    /// A secp256k1 ECDSA error (key or signature operations).
-    ///
-    /// Note: `k256::ecdsa::Error` and `ed25519_dalek::SignatureError` are both
-    /// re-exports of `signature::Error`, so we use a single variant for both.
-    /// The `#[from]` trait is not used to avoid conflicting blanket implementations;
-    /// use `FibreError::CryptoSignature(err)` explicitly instead.
-    #[error("cryptographic signature error: {0}")]
-    CryptoSignature(k256::ecdsa::Error),
-
-    /// A protobuf decoding error.
-    #[error("proto decode error: {0}")]
-    ProtoDecode(#[from] prost::DecodeError),
-
-    /// A catch-all error for cases not covered by other variants.
-    #[error("{0}")]
-    Other(String),
-}
-
-impl From<tonic::Status> for FibreError {
-    fn from(err: tonic::Status) -> Self {
-        FibreError::Grpc(Box::new(err))
-    }
-}
-
-impl From<k256::ecdsa::Error> for FibreError {
-    fn from(err: k256::ecdsa::Error) -> Self {
-        FibreError::CryptoSignature(err)
-    }
 }
 
 /// Convenience alias for `std::result::Result<T, FibreError>`.

--- a/fibre/src/domain/payment_promise.rs
+++ b/fibre/src/domain/payment_promise.rs
@@ -13,7 +13,7 @@ use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
 
 use crate::blob::Commitment;
-use crate::error::FibreError;
+use crate::error::{ChainIdError, FibreError, PaymentPromiseError};
 
 /// Domain separation prefix prepended to sign bytes.
 /// Ensures payment promise signatures cannot be confused with consensus messages.
@@ -23,10 +23,20 @@ pub const SIGN_BYTES_PREFIX: &[u8] = b"fibre/pp:v0";
 const PUBKEY_SIZE: usize = 33;
 
 /// Size of a secp256k1 signature in compact format (32 bytes r + 32 bytes s).
-const SIGNATURE_SIZE: usize = 64;
+pub(crate) const SIGNATURE_SIZE: usize = 64;
 
 /// Maximum allowed chain ID length.
 pub(crate) const MAX_CHAIN_ID_SIZE: usize = 20;
+
+pub(crate) fn validate_chain_id(chain_id: &str) -> Result<(), ChainIdError> {
+    if chain_id.is_empty() {
+        return Err(ChainIdError::Empty);
+    }
+    if chain_id.len() > MAX_CHAIN_ID_SIZE {
+        return Err(ChainIdError::TooLong(chain_id.len()));
+    }
+    Ok(())
+}
 
 /// Size of the Go time.Time MarshalBinary output for UTC times.
 const TIMESTAMP_BINARY_SIZE: usize = 15;
@@ -149,63 +159,38 @@ impl PaymentPromise {
     /// Performs stateless validation of all field constraints and verifies
     /// the signature using the signer's public key.
     pub fn validate(&self) -> Result<(), FibreError> {
-        // Chain ID must not be empty
-        if self.chain_id.is_empty() {
-            return Err(FibreError::InvalidPaymentPromise(
-                "chain id must not be empty".into(),
-            ));
-        }
-
-        // Chain ID length limit
-        if self.chain_id.len() > MAX_CHAIN_ID_SIZE {
-            return Err(FibreError::InvalidPaymentPromise(format!(
-                "chain id length {} exceeds maximum {}",
-                self.chain_id.len(),
-                MAX_CHAIN_ID_SIZE
-            )));
-        }
+        validate_chain_id(&self.chain_id).map_err(PaymentPromiseError::ChainId)?;
 
         // Upload size must be positive
         if self.upload_size == 0 {
-            return Err(FibreError::InvalidPaymentPromise(
-                "upload size must be positive".into(),
-            ));
+            return Err(PaymentPromiseError::ZeroUploadSize.into());
         }
 
         // Creation timestamp must not be Unix epoch (Go's zero value check)
         if self.creation_timestamp == SystemTime::UNIX_EPOCH {
-            return Err(FibreError::InvalidPaymentPromise(
-                "creation timestamp must not be zero".into(),
-            ));
+            return Err(PaymentPromiseError::ZeroTimestamp.into());
         }
 
         // Signature must be present and correct size
         let signature_bytes = self
             .signature
             .as_ref()
-            .ok_or_else(|| FibreError::InvalidPaymentPromise("signature must be present".into()))?;
+            .ok_or(PaymentPromiseError::MissingSignature)?;
 
         if signature_bytes.len() != SIGNATURE_SIZE {
-            return Err(FibreError::InvalidPaymentPromise(format!(
-                "signature must be {} bytes, got {}",
-                SIGNATURE_SIZE,
-                signature_bytes.len()
-            )));
+            return Err(PaymentPromiseError::SignatureLength(signature_bytes.len()).into());
         }
 
         // Verify signature
         let sign_bytes = self.sign_bytes()?;
 
-        let signature = Signature::from_slice(signature_bytes).map_err(|e| {
-            FibreError::InvalidPaymentPromise(format!("invalid signature format: {}", e))
-        })?;
+        let signature =
+            Signature::from_slice(signature_bytes).map_err(PaymentPromiseError::SignatureFormat)?;
 
         use k256::ecdsa::signature::Verifier;
         self.signer_pubkey
             .verify(&sign_bytes, &signature)
-            .map_err(|_| {
-                FibreError::InvalidPaymentPromise("signature verification failed".into())
-            })?;
+            .map_err(PaymentPromiseError::SignatureVerification)?;
 
         Ok(())
     }
@@ -214,9 +199,10 @@ impl PaymentPromise {
     ///
     /// The signature must be set before calling this method.
     pub fn hash(&self) -> Result<[u8; 32], FibreError> {
-        let signature = self.signature.as_ref().ok_or_else(|| {
-            FibreError::InvalidPaymentPromise("signature must be set before computing hash".into())
-        })?;
+        let signature = self
+            .signature
+            .as_ref()
+            .ok_or(PaymentPromiseError::MissingSignature)?;
 
         let sign_bytes = self.sign_bytes()?;
 
@@ -272,7 +258,7 @@ const UNIX_TO_INTERNAL: i64 = (1969 * 365 + 1969 / 4 - 1969 / 100 + 1969 / 400) 
 fn marshal_binary_time(t: SystemTime) -> Result<Vec<u8>, FibreError> {
     let duration = t
         .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|_| FibreError::InvalidPaymentPromise("timestamp before Unix epoch".into()))?;
+        .map_err(PaymentPromiseError::TimestampBeforeEpoch)?;
 
     // Convert from Unix epoch to Go's internal epoch (year 1)
     let secs = duration.as_secs() as i64 + UNIX_TO_INTERNAL;
@@ -299,21 +285,9 @@ fn marshal_binary_time(t: SystemTime) -> Result<Vec<u8>, FibreError> {
 
 /// Unmarshal a timestamp from Go's `time.Time.MarshalBinary()` format back to `SystemTime`.
 #[cfg(test)]
-fn unmarshal_binary_time(data: &[u8]) -> Result<SystemTime, FibreError> {
-    if data.len() != TIMESTAMP_BINARY_SIZE {
-        return Err(FibreError::Other(format!(
-            "timestamp binary must be {} bytes, got {}",
-            TIMESTAMP_BINARY_SIZE,
-            data.len()
-        )));
-    }
-
-    if data[0] != 1 {
-        return Err(FibreError::Other(format!(
-            "unsupported timestamp version: {}",
-            data[0]
-        )));
-    }
+fn unmarshal_binary_time(data: &[u8]) -> SystemTime {
+    assert_eq!(data.len(), TIMESTAMP_BINARY_SIZE);
+    assert_eq!(data[0], 1);
 
     // Seconds since year 1 (Go's internal epoch)
     let internal_secs = i64::from_be_bytes(data[1..9].try_into().unwrap());
@@ -322,19 +296,11 @@ fn unmarshal_binary_time(data: &[u8]) -> Result<SystemTime, FibreError> {
     // Convert from Go's internal epoch to Unix epoch
     let unix_secs = internal_secs - UNIX_TO_INTERNAL;
 
-    if unix_secs < 0 {
-        return Err(FibreError::Other(
-            "timestamp before Unix epoch not supported".into(),
-        ));
-    }
-    if nsecs < 0 {
-        return Err(FibreError::Other(
-            "negative timestamp nanoseconds not supported".into(),
-        ));
-    }
+    assert!(unix_secs >= 0);
+    assert!(nsecs >= 0);
 
     let duration = std::time::Duration::new(unix_secs as u64, nsecs as u32);
-    Ok(SystemTime::UNIX_EPOCH + duration)
+    SystemTime::UNIX_EPOCH + duration
 }
 
 #[cfg(test)]
@@ -450,7 +416,12 @@ mod tests {
     #[test]
     fn validate_fails_without_signature() {
         let (_, promise) = make_test_promise();
-        assert!(promise.validate().is_err());
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::MissingSignature
+            ))
+        ));
     }
 
     #[test]
@@ -462,7 +433,12 @@ mod tests {
         let wrong_key = SigningKey::random(&mut OsRng);
         promise.signer_pubkey = *wrong_key.verifying_key();
 
-        assert!(promise.validate().is_err());
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::SignatureVerification(_)
+            ))
+        ));
     }
 
     #[test]
@@ -470,7 +446,25 @@ mod tests {
         let (signing_key, mut promise) = make_test_promise();
         promise.chain_id = String::new();
         promise.sign(&signing_key).unwrap();
-        assert!(promise.validate().is_err());
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::ChainId(ChainIdError::Empty)
+            ))
+        ));
+    }
+
+    #[test]
+    fn validate_fails_with_long_chain_id() {
+        let (signing_key, mut promise) = make_test_promise();
+        promise.chain_id = "x".repeat(MAX_CHAIN_ID_SIZE + 1);
+        promise.sign(&signing_key).unwrap();
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::ChainId(ChainIdError::TooLong(len))
+            )) if len == MAX_CHAIN_ID_SIZE + 1
+        ));
     }
 
     #[test]
@@ -478,13 +472,60 @@ mod tests {
         let (signing_key, mut promise) = make_test_promise();
         promise.upload_size = 0;
         promise.sign(&signing_key).unwrap();
-        assert!(promise.validate().is_err());
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::ZeroUploadSize
+            ))
+        ));
+    }
+
+    #[test]
+    fn validate_fails_with_zero_timestamp() {
+        let (signing_key, mut promise) = make_test_promise();
+        promise.creation_timestamp = SystemTime::UNIX_EPOCH;
+        promise.sign(&signing_key).unwrap();
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::ZeroTimestamp
+            ))
+        ));
+    }
+
+    #[test]
+    fn validate_fails_with_wrong_signature_length() {
+        let (_, mut promise) = make_test_promise();
+        promise.signature = Some(vec![0; SIGNATURE_SIZE - 1]);
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::SignatureLength(len)
+            )) if len == SIGNATURE_SIZE - 1
+        ));
+    }
+
+    #[test]
+    fn validate_fails_with_invalid_signature_format() {
+        let (_, mut promise) = make_test_promise();
+        promise.signature = Some(vec![0; SIGNATURE_SIZE]);
+        assert!(matches!(
+            promise.validate(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::SignatureFormat(_)
+            ))
+        ));
     }
 
     #[test]
     fn hash_requires_signature() {
         let (_, promise) = make_test_promise();
-        assert!(promise.hash().is_err());
+        assert!(matches!(
+            promise.hash(),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::MissingSignature
+            ))
+        ));
     }
 
     #[test]
@@ -517,7 +558,7 @@ mod tests {
         assert_eq!(bytes.len(), TIMESTAMP_BINARY_SIZE);
         assert_eq!(bytes[0], 1); // version
 
-        let recovered = unmarshal_binary_time(&bytes).unwrap();
+        let recovered = unmarshal_binary_time(&bytes);
 
         // Check precision is maintained (nanosecond-level)
         let diff = now
@@ -544,6 +585,17 @@ mod tests {
         // Check nanoseconds
         let nsecs = i32::from_be_bytes(bytes[9..13].try_into().unwrap());
         assert_eq!(nsecs, 500_000_000);
+    }
+
+    #[test]
+    fn timestamp_before_epoch_is_rejected() {
+        let timestamp = SystemTime::UNIX_EPOCH - std::time::Duration::from_secs(1);
+        assert!(matches!(
+            marshal_binary_time(timestamp),
+            Err(FibreError::InvalidPaymentPromise(
+                PaymentPromiseError::TimestampBeforeEpoch(_)
+            ))
+        ));
     }
 
     #[test]

--- a/fibre/src/domain/payment_promise.rs
+++ b/fibre/src/domain/payment_promise.rs
@@ -13,7 +13,8 @@ use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
 
 use crate::blob::Commitment;
-use crate::error::{ChainIdError, FibreError, PaymentPromiseError};
+use crate::config::validate_chain_id;
+use crate::error::{FibreError, PaymentPromiseError};
 
 /// Domain separation prefix prepended to sign bytes.
 /// Ensures payment promise signatures cannot be confused with consensus messages.
@@ -24,19 +25,6 @@ const PUBKEY_SIZE: usize = 33;
 
 /// Size of a secp256k1 signature in compact format (32 bytes r + 32 bytes s).
 pub(crate) const SIGNATURE_SIZE: usize = 64;
-
-/// Maximum allowed chain ID length.
-pub(crate) const MAX_CHAIN_ID_SIZE: usize = 20;
-
-pub(crate) fn validate_chain_id(chain_id: &str) -> Result<(), ChainIdError> {
-    if chain_id.is_empty() {
-        return Err(ChainIdError::Empty);
-    }
-    if chain_id.len() > MAX_CHAIN_ID_SIZE {
-        return Err(ChainIdError::TooLong(chain_id.len()));
-    }
-    Ok(())
-}
 
 /// Size of the Go time.Time MarshalBinary output for UTC times.
 const TIMESTAMP_BINARY_SIZE: usize = 15;
@@ -159,7 +147,7 @@ impl PaymentPromise {
     /// Performs stateless validation of all field constraints and verifies
     /// the signature using the signer's public key.
     pub fn validate(&self) -> Result<(), FibreError> {
-        validate_chain_id(&self.chain_id).map_err(PaymentPromiseError::ChainId)?;
+        validate_chain_id(&self.chain_id)?;
 
         // Upload size must be positive
         if self.upload_size == 0 {
@@ -306,6 +294,7 @@ fn unmarshal_binary_time(data: &[u8]) -> SystemTime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::MAX_CHAIN_ID_SIZE;
     use k256::ecdsa::SigningKey;
     use rand::rngs::OsRng;
 
@@ -448,9 +437,7 @@ mod tests {
         promise.sign(&signing_key).unwrap();
         assert!(matches!(
             promise.validate(),
-            Err(FibreError::InvalidPaymentPromise(
-                PaymentPromiseError::ChainId(ChainIdError::Empty)
-            ))
+            Err(FibreError::InvalidChainId { len: 0 })
         ));
     }
 
@@ -461,9 +448,7 @@ mod tests {
         promise.sign(&signing_key).unwrap();
         assert!(matches!(
             promise.validate(),
-            Err(FibreError::InvalidPaymentPromise(
-                PaymentPromiseError::ChainId(ChainIdError::TooLong(len))
-            )) if len == MAX_CHAIN_ID_SIZE + 1
+            Err(FibreError::InvalidChainId { len }) if len == MAX_CHAIN_ID_SIZE + 1
         ));
     }
 

--- a/fibre/src/lib.rs
+++ b/fibre/src/lib.rs
@@ -34,8 +34,8 @@ pub use config::{
 pub use domain::blob::{Blob, BlobID, Commitment, EncodedBlob};
 pub use domain::payment_promise::{PaymentPromise, SignedPaymentPromise};
 pub use error::{
-    BlobHeaderError, BlobIdError, ChainIdError, FibreClientBuilderError, FibreError,
-    PaymentPromiseError, Result, ShardError, ValidatorSetError,
+    BlobHeaderError, BlobIdError, FibreClientBuilderError, FibreError, PaymentPromiseError, Result,
+    ShardError, ValidatorSetError,
 };
 pub use transport::grpc_validator_client::GrpcValidatorConnector;
 pub use transport::host_registry::{GrpcHostRegistry, Host, HostRegistry};

--- a/fibre/src/lib.rs
+++ b/fibre/src/lib.rs
@@ -33,7 +33,10 @@ pub use config::{
 };
 pub use domain::blob::{Blob, BlobID, Commitment, EncodedBlob};
 pub use domain::payment_promise::{PaymentPromise, SignedPaymentPromise};
-pub use error::{FibreError, Result};
+pub use error::{
+    BlobHeaderError, BlobIdError, ChainIdError, FibreClientBuilderError, FibreError,
+    PaymentPromiseError, Result, ShardError, ValidatorSetError,
+};
 pub use transport::grpc_validator_client::GrpcValidatorConnector;
 pub use transport::host_registry::{GrpcHostRegistry, Host, HostRegistry};
 #[cfg(target_arch = "wasm32")]

--- a/fibre/src/test_utils.rs
+++ b/fibre/src/test_utils.rs
@@ -136,7 +136,9 @@ impl ValidatorConnection for MockValidatorConnection {
         rlc_vector: &[rsema1d::GF128],
     ) -> Result<UploadResponse, FibreError> {
         if self.fail {
-            return Err(FibreError::Other("mock connection failure".into()));
+            return Err(FibreError::GrpcClient(
+                tonic::Status::unavailable("mock connection failure").into(),
+            ));
         }
 
         // Record what was uploaded and notify waiters.
@@ -162,7 +164,9 @@ impl ValidatorConnection for MockValidatorConnection {
 
     async fn download_shard(&self, blob_id: &BlobID) -> Result<DownloadResponse, FibreError> {
         if self.fail {
-            return Err(FibreError::Other("mock connection failure".into()));
+            return Err(FibreError::GrpcClient(
+                tonic::Status::unavailable("mock connection failure").into(),
+            ));
         }
 
         self.stored
@@ -207,7 +211,7 @@ impl ValidatorConnector for MockConnector {
             .get(&validator.address)
             .cloned()
             .map(|c| c as Arc<dyn ValidatorConnection>)
-            .ok_or_else(|| FibreError::HostNotFound(validator.address_hex()))
+            .ok_or(FibreError::HostNotFound(validator.address))
     }
 }
 
@@ -225,7 +229,7 @@ impl ValidatorConnector for FailingConnector {
         validator: &ValidatorInfo,
     ) -> Result<Arc<dyn ValidatorConnection>, FibreError> {
         if self.fail_addresses.contains(&validator.address) {
-            return Err(FibreError::HostNotFound(validator.address_hex()));
+            return Err(FibreError::HostNotFound(validator.address));
         }
         self.inner.connect(validator).await
     }

--- a/fibre/src/transport/grpc_validator_client.rs
+++ b/fibre/src/transport/grpc_validator_client.rs
@@ -79,7 +79,7 @@ impl ValidatorConnector for GrpcValidatorConnector {
         let url = normalize_host(&host.0);
 
         let client = crate::transport::tls::grpc_client(
-            &url,
+            url,
             validator.pubkey,
             self.chain_id.clone(),
             self.io_connector.clone(),
@@ -170,7 +170,7 @@ mod tests {
             self.hosts
                 .get(&validator.address)
                 .cloned()
-                .ok_or_else(|| FibreError::HostNotFound(validator.address_hex()))
+                .ok_or(FibreError::HostNotFound(validator.address))
         }
     }
 
@@ -265,12 +265,8 @@ mod tests {
 
         let result = connector.connect(&validator).await;
         match result {
-            Err(FibreError::HostNotFound(addr_hex)) => {
-                assert_eq!(
-                    addr_hex,
-                    validator.address_hex(),
-                    "error should contain the validator address"
-                );
+            Err(FibreError::HostNotFound(addr)) => {
+                assert_eq!(addr, validator.address);
             }
             Err(other) => panic!("expected HostNotFound error, got: {other}"),
             Ok(_) => panic!("expected connect to fail for unknown validator"),

--- a/fibre/src/transport/host_registry.rs
+++ b/fibre/src/transport/host_registry.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use crate::error::FibreError;
 use crate::validator::ValidatorInfo;
 use celestia_grpc::GrpcClient;
+use celestia_types::state::{AddressTrait, ConsAddress};
 
 /// A validator's network address (e.g., `"dns:///validator.example.com:9090"`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -57,7 +58,7 @@ impl GrpcHostRegistry {
         let mut cache = self.cache.write().await;
 
         for provider in providers {
-            let addr_bytes = decode_bech32_address(&provider.validator_consensus_address)?;
+            let addr_bytes = consensus_address_bytes(&provider.validator_consensus_address)?;
             let host_str = provider.info.map(|info| info.host).unwrap_or_default();
 
             if !host_str.is_empty() {
@@ -73,22 +74,18 @@ impl GrpcHostRegistry {
     /// Uses the validator's 20-byte address encoded as a bech32 consensus
     /// address to query `FibreProviderInfo`.
     pub async fn pull_host(&self, validator: &ValidatorInfo) -> Result<Host, FibreError> {
-        let bech32_addr = encode_bech32_address("celestiavalcons", &validator.address)?;
+        let bech32_addr = ConsAddress::from(validator.address).to_string();
 
         let resp = self.client.get_fibre_provider_info(bech32_addr).await?;
 
         if !resp.found {
-            return Err(FibreError::HostNotFound(hex::encode_upper(
-                validator.address,
-            )));
+            return Err(FibreError::HostNotFound(validator.address));
         }
 
         let host_str = resp.info.map(|info| info.host).unwrap_or_default();
 
         if host_str.is_empty() {
-            return Err(FibreError::HostNotFound(hex::encode_upper(
-                validator.address,
-            )));
+            return Err(FibreError::HostNotFound(validator.address));
         }
 
         let host = Host(host_str);
@@ -101,6 +98,17 @@ impl GrpcHostRegistry {
 
         Ok(host)
     }
+}
+
+fn consensus_address_bytes(address: &str) -> Result<[u8; 20], FibreError> {
+    let address: ConsAddress = address
+        .parse()
+        .map_err(FibreError::InvalidValidatorAddress)?;
+    Ok(address
+        .id_ref()
+        .as_bytes()
+        .try_into()
+        .expect("consensus address id is 20 bytes"))
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -118,33 +126,6 @@ impl HostRegistry for GrpcHostRegistry {
         // Cache miss: query the chain for this specific validator.
         self.pull_host(validator).await
     }
-}
-
-/// Decode a bech32-encoded address (e.g., `"celestiavalcons1..."`) into a
-/// 20-byte raw address.
-fn decode_bech32_address(bech32_addr: &str) -> Result<[u8; 20], FibreError> {
-    let (_hrp, data) = bech32::decode(bech32_addr).map_err(|e| {
-        FibreError::InvalidData(format!("invalid bech32 address '{bech32_addr}': {e}"))
-    })?;
-
-    let addr: [u8; 20] = data.try_into().map_err(|v: Vec<u8>| {
-        FibreError::InvalidData(format!(
-            "bech32 address decoded to {} bytes, expected 20",
-            v.len()
-        ))
-    })?;
-
-    Ok(addr)
-}
-
-/// Encode a 20-byte address into a bech32 string with the given human-readable
-/// prefix (e.g., `"celestiavalcons"`).
-fn encode_bech32_address(hrp: &str, addr: &[u8; 20]) -> Result<String, FibreError> {
-    let hrp = bech32::Hrp::parse(hrp)
-        .map_err(|e| FibreError::Other(format!("invalid bech32 hrp '{hrp}': {e}")))?;
-    let encoded = bech32::encode::<bech32::Bech32>(hrp, addr)
-        .map_err(|e| FibreError::Other(format!("bech32 encoding failed: {e}")))?;
-    Ok(encoded)
 }
 
 #[cfg(test)]
@@ -165,78 +146,12 @@ mod tests {
     }
 
     #[test]
-    fn bech32_encode_decode_roundtrip() {
-        let addr: [u8; 20] = [
-            0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
-            0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-        ];
-
-        let encoded =
-            encode_bech32_address("celestiavalcons", &addr).expect("encoding should succeed");
-        let decoded = decode_bech32_address(&encoded).expect("decoding should succeed");
-
-        assert_eq!(decoded, addr);
-    }
-
-    #[test]
-    fn bech32_encode_known_vector() {
-        let addr = [1u8; 20];
-        let encoded =
-            encode_bech32_address("celestiavalcons", &addr).expect("encoding should succeed");
-
-        assert!(
-            encoded.starts_with("celestiavalcons1"),
-            "encoded address should start with 'celestiavalcons1', got: {encoded}"
-        );
-
-        // Round-trip check: decoding gives back the same bytes.
-        let decoded = decode_bech32_address(&encoded).expect("decoding should succeed");
-        assert_eq!(decoded, addr);
-    }
-
-    #[test]
-    fn bech32_decode_invalid_string() {
-        let result = decode_bech32_address("notvalid");
-        assert!(
-            result.is_err(),
-            "decoding an invalid bech32 string should fail"
-        );
-
-        let err = result.unwrap_err();
-        match &err {
-            FibreError::InvalidData(msg) => {
-                assert!(
-                    msg.contains("invalid bech32 address"),
-                    "error message should mention 'invalid bech32 address', got: {msg}"
-                );
-            }
-            other => panic!("expected InvalidData error, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn bech32_decode_wrong_data_length() {
-        // Encode a 10-byte payload (not 20), which should fail on decode.
-        let short_bech32 =
-            bech32::encode::<bech32::Bech32>(bech32::Hrp::parse("test").unwrap(), &[0u8; 10])
-                .expect("bech32 encoding of short payload should succeed");
-
-        let result = decode_bech32_address(&short_bech32);
-        assert!(
-            result.is_err(),
-            "decoding a non-20-byte payload should fail"
-        );
-
-        let err = result.unwrap_err();
-        match &err {
-            FibreError::InvalidData(msg) => {
-                assert!(
-                    msg.contains("expected 20"),
-                    "error message should mention 'expected 20', got: {msg}"
-                );
-            }
-            other => panic!("expected InvalidData error, got: {other:?}"),
-        }
+    fn consensus_address_rejects_wrong_prefix() {
+        let address = celestia_types::state::AccAddress::from([1u8; 20]).to_string();
+        assert!(matches!(
+            consensus_address_bytes(&address),
+            Err(FibreError::InvalidValidatorAddress(_))
+        ));
     }
 
     struct MapRegistry {
@@ -250,7 +165,7 @@ mod tests {
             self.hosts
                 .get(&validator.address)
                 .cloned()
-                .ok_or_else(|| FibreError::HostNotFound(hex::encode_upper(validator.address)))
+                .ok_or(FibreError::HostNotFound(validator.address))
         }
     }
 
@@ -283,12 +198,8 @@ mod tests {
         assert!(result.is_err(), "should return an error for missing host");
 
         match result.unwrap_err() {
-            FibreError::HostNotFound(addr_hex) => {
-                assert_eq!(
-                    addr_hex,
-                    hex::encode_upper([99u8; 20]),
-                    "error should contain the hex-encoded address"
-                );
+            FibreError::HostNotFound(addr) => {
+                assert_eq!(addr, [99u8; 20]);
             }
             other => panic!("expected HostNotFound, got: {other:?}"),
         }

--- a/fibre/src/transport/io_connector.rs
+++ b/fibre/src/transport/io_connector.rs
@@ -2,8 +2,6 @@ use std::pin::Pin;
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use crate::error::FibreError;
-
 /// A Fibre transport byte stream.
 pub trait FibreIo: AsyncRead + AsyncWrite + Send + Unpin {}
 
@@ -16,7 +14,7 @@ pub type BoxedFibreIo = Pin<Box<dyn FibreIo + 'static>>;
 #[async_trait::async_trait]
 pub trait FibreIoConnector: Send + Sync {
     /// Connect to `host:port` without applying TLS.
-    async fn connect(&self, host: String, port: u16) -> Result<BoxedFibreIo, FibreError>;
+    async fn connect(&self, host: String, port: u16) -> Result<BoxedFibreIo, std::io::Error>;
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -27,12 +25,8 @@ pub struct NativeTcpConnector;
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl FibreIoConnector for NativeTcpConnector {
-    async fn connect(&self, host: String, port: u16) -> Result<BoxedFibreIo, FibreError> {
-        let stream = tokio::net::TcpStream::connect((host, port))
-            .await
-            .map_err(|error| {
-                FibreError::Other(format!("failed to connect Fibre socket: {error}"))
-            })?;
+    async fn connect(&self, host: String, port: u16) -> Result<BoxedFibreIo, std::io::Error> {
+        let stream = tokio::net::TcpStream::connect((host, port)).await?;
         Ok(Box::pin(stream))
     }
 }
@@ -151,7 +145,7 @@ impl AsyncWrite for BrowserIo {
 #[cfg(target_arch = "wasm32")]
 #[async_trait::async_trait]
 impl FibreIoConnector for BrowserWebSocketConnector {
-    async fn connect(&self, host: String, port: u16) -> Result<BoxedFibreIo, FibreError> {
+    async fn connect(&self, host: String, port: u16) -> Result<BoxedFibreIo, std::io::Error> {
         use futures::{SinkExt, StreamExt};
         use gloo_net::websocket::{Message, futures::WebSocket};
 
@@ -166,29 +160,27 @@ impl FibreIoConnector for BrowserWebSocketConnector {
         let connect = async move {
             let mut socket =
                 WebSocket::open_with_protocol(&relay_url, PROTOCOL).map_err(|error| {
-                    FibreError::Other(format!("failed to connect Fibre relay: {error}"))
+                    std::io::Error::new(std::io::ErrorKind::ConnectionRefused, error)
                 })?;
             socket
                 .send(Message::Text(authority))
                 .await
-                .map_err(|error| {
-                    FibreError::Other(format!("failed to open Fibre tunnel: {error}"))
-                })?;
+                .map_err(std::io::Error::other)?;
             match socket.next().await {
                 Some(Ok(Message::Text(response))) if response == "ok" => {}
                 Some(Ok(_)) => {
-                    return Err(FibreError::Other(
-                        "Fibre relay returned an invalid tunnel acknowledgement".into(),
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "Fibre relay returned an invalid tunnel acknowledgement",
                     ));
                 }
                 Some(Err(error)) => {
-                    return Err(FibreError::Other(format!(
-                        "failed to open Fibre tunnel: {error}"
-                    )));
+                    return Err(std::io::Error::other(error));
                 }
                 None => {
-                    return Err(FibreError::Other(
-                        "Fibre relay closed before acknowledging the tunnel".into(),
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionAborted,
+                        "Fibre relay closed before acknowledging the tunnel",
                     ));
                 }
             }

--- a/fibre/src/transport/proto_conv.rs
+++ b/fibre/src/transport/proto_conv.rs
@@ -15,7 +15,9 @@ use tendermint_proto::google::protobuf::Timestamp;
 #[cfg(test)]
 use tendermint_proto::v0_38::crypto::public_key::Sum as CryptoKeySum;
 
-use crate::error::FibreError;
+#[cfg(test)]
+use crate::error::ValidatorSetError;
+use crate::error::{FibreError, ShardError};
 use crate::payment_promise::PaymentPromise;
 #[cfg(test)]
 use crate::validator::ValidatorInfo;
@@ -71,11 +73,9 @@ pub(crate) fn blob_row_to_row_proof(
         .into_iter()
         .map(|h| {
             let len = h.len();
-            h.as_ref().try_into().map_err(|_| {
-                FibreError::InvalidData(
-                    format!("proof hash has invalid length {len}, expected 32",),
-                )
-            })
+            h.as_ref()
+                .try_into()
+                .map_err(|_| ShardError::ProofHashLength(len).into())
         })
         .collect::<Result<Vec<[u8; 32]>, FibreError>>()?;
 
@@ -113,15 +113,10 @@ pub(crate) fn build_upload_shard(
 pub fn parse_download_response(
     resp: proto::DownloadShardResponse,
 ) -> Result<DownloadResponse, FibreError> {
-    let shard = resp
-        .shard
-        .ok_or_else(|| FibreError::InvalidData("download response missing shard".into()))?;
+    let shard = resp.shard.ok_or(ShardError::MissingShard)?;
 
     if shard.rlcs.is_empty() || !shard.rlcs.len().is_multiple_of(16) {
-        return Err(FibreError::InvalidData(format!(
-            "rlc vector has invalid length {}, expected a non-zero multiple of 16",
-            shard.rlcs.len()
-        )));
+        return Err(ShardError::RlcVectorLength(shard.rlcs.len()).into());
     }
     let rlcs = shard
         .rlcs
@@ -167,12 +162,10 @@ fn system_time_to_timestamp(t: SystemTime) -> Timestamp {
 }
 
 #[cfg(test)]
-pub(crate) fn timestamp_to_system_time(t: &Timestamp) -> Result<SystemTime, FibreError> {
+pub(crate) fn timestamp_to_system_time(t: &Timestamp) -> SystemTime {
     if t.seconds >= 0 {
         let d = Duration::new(t.seconds as u64, t.nanos as u32);
-        UNIX_EPOCH
-            .checked_add(d)
-            .ok_or_else(|| FibreError::Other("timestamp overflow".into()))
+        UNIX_EPOCH.checked_add(d).expect("timestamp overflow")
     } else {
         // Reverse the protobuf convention: if nanos > 0 the actual
         // duration is (|seconds| - 1) seconds + (1e9 - nanos) subsec nanos.
@@ -182,9 +175,7 @@ pub(crate) fn timestamp_to_system_time(t: &Timestamp) -> Result<SystemTime, Fibr
             ((-t.seconds) as u64, 0u32)
         };
         let d = Duration::new(secs, nanos);
-        UNIX_EPOCH
-            .checked_sub(d)
-            .ok_or_else(|| FibreError::Other("timestamp underflow".into()))
+        UNIX_EPOCH.checked_sub(d).expect("timestamp underflow")
     }
 }
 
@@ -252,8 +243,10 @@ mod tests {
             data: vec![0u8; 64].into(),
             proof: vec![vec![0u8; 31].into()], // wrong length
         };
-        let result = blob_row_to_row_proof(row);
-        assert!(result.is_err());
+        assert!(matches!(
+            blob_row_to_row_proof(row),
+            Err(FibreError::InvalidShard(ShardError::ProofHashLength(31)))
+        ));
     }
 
     #[test]
@@ -294,19 +287,28 @@ mod tests {
     #[test]
     fn parse_download_response_missing_shard() {
         let resp = proto::DownloadShardResponse { shard: None };
-        assert!(parse_download_response(resp).is_err());
+        assert!(matches!(
+            parse_download_response(resp),
+            Err(FibreError::InvalidShard(ShardError::MissingShard))
+        ));
     }
 
     #[test]
     fn parse_download_response_invalid_rlc_length() {
         for rlcs in [vec![], vec![1u8; 15]] {
+            let expected_len = rlcs.len();
             let resp = proto::DownloadShardResponse {
                 shard: Some(proto::BlobShard {
                     rows: vec![],
                     rlcs: rlcs.into(),
                 }),
             };
-            assert!(parse_download_response(resp).is_err());
+            assert!(matches!(
+                parse_download_response(resp),
+                Err(FibreError::InvalidShard(ShardError::RlcVectorLength(
+                    len
+                ))) if len == expected_len
+            ));
         }
     }
 
@@ -314,7 +316,7 @@ mod tests {
     fn timestamp_roundtrip() {
         let now = SystemTime::now();
         let ts = system_time_to_timestamp(now);
-        let back = timestamp_to_system_time(&ts).unwrap();
+        let back = timestamp_to_system_time(&ts);
 
         // Compare with nanosecond tolerance
         let diff = now
@@ -335,7 +337,7 @@ mod tests {
         assert_eq!(ts.seconds, -11);
         assert_eq!(ts.nanos, 500_000_000);
 
-        let back = timestamp_to_system_time(&ts).unwrap();
+        let back = timestamp_to_system_time(&ts);
         let diff = t
             .duration_since(back)
             .or_else(|_| back.duration_since(t))
@@ -350,7 +352,7 @@ mod tests {
         assert_eq!(ts.seconds, -5);
         assert_eq!(ts.nanos, 0);
 
-        let back = timestamp_to_system_time(&ts).unwrap();
+        let back = timestamp_to_system_time(&ts);
         let diff = t
             .duration_since(back)
             .or_else(|_| back.duration_since(t))
@@ -392,6 +394,65 @@ mod tests {
             voting_power: 100,
             proposer_priority: 0,
         };
-        assert!(ValidatorInfo::try_from(&proto_val).is_err());
+        assert!(matches!(
+            ValidatorInfo::try_from(&proto_val),
+            Err(FibreError::InvalidValidatorSet(
+                ValidatorSetError::MissingPublicKey
+            ))
+        ));
+    }
+
+    #[test]
+    fn validator_from_proto_rejects_unsupported_key_type() {
+        let proto_val = tendermint_proto::v0_38::types::Validator {
+            address: vec![],
+            pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
+                sum: Some(CryptoKeySum::Secp256k1(vec![0; 33])),
+            }),
+            voting_power: 100,
+            proposer_priority: 0,
+        };
+        assert!(matches!(
+            ValidatorInfo::try_from(&proto_val),
+            Err(FibreError::InvalidValidatorSet(
+                ValidatorSetError::UnsupportedPublicKeyType
+            ))
+        ));
+    }
+
+    #[test]
+    fn validator_from_proto_rejects_wrong_key_length() {
+        let proto_val = tendermint_proto::v0_38::types::Validator {
+            address: vec![],
+            pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
+                sum: Some(CryptoKeySum::Ed25519(vec![0; 31])),
+            }),
+            voting_power: 100,
+            proposer_priority: 0,
+        };
+        assert!(matches!(
+            ValidatorInfo::try_from(&proto_val),
+            Err(FibreError::InvalidValidatorSet(
+                ValidatorSetError::PublicKeyLength(31)
+            ))
+        ));
+    }
+
+    #[test]
+    fn validator_from_proto_rejects_invalid_key() {
+        let proto_val = tendermint_proto::v0_38::types::Validator {
+            address: vec![],
+            pub_key: Some(tendermint_proto::v0_38::crypto::PublicKey {
+                sum: Some(CryptoKeySum::Ed25519(vec![2; 32])),
+            }),
+            voting_power: 100,
+            proposer_priority: 0,
+        };
+        assert!(matches!(
+            ValidatorInfo::try_from(&proto_val),
+            Err(FibreError::InvalidValidatorSet(
+                ValidatorSetError::InvalidPublicKey(_)
+            ))
+        ));
     }
 }

--- a/fibre/src/transport/tls.rs
+++ b/fibre/src/transport/tls.rs
@@ -419,10 +419,6 @@ fn decode_binding(payload: &[u8]) -> Result<BindingPayload<'_>, FibreCertificate
     })
 }
 
-fn decode_identity_signature(bytes: &[u8]) -> Result<Signature, FibreCertificateError> {
-    Signature::from_slice(bytes).map_err(FibreCertificateError::InvalidIdentitySignature)
-}
-
 fn verify_certificate(
     cert_der: &[u8],
     validator_key: &VerifyingKey,
@@ -469,7 +465,8 @@ fn verify_certificate(
     sign_input.extend_from_slice(SIGN_PREFIX);
     sign_input.extend_from_slice(payload);
     let signed_bytes = raw_bytes_message_sign_bytes(chain_id, SIGN_UNIQUE_ID, &sign_input);
-    let signature = decode_identity_signature(identity.signature.as_bytes())?;
+    let signature = Signature::from_slice(identity.signature.as_bytes())
+        .map_err(FibreCertificateError::InvalidIdentitySignature)?;
     validator_key
         .verify_strict(&signed_bytes, &signature)
         .map_err(FibreCertificateError::InvalidIdentitySignature)?;
@@ -664,14 +661,6 @@ mod tests {
         assert!(matches!(
             verify_certificate(&[0], &key, "chain", now),
             Err(FibreCertificateError::CertificateParse(_))
-        ));
-    }
-
-    #[test]
-    fn rejects_invalid_identity_signature_length() {
-        assert!(matches!(
-            decode_identity_signature(&[0; 63]),
-            Err(FibreCertificateError::InvalidIdentitySignature(_))
         ));
     }
 

--- a/fibre/src/transport/tls.rs
+++ b/fibre/src/transport/tls.rs
@@ -72,6 +72,75 @@ struct BindingPayload<'a> {
     tls_pub_key: OctetStringRef<'a>,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum FibreCertificateError {
+    #[error("peer cert is missing the fibre identity extension")]
+    MissingIdentityExtension,
+    #[error("peer cert has duplicate fibre identity extensions")]
+    DuplicateIdentityExtensions,
+    #[error("trailing bytes in identity extension: {0}")]
+    IdentityTrailingData(#[source] der::Error),
+    #[error("unmarshal identity extension: {0}")]
+    IdentityDer(#[source] der::Error),
+    #[error("trailing bytes in binding payload: {0}")]
+    BindingTrailingData(#[source] der::Error),
+    #[error("unmarshal binding payload: {0}")]
+    BindingDer(#[source] der::Error),
+    #[error("parse peer cert: {0}")]
+    CertificateParse(#[source] x509_parser::nom::Err<x509_parser::error::X509Error>),
+    #[error("peer cert has {0} trailing bytes")]
+    CertificateTrailingData(usize),
+    #[error("identity extension size {0} exceeds maximum {MAX_IDENTITY_EXTENSION_SIZE}")]
+    IdentityExtensionTooLarge(usize),
+    #[error("empty identity payload")]
+    EmptyIdentityPayload,
+    #[error("identity payload size {0} exceeds maximum {MAX_PAYLOAD_DER_SIZE}")]
+    IdentityPayloadTooLarge(usize),
+    #[error("empty identity signature")]
+    EmptyIdentitySignature,
+    #[error("unsupported fibre identity version {0}")]
+    UnsupportedIdentityVersion(i64),
+    #[error("peer cert signature is invalid: {0}")]
+    InvalidIdentitySignature(#[source] ed25519_dalek::SignatureError),
+    #[error("peer cert public key does not match signed identity")]
+    TlsPublicKeyMismatch,
+    #[error("fibre identity validity window is empty: {not_before}..{not_after}")]
+    EmptyValidityWindow { not_before: i128, not_after: i128 },
+    #[error("fibre identity validity window is {0} seconds, exceeding the maximum")]
+    ValidityWindowTooLong(i128),
+    #[error(
+        "peer fibre identity is not currently valid: now {now}, window {not_before}..{not_after}"
+    )]
+    OutsideValidityWindow {
+        now: i128,
+        not_before: i128,
+        not_after: i128,
+    },
+    #[error(
+        "certificate validity {certificate_not_before}..{certificate_not_after} does not match signed identity {signed_not_before}..{signed_not_after}"
+    )]
+    CertificateValidityMismatch {
+        signed_not_before: i64,
+        signed_not_after: i64,
+        certificate_not_before: i64,
+        certificate_not_after: i64,
+    },
+    #[error("parse peer cert extended key usage: {0}")]
+    ExtendedKeyUsage(#[source] x509_parser::error::X509Error),
+    #[error("peer cert missing serverAuth extended key usage")]
+    MissingServerAuth,
+}
+
+impl From<FibreCertificateError> for tokio_rustls::rustls::Error {
+    fn from(error: FibreCertificateError) -> Self {
+        tokio_rustls::rustls::Error::InvalidCertificate(
+            tokio_rustls::rustls::CertificateError::Other(tokio_rustls::rustls::OtherError(
+                Arc::new(error),
+            )),
+        )
+    }
+}
+
 #[derive(Debug)]
 struct FibreServerCertVerifier {
     validator_key: VerifyingKey,
@@ -93,8 +162,7 @@ impl ServerCertVerifier for FibreServerCertVerifier {
             &self.validator_key,
             &self.chain_id,
             now,
-        )
-        .map_err(tokio_rustls::rustls::Error::General)?;
+        )?;
 
         Ok(ServerCertVerified::assertion())
     }
@@ -135,21 +203,24 @@ impl ServerCertVerifier for FibreServerCertVerifier {
 }
 
 pub(crate) fn grpc_client(
-    url: &str,
+    url: String,
     validator_key: VerifyingKey,
     chain_id: String,
     io_connector: Arc<dyn FibreIoConnector>,
 ) -> Result<celestia_grpc::GrpcClient, FibreError> {
     let uri = url
         .parse::<http::Uri>()
-        .map_err(|error| FibreError::Other(format!("invalid Fibre endpoint '{url}': {error}")))?;
+        .map_err(|source| FibreError::InvalidEndpoint {
+            endpoint: url,
+            source,
+        })?;
     let host = uri
         .host()
-        .ok_or_else(|| FibreError::Other(format!("Fibre endpoint '{url}' has no host")))?
+        .ok_or_else(|| FibreError::EndpointMissingHost(uri.clone()))?
         .to_string();
     let port = uri.port_u16().unwrap_or(443);
     let provider = Arc::new(tokio_rustls::rustls::crypto::ring::default_provider());
-    let mut tls_config = fibre_tls_config(validator_key, chain_id, provider, None)?;
+    let mut tls_config = fibre_tls_config(validator_key, chain_id, provider, None);
     tls_config.alpn_protocols = vec![b"h2".to_vec()];
     let tls_connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
     let transport = FibreH2Transport {
@@ -166,7 +237,7 @@ pub(crate) fn grpc_client(
     celestia_grpc::GrpcClient::builder()
         .transport(transport)
         .build()
-        .map_err(|error| FibreError::Other(format!("failed to build Fibre gRPC client: {error}")))
+        .map_err(FibreError::from)
 }
 
 fn fibre_tls_config(
@@ -174,7 +245,7 @@ fn fibre_tls_config(
     chain_id: String,
     provider: Arc<CryptoProvider>,
     time_provider: Option<Arc<dyn tokio_rustls::rustls::time_provider::TimeProvider>>,
-) -> Result<ClientConfig, FibreError> {
+) -> ClientConfig {
     let verifier = FibreServerCertVerifier {
         validator_key,
         chain_id,
@@ -186,12 +257,12 @@ fn fibre_tls_config(
     };
     let mut tls_config = builder
         .with_protocol_versions(&[&tokio_rustls::rustls::version::TLS13])
-        .map_err(|error| FibreError::Other(format!("failed to configure Fibre TLS: {error}")))?
+        .expect("ring crypto provider supports TLS 1.3")
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(verifier))
         .with_no_client_auth();
     tls_config.resumption = Resumption::disabled();
-    Ok(tls_config)
+    tls_config
 }
 
 struct FibreH2TransportInner {
@@ -315,37 +386,41 @@ where
 
 fn identity_extension<'a>(
     extensions: &'a [x509_parser::extensions::X509Extension<'a>],
-) -> Result<&'a [u8], String> {
+) -> Result<&'a [u8], FibreCertificateError> {
     let mut matching = extensions
         .iter()
         .filter(|extension| extension.oid.to_id_string() == IDENTITY_EXTENSION_OID);
     let extension = matching
         .next()
-        .ok_or_else(|| "peer cert is missing the fibre identity extension".to_string())?;
+        .ok_or(FibreCertificateError::MissingIdentityExtension)?;
     if matching.next().is_some() {
-        return Err("peer cert has duplicate fibre identity extensions".to_string());
+        return Err(FibreCertificateError::DuplicateIdentityExtensions);
     }
     Ok(extension.value)
 }
 
-fn decode_identity(extension: &[u8]) -> Result<SignedIdentity<'_>, String> {
+fn decode_identity(extension: &[u8]) -> Result<SignedIdentity<'_>, FibreCertificateError> {
     SignedIdentity::from_der(extension).map_err(|error| {
         if matches!(error.kind(), der::ErrorKind::TrailingData { .. }) {
-            "trailing bytes in identity extension".to_string()
+            FibreCertificateError::IdentityTrailingData(error)
         } else {
-            format!("unmarshal identity extension: {error}")
+            FibreCertificateError::IdentityDer(error)
         }
     })
 }
 
-fn decode_binding(payload: &[u8]) -> Result<BindingPayload<'_>, String> {
+fn decode_binding(payload: &[u8]) -> Result<BindingPayload<'_>, FibreCertificateError> {
     BindingPayload::from_der(payload).map_err(|error| {
         if matches!(error.kind(), der::ErrorKind::TrailingData { .. }) {
-            "trailing bytes in binding payload".to_string()
+            FibreCertificateError::BindingTrailingData(error)
         } else {
-            format!("unmarshal binding payload: {error}")
+            FibreCertificateError::BindingDer(error)
         }
     })
+}
+
+fn decode_identity_signature(bytes: &[u8]) -> Result<Signature, FibreCertificateError> {
+    Signature::from_slice(bytes).map_err(FibreCertificateError::InvalidIdentitySignature)
 }
 
 fn verify_certificate(
@@ -353,41 +428,40 @@ fn verify_certificate(
     validator_key: &VerifyingKey,
     chain_id: &str,
     now: UnixTime,
-) -> Result<(), String> {
+) -> Result<(), FibreCertificateError> {
     let (remaining, cert) =
-        parse_x509_certificate(cert_der).map_err(|error| format!("parse peer cert: {error}"))?;
+        parse_x509_certificate(cert_der).map_err(FibreCertificateError::CertificateParse)?;
     if !remaining.is_empty() {
-        return Err("trailing bytes in peer cert".to_string());
+        return Err(FibreCertificateError::CertificateTrailingData(
+            remaining.len(),
+        ));
     }
 
     let extension = identity_extension(cert.extensions())?;
     if extension.len() > MAX_IDENTITY_EXTENSION_SIZE {
-        return Err(format!(
-            "identity extension size {} exceeds maximum {MAX_IDENTITY_EXTENSION_SIZE}",
-            extension.len()
+        return Err(FibreCertificateError::IdentityExtensionTooLarge(
+            extension.len(),
         ));
     }
 
     let identity = decode_identity(extension)?;
     let payload = identity.payload.as_bytes();
     if payload.is_empty() {
-        return Err("empty identity payload".to_string());
+        return Err(FibreCertificateError::EmptyIdentityPayload);
     }
     if payload.len() > MAX_PAYLOAD_DER_SIZE {
-        return Err(format!(
-            "identity payload size {} exceeds maximum {MAX_PAYLOAD_DER_SIZE}",
-            payload.len()
+        return Err(FibreCertificateError::IdentityPayloadTooLarge(
+            payload.len(),
         ));
     }
     if identity.signature.as_bytes().is_empty() {
-        return Err("empty identity signature".to_string());
+        return Err(FibreCertificateError::EmptyIdentitySignature);
     }
 
     let binding = decode_binding(payload)?;
     if binding.version != BINDING_VERSION {
-        return Err(format!(
-            "unsupported fibre identity version {}",
-            binding.version
+        return Err(FibreCertificateError::UnsupportedIdentityVersion(
+            binding.version,
         ));
     }
 
@@ -395,41 +469,54 @@ fn verify_certificate(
     sign_input.extend_from_slice(SIGN_PREFIX);
     sign_input.extend_from_slice(payload);
     let signed_bytes = raw_bytes_message_sign_bytes(chain_id, SIGN_UNIQUE_ID, &sign_input);
-    let signature = Signature::from_slice(identity.signature.as_bytes())
-        .map_err(|_| "peer cert signature is invalid".to_string())?;
+    let signature = decode_identity_signature(identity.signature.as_bytes())?;
     validator_key
         .verify_strict(&signed_bytes, &signature)
-        .map_err(|_| "peer cert signature is invalid".to_string())?;
+        .map_err(FibreCertificateError::InvalidIdentitySignature)?;
 
     if cert.tbs_certificate.subject_pki.raw != binding.tls_pub_key.as_bytes() {
-        return Err("peer cert public key does not match signed identity".to_string());
+        return Err(FibreCertificateError::TlsPublicKeyMismatch);
     }
 
     let not_before = i128::from(binding.not_before);
     let not_after = i128::from(binding.not_after);
     if not_after <= not_before {
-        return Err("fibre identity validity window is empty".to_string());
+        return Err(FibreCertificateError::EmptyValidityWindow {
+            not_before,
+            not_after,
+        });
     }
     if not_after - not_before > MAX_CERT_VALIDITY_SECONDS {
-        return Err("fibre identity validity window exceeds maximum".to_string());
+        return Err(FibreCertificateError::ValidityWindowTooLong(
+            not_after - not_before,
+        ));
     }
     let now = i128::from(now.as_secs());
     if now < not_before - CLOCK_SKEW_SECONDS || now > not_after + CLOCK_SKEW_SECONDS {
-        return Err("peer fibre identity is not currently valid".to_string());
+        return Err(FibreCertificateError::OutsideValidityWindow {
+            now,
+            not_before,
+            not_after,
+        });
     }
 
     if cert.validity().not_before.timestamp() != binding.not_before
         || cert.validity().not_after.timestamp() != binding.not_after
     {
-        return Err("certificate validity does not match signed identity".to_string());
+        return Err(FibreCertificateError::CertificateValidityMismatch {
+            signed_not_before: binding.not_before,
+            signed_not_after: binding.not_after,
+            certificate_not_before: cert.validity().not_before.timestamp(),
+            certificate_not_after: cert.validity().not_after.timestamp(),
+        });
     }
 
     let has_server_auth = cert
         .extended_key_usage()
-        .map_err(|error| format!("parse peer cert extended key usage: {error}"))?
+        .map_err(FibreCertificateError::ExtendedKeyUsage)?
         .is_some_and(|usage| usage.value.server_auth);
     if !has_server_auth {
-        return Err("peer cert missing serverAuth extended key usage".to_string());
+        return Err(FibreCertificateError::MissingServerAuth);
     }
 
     Ok(())
@@ -468,25 +555,44 @@ mod tests {
         error: Option<String>,
     }
 
-    fn expected_error_fragment(error: &str) -> &str {
-        match error {
-            "extension_missing" => "missing the fibre identity extension",
-            "extension_too_large" => "identity extension size",
-            "extension_malformed" => "unmarshal identity extension",
-            "extension_trailing_data" => "trailing bytes in identity extension",
-            "payload_empty" => "empty identity payload",
-            "payload_too_large" => "identity payload size",
-            "signature_empty" => "empty identity signature",
-            "payload_malformed" => "unmarshal binding payload",
-            "binding_trailing_data" => "trailing bytes in binding payload",
-            "unsupported_version" => "unsupported fibre identity version",
-            "signature_invalid" => "signature is invalid",
-            "tls_key_mismatch" => "public key does not match signed identity",
-            "window_empty" => "validity window is empty",
-            "window_too_long" => "validity window exceeds maximum",
-            "outside_validity_window" => "not currently valid",
-            "cert_window_mismatch" => "certificate validity does not match signed identity",
-            "eku_missing" => "serverAuth",
+    fn matches_error_code(error: &FibreCertificateError, code: &str) -> bool {
+        match code {
+            "extension_missing" => matches!(error, FibreCertificateError::MissingIdentityExtension),
+            "extension_too_large" => {
+                matches!(error, FibreCertificateError::IdentityExtensionTooLarge(_))
+            }
+            "extension_malformed" => {
+                matches!(error, FibreCertificateError::IdentityDer(_))
+            }
+            "extension_trailing_data" => {
+                matches!(error, FibreCertificateError::IdentityTrailingData(_))
+            }
+            "payload_empty" => matches!(error, FibreCertificateError::EmptyIdentityPayload),
+            "payload_too_large" => {
+                matches!(error, FibreCertificateError::IdentityPayloadTooLarge(_))
+            }
+            "signature_empty" => matches!(error, FibreCertificateError::EmptyIdentitySignature),
+            "payload_malformed" => matches!(error, FibreCertificateError::BindingDer(_)),
+            "binding_trailing_data" => {
+                matches!(error, FibreCertificateError::BindingTrailingData(_))
+            }
+            "unsupported_version" => {
+                matches!(error, FibreCertificateError::UnsupportedIdentityVersion(_))
+            }
+            "signature_invalid" => {
+                matches!(error, FibreCertificateError::InvalidIdentitySignature(_))
+            }
+            "tls_key_mismatch" => matches!(error, FibreCertificateError::TlsPublicKeyMismatch),
+            "window_empty" => matches!(error, FibreCertificateError::EmptyValidityWindow { .. }),
+            "window_too_long" => matches!(error, FibreCertificateError::ValidityWindowTooLong(_)),
+            "outside_validity_window" => {
+                matches!(error, FibreCertificateError::OutsideValidityWindow { .. })
+            }
+            "cert_window_mismatch" => matches!(
+                error,
+                FibreCertificateError::CertificateValidityMismatch { .. }
+            ),
+            "eku_missing" => matches!(error, FibreCertificateError::MissingServerAuth),
             unknown => panic!("unknown upstream error code {unknown}"),
         }
     }
@@ -519,7 +625,7 @@ mod tests {
                     .as_deref()
                     .expect("invalid vector should name its expected error");
                 assert!(
-                    error.contains(expected_error_fragment(expected)),
+                    matches_error_code(&error, expected),
                     "vector {} returned {error:?}, expected {expected}",
                     vector.name
                 );
@@ -545,7 +651,138 @@ mod tests {
 
         let error = identity_extension(&[extension.clone(), extension])
             .expect_err("duplicate identity extensions should fail");
-        assert!(error.contains("duplicate fibre identity extensions"));
+        assert!(matches!(
+            error,
+            FibreCertificateError::DuplicateIdentityExtensions
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_certificate() {
+        let key = VerifyingKey::from_bytes(&[1u8; 32]).expect("key should be valid");
+        let now = UnixTime::since_unix_epoch(Duration::from_secs(0));
+        assert!(matches!(
+            verify_certificate(&[0], &key, "chain", now),
+            Err(FibreCertificateError::CertificateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_identity_signature_length() {
+        assert!(matches!(
+            decode_identity_signature(&[0; 63]),
+            Err(FibreCertificateError::InvalidIdentitySignature(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_trailing_certificate_data() {
+        let vector = vectors()
+            .cases
+            .into_iter()
+            .find(|vector| vector.name == "valid")
+            .expect("valid vector should exist");
+        let mut cert_der = hex::decode(&vector.cert_der).expect("certificate should be hex");
+        cert_der.push(0);
+        let key_bytes: [u8; 32] = hex::decode(&vector.verifier_consensus_pub)
+            .expect("validator key should be hex")
+            .try_into()
+            .expect("validator key should have 32 bytes");
+        let key = VerifyingKey::from_bytes(&key_bytes).expect("validator key should be valid");
+        let now = UnixTime::since_unix_epoch(Duration::from_secs(vector.verify_at));
+        assert!(matches!(
+            verify_certificate(&cert_der, &key, &vector.verifier_chain_id, now),
+            Err(FibreCertificateError::CertificateTrailingData(1))
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_extended_key_usage() {
+        let vector = vectors()
+            .cases
+            .into_iter()
+            .find(|vector| vector.name == "valid")
+            .expect("valid vector should exist");
+        let mut cert_der = hex::decode(&vector.cert_der).expect("certificate should be hex");
+        let (_, cert) = parse_x509_certificate(&cert_der).expect("certificate should parse");
+        let eku = cert
+            .extensions()
+            .iter()
+            .find(|extension| extension.oid.to_id_string() == "2.5.29.37")
+            .expect("certificate should contain extended key usage");
+        let offset = cert_der
+            .windows(eku.value.len())
+            .position(|window| window == eku.value)
+            .expect("extension value should occur in certificate");
+        cert_der[offset] = 0xff;
+
+        let key_bytes: [u8; 32] = hex::decode(&vector.verifier_consensus_pub)
+            .expect("validator key should be hex")
+            .try_into()
+            .expect("validator key should have 32 bytes");
+        let key = VerifyingKey::from_bytes(&key_bytes).expect("validator key should be valid");
+        let now = UnixTime::since_unix_epoch(Duration::from_secs(vector.verify_at));
+        assert!(matches!(
+            verify_certificate(&cert_der, &key, &vector.verifier_chain_id, now),
+            Err(FibreCertificateError::ExtendedKeyUsage(_))
+        ));
+    }
+
+    #[test]
+    fn certificate_error_maps_to_rustls_other() {
+        let error: tokio_rustls::rustls::Error =
+            FibreCertificateError::MissingIdentityExtension.into();
+        let tokio_rustls::rustls::Error::InvalidCertificate(
+            tokio_rustls::rustls::CertificateError::Other(other),
+        ) = error
+        else {
+            panic!("expected InvalidCertificate(Other)")
+        };
+        assert!(
+            other
+                .0
+                .downcast_ref::<FibreCertificateError>()
+                .is_some_and(|error| matches!(
+                    error,
+                    FibreCertificateError::MissingIdentityExtension
+                ))
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn grpc_client_rejects_invalid_uri() {
+        let url = "not a valid url \0".to_string();
+        let key = VerifyingKey::from_bytes(&[1u8; 32]).expect("key should be valid");
+        let error = grpc_client(
+            url.clone(),
+            key,
+            "chain".to_string(),
+            Arc::new(crate::transport::io_connector::NativeTcpConnector),
+        )
+        .expect_err("invalid URI should fail");
+        assert!(matches!(
+            error,
+            FibreError::InvalidEndpoint { endpoint, .. } if endpoint == url
+        ));
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn grpc_client_rejects_uri_without_host() {
+        let uri: http::Uri = "/relative".parse().expect("relative URI should parse");
+        let key = VerifyingKey::from_bytes(&[1u8; 32]).expect("key should be valid");
+        let error = grpc_client(
+            uri.to_string(),
+            key,
+            "chain".to_string(),
+            Arc::new(crate::transport::io_connector::NativeTcpConnector),
+        )
+        .expect_err("URI without host should fail");
+        assert!(matches!(
+            error,
+            FibreError::EndpointMissingHost(value) if value == uri
+        ));
     }
 
     #[test]
@@ -644,8 +881,7 @@ mod tests {
             vector.verifier_chain_id,
             provider,
             Some(Arc::new(FixedTime(fixed_time))),
-        )
-        .expect("TLS configuration should succeed");
+        );
         client_config.alpn_protocols = vec![b"h2".to_vec()];
         let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
         let server_name =

--- a/fibre/src/validator/mod.rs
+++ b/fibre/src/validator/mod.rs
@@ -5,13 +5,14 @@ pub(crate) mod signature_set;
 
 use std::collections::HashMap;
 
+use celestia_proto::tendermint_celestia_mods::rpc::grpc::ValidatorSetResponse;
 use chacha8rand::ChaCha8Rand;
 use ed25519_dalek::VerifyingKey as Ed25519PublicKey;
 use rand::Rng;
 
 use crate::blob::Commitment;
 use crate::config::Fraction;
-use crate::error::FibreError;
+use crate::error::{FibreError, ValidatorSetError};
 use celestia_grpc::GrpcClient;
 
 pub(crate) use shard_map::ShardMap;
@@ -190,15 +191,14 @@ impl GrpcSetGetter {
 
     async fn get_by_height_inner(&self, height: i64) -> Result<ValidatorSet, FibreError> {
         let resp = self.client.get_fibre_validator_set(height).await?;
-
-        let height = resp.height as u64;
-
-        let proto_set = resp.validator_set.ok_or_else(|| {
-            FibreError::Other("ValidatorSetResponse missing validator_set".into())
-        })?;
-
-        (&proto_set, height).try_into()
+        validator_set_from_response(resp)
     }
+}
+
+fn validator_set_from_response(resp: ValidatorSetResponse) -> Result<ValidatorSet, FibreError> {
+    let height = resp.height as u64;
+    let proto_set = resp.validator_set.ok_or(ValidatorSetError::Missing)?;
+    (&proto_set, height).try_into()
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -210,9 +210,7 @@ impl SetGetter for GrpcSetGetter {
 
     async fn get_by_height(&self, height: u64) -> Result<ValidatorSet, FibreError> {
         if height == 0 {
-            return Err(FibreError::Other(
-                "get_by_height requires height > 0".into(),
-            ));
+            return Err(ValidatorSetError::ZeroHeight.into());
         }
         self.get_by_height_inner(height as i64).await
     }
@@ -245,25 +243,18 @@ impl TryFrom<&tendermint_proto::v0_38::types::Validator> for ValidatorInfo {
         let pubkey_bytes = match proto_val.pub_key.as_ref() {
             Some(pk) => match &pk.sum {
                 Some(CryptoKeySum::Ed25519(bytes)) => bytes.clone(),
-                _ => {
-                    return Err(FibreError::Other(
-                        "expected ed25519 public key for validator".into(),
-                    ));
-                }
+                _ => return Err(ValidatorSetError::UnsupportedPublicKeyType.into()),
             },
-            None => {
-                return Err(FibreError::Other("validator missing public key".into()));
-            }
+            None => return Err(ValidatorSetError::MissingPublicKey.into()),
         };
 
-        let pubkey =
-            Ed25519PublicKey::from_bytes(pubkey_bytes.as_slice().try_into().map_err(|_| {
-                FibreError::InvalidData(format!(
-                    "ed25519 key has invalid length {}, expected 32",
-                    pubkey_bytes.len()
-                ))
-            })?)
-            .map_err(|e| FibreError::Other(format!("invalid ed25519 key: {e}")))?;
+        let pubkey = Ed25519PublicKey::from_bytes(
+            pubkey_bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| ValidatorSetError::PublicKeyLength(pubkey_bytes.len()))?,
+        )
+        .map_err(ValidatorSetError::InvalidPublicKey)?;
 
         // CometBFT address = first 20 bytes of SHA-256(pubkey)
         let address: [u8; 20] = {
@@ -356,6 +347,32 @@ mod assignment_tests {
 
     fn default_liveness() -> Fraction {
         crate::test_utils::fraction(1, 3)
+    }
+
+    #[tokio::test]
+    async fn grpc_set_getter_rejects_zero_height() {
+        let client = GrpcClient::builder()
+            .url("http://localhost:50051")
+            .build()
+            .expect("GrpcClient builder should accept the test URL");
+        let getter = GrpcSetGetter::new(client);
+        assert!(matches!(
+            getter.get_by_height(0).await,
+            Err(FibreError::InvalidValidatorSet(
+                ValidatorSetError::ZeroHeight
+            ))
+        ));
+    }
+
+    #[test]
+    fn validator_set_response_requires_set() {
+        assert!(matches!(
+            validator_set_from_response(ValidatorSetResponse {
+                validator_set: None,
+                height: 1,
+            }),
+            Err(FibreError::InvalidValidatorSet(ValidatorSetError::Missing))
+        ));
     }
 
     #[test]
@@ -454,39 +471,6 @@ mod assignment_tests {
             assert_eq!(map1.get(i).unwrap().len(), map2.get(i).unwrap().len());
         }
         assert_ne!(map1.get(0).unwrap(), map2.get(0).unwrap());
-    }
-
-    #[test]
-    fn shard_map_verify_correct() {
-        let set = ValidatorSet::new(vec![make_validator(50, 1), make_validator(50, 2)], 0);
-        let map = set.assign([10u8; 32], 200, 100, 10, default_liveness());
-        let row_indices_u32: Vec<u32> = map.get(0).unwrap().iter().map(|&r| r as u32).collect();
-        assert!(map.verify(0, &row_indices_u32).is_ok());
-    }
-
-    #[test]
-    fn shard_map_verify_wrong_count() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
-        let map = set.assign([11u8; 32], 200, 100, 10, default_liveness());
-        assert!(map.verify(0, &[0, 1, 2]).is_err());
-    }
-
-    #[test]
-    fn shard_map_verify_wrong_row() {
-        let set = ValidatorSet::new(vec![make_validator(50, 1), make_validator(50, 2)], 0);
-        let total_rows = 200;
-        let map = set.assign([12u8; 32], total_rows, 100, 10, default_liveness());
-
-        let mut wrong_indices: Vec<u32> = map.get(0).unwrap().iter().map(|&r| r as u32).collect();
-        wrong_indices[0] = (total_rows + 999) as u32;
-        assert!(map.verify(0, &wrong_indices).is_err());
-    }
-
-    #[test]
-    fn shard_map_verify_missing_validator() {
-        let set = ValidatorSet::new(vec![make_validator(100, 1)], 0);
-        let map = set.assign([13u8; 32], 200, 100, 10, default_liveness());
-        assert!(map.verify(5, &[0]).is_err());
     }
 
     #[test]

--- a/fibre/src/validator/shard_map.rs
+++ b/fibre/src/validator/shard_map.rs
@@ -1,8 +1,6 @@
 //! Row assignment map for validator uploads.
 
-use std::collections::{HashMap, HashSet};
-
-use crate::error::FibreError;
+use std::collections::HashMap;
 
 /// Maps validator index to the row indices assigned to that validator.
 ///
@@ -37,36 +35,5 @@ impl ShardMap {
     /// Returns true if the shard map contains no validators.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
-    }
-
-    /// Verify that a validator's claimed row indices match their assignment.
-    pub fn verify(&self, validator_index: usize, row_indices: &[u32]) -> Result<(), FibreError> {
-        let rows = self.inner.get(&validator_index).ok_or_else(|| {
-            FibreError::InvalidData(format!(
-                "validator index {} not in shard map",
-                validator_index
-            ))
-        })?;
-
-        if row_indices.len() != rows.len() {
-            return Err(FibreError::InvalidData(format!(
-                "expected {} rows, got {}",
-                rows.len(),
-                row_indices.len()
-            )));
-        }
-
-        let assigned_set: HashSet<usize> = rows.iter().copied().collect();
-
-        for &row_idx in row_indices {
-            if !assigned_set.contains(&(row_idx as usize)) {
-                return Err(FibreError::InvalidData(format!(
-                    "row {} not assigned to validator {}",
-                    row_idx, validator_index
-                )));
-            }
-        }
-
-        Ok(())
     }
 }

--- a/fibre/src/validator/signature_set.rs
+++ b/fibre/src/validator/signature_set.rs
@@ -74,8 +74,8 @@ impl SignatureSet {
         // Parse the raw signature bytes into an ed25519 Signature.
         let ed_sig = Ed25519Signature::from_slice(signature).map_err(|e| {
             FibreError::InvalidValidatorSignature {
-                validator: validator.address_hex(),
-                reason: e.to_string(),
+                validator: validator.address,
+                source: e,
             }
         })?;
 
@@ -83,8 +83,8 @@ impl SignatureSet {
             .pubkey
             .verify(&self.required_bytes_signed, &ed_sig)
             .map_err(|e| FibreError::InvalidValidatorSignature {
-                validator: validator.address_hex(),
-                reason: e.to_string(),
+                validator: validator.address,
+                source: e,
             })?;
 
         // Lock, record, and check threshold.
@@ -201,10 +201,22 @@ mod tests {
         assert!(result.is_err(), "invalid signature should be rejected");
         match result.unwrap_err() {
             FibreError::InvalidValidatorSignature { validator, .. } => {
-                assert_eq!(validator, val.address_hex());
+                assert_eq!(validator, val.address);
             }
             other => panic!("expected InvalidValidatorSignature, got: {other}"),
         }
+    }
+
+    #[test]
+    fn add_malformed_signature() {
+        let (_, val) = make_validator(10);
+        let ss = SignatureSet::new(vec![val.clone()], fraction(1, 2), b"data".to_vec());
+
+        assert!(matches!(
+            ss.add(&val, &[0u8; 63]),
+            Err(FibreError::InvalidValidatorSignature { validator, .. })
+                if validator == val.address
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Overview

So there's a less work on the error path, as error formatting happens(if ever) when serializing response.

Also errors are more granular and callers can rely on different errors in pattern matches rather than parsing strings


Resolves #994