### PR TITLE
chore(node-wasm): wait for the submitted height before requesting blobs

### DIFF
--- a/node-wasm/tests/client.rs
+++ b/node-wasm/tests/client.rs
@@ -6,10 +6,11 @@ use std::time::Duration;
 use celestia_rpc::TxConfig;
 use celestia_rpc::p2p::PeerId;
 use celestia_rpc::prelude::*;
-use celestia_types::Blob;
 use celestia_types::nmt::Namespace;
+use celestia_types::{Blob, ExtendedHeader};
 use futures::FutureExt;
 use gloo_timers::future::sleep;
+use lumina_node_wasm::client::NodeClient;
 use lumina_node_wasm::utils::setup_logging;
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -71,8 +72,8 @@ async fn get_blob() {
     let bridge_ma = fetch_bridge_webtransport_multiaddr(&rpc_client).await;
     let client = spawn_connected_node(vec![bridge_ma.to_string()]).await;
 
-    // Wait for the `client` node to sync until the `submitted_height`.
-    sleep(Duration::from_secs(2)).await;
+    // Blobs can only be requested for heights the node has already synced.
+    wait_for_header(&client, submitted_height).await;
 
     let mut blobs = client
         .request_all_blobs(&namespace, submitted_height, None)
@@ -83,4 +84,17 @@ async fn get_blob() {
     let blob = blobs.pop().unwrap();
     assert_eq!(blob.data, data);
     assert_eq!(blob.namespace, namespace);
+}
+
+/// Waits until the node has synced the header at `height` and returns it.
+async fn wait_for_header(client: &NodeClient, height: u64) -> ExtendedHeader {
+    // 30 s, the node syncs the head first and then backfills
+    for _ in 0..120 {
+        if let Ok(header) = client.get_header_by_height(height).await {
+            return header;
+        }
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    panic!("node did not sync header {height} within 30s");
 }


### PR DESCRIPTION
## Problem

`test-wasm (lumina-node-wasm, node-wasm, --release, true)` failed on #1030 (run 34239030740):

```
test get_blob ... FAIL
panicked at node-wasm/tests/client.rs:80:10:
to fetch blob: Error(JsValue(Error: Node error: Error (P2p: Header of 520 block is not synced yet)
```

The test submits a blob, starts a light node, sleeps a fixed 2 s "for the node to sync", and requests the blobs at the submitted height. Whether 2 s is enough depends on the runner.

## Fix

Poll `get_header_by_height(submitted_height)` until the node has the header (30 s deadline) instead of sleeping. The `wait_for_header` helper is local to the `client` test binary.

## Verification

- `cargo clippy --all-targets --all-features --target=wasm32-unknown-unknown -p lumina-node-wasm -- -D warnings --no-deps`
- Browser tests only run in CI; `test-wasm (lumina-node-wasm, …)` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bvFWKViYzDSdi9uiMZ5Pb
