### PR TITLE
perf(proto): preallocate tonic encoding buffers

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -299,6 +299,7 @@ fn tonic_build(fds: FileDescriptorSet) {
         .build_transport(false)
         .use_arc_self(true)
         .compile_well_known_types(true)
+        .codec_path("crate::tonic_codec::PreallocProstCodec")
         .skip_protoc_run()
         .bytes([
             ".tendermint_celestia_mods.abci",

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -6,6 +6,9 @@
 
 pub mod serializers;
 
+#[cfg(feature = "tonic")]
+mod tonic_codec;
+
 include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 
 #[cfg(feature = "uniffi")]

--- a/proto/src/tonic_codec.rs
+++ b/proto/src/tonic_codec.rs
@@ -1,0 +1,62 @@
+use core::marker::PhantomData;
+
+use prost::Message;
+use tonic::Status;
+use tonic::codec::{Codec, EncodeBuf, Encoder, ProstCodec};
+
+#[derive(Debug, Clone)]
+pub struct PreallocProstCodec<T, U> {
+    marker: PhantomData<(T, U)>,
+}
+
+impl<T, U> Default for PreallocProstCodec<T, U> {
+    fn default() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T, U> Codec for PreallocProstCodec<T, U>
+where
+    T: Message + Send + 'static,
+    U: Message + Default + Send + 'static,
+{
+    type Encode = T;
+    type Decode = U;
+    type Encoder = PreallocProstEncoder<T>;
+    type Decoder = <ProstCodec<T, U> as Codec>::Decoder;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        PreallocProstEncoder::default()
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        ProstCodec::<T, U>::default().decoder()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PreallocProstEncoder<T> {
+    marker: PhantomData<T>,
+}
+
+impl<T> Default for PreallocProstEncoder<T> {
+    fn default() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Message> Encoder for PreallocProstEncoder<T> {
+    type Item = T;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, buf: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        buf.reserve(item.encoded_len());
+        item.encode(buf)
+            .expect("Message only errors if not enough space");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Overview

Extracting it from #1019

Given that fibre has pretty big messages, default buffers for serialization are constantly resized, which brings the performance penalty.

It has been explored in #1019, that this codec from 2.05 GiB/s against mock server to 2.52 GiB/s with 10 validators.

## Summary

  The codec:

- Reserves the protobuf message’s exact encoded size before writing
- Uses normal Prost encoding afterward.
- Delegates decoding unchanged to `ProstCodec`.
- Exists only when the tonic feature is enabled.

The optimization helps outbound messages.

Existing benchmarks use encode_to_vec, which skips tonic codec.