### PR TITLE
chore(ci): retry the msrv index fetch and the devnet start

### DIFF
--- a/.github/actions/local-devnet/action.yml
+++ b/.github/actions/local-devnet/action.yml
@@ -23,8 +23,19 @@ runs:
     - name: Run the docker-compose stack
       shell: bash
       # --wait fails if any service exits or becomes unhealthy,
-      # instead of hanging until the job timeout
-      run: docker compose -f ci/docker-compose.yml up --no-build -d --wait --wait-timeout 180
+      # instead of hanging until the job timeout.
+      #
+      # `celestia-appd` in the `validator-eviction-testing` service occasionally
+      # exits while initialising its config (seen twice on 2026-09-03). Recreate
+      # the stack once before failing the job.
+      run: |
+        for attempt in 1 2; do
+          docker compose -f ci/docker-compose.yml up --no-build -d --wait --wait-timeout 180 && exit 0
+          echo "attempt $attempt failed, recreating the stack"
+          docker compose -f ci/docker-compose.yml logs --no-color --tail 50 || true
+          docker compose -f ci/docker-compose.yml down -v || true
+        done
+        exit 1
 
     - name: Generate auth tokens
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,11 +414,26 @@ jobs:
       with:
         tool: cargo-msrv
 
+    # `cargo msrv` fetches the Rust release index before checking anything, and
+    # that fetch occasionally fails with a connection reset. Retry the step a
+    # few times before treating it as a failure.
     - name: Run msrv verify for native
-      run: cargo msrv verify --manifest-path ./${{ matrix.crate.dir }}/Cargo.toml --all-features
+      run: |
+        for attempt in 1 2 3; do
+          cargo msrv verify --manifest-path ./${{ matrix.crate.dir }}/Cargo.toml --all-features && exit 0
+          echo "attempt $attempt failed, retrying"
+          sleep 10
+        done
+        exit 1
 
     - name: Run msrv verify for wasm32
-      run: cargo msrv verify --manifest-path ./${{ matrix.crate.dir }}/Cargo.toml --all-features --target wasm32-unknown-unknown
+      run: |
+        for attempt in 1 2 3; do
+          cargo msrv verify --manifest-path ./${{ matrix.crate.dir }}/Cargo.toml --all-features --target wasm32-unknown-unknown && exit 0
+          echo "attempt $attempt failed, retrying"
+          sleep 10
+        done
+        exit 1
 
 
   required:


### PR DESCRIPTION
Two infrastructure flakes from last week's CI failures (see the 7-day sweep in the internal `ci-analysis` notes):

## `msrv` — connection reset while fetching the release index

`msrv (celestia-rpc, rpc)` on #1019 (run 34235549999) failed before checking anything:

```
[Meta]   cargo-msrv 0.19.3
HTTP error: io: Connection reset by peer (os error 104)
```

`cargo msrv verify` fetches the Rust release index first; the matrix does that 24 times per run (12 crates × 2 targets). Each `cargo msrv verify` step now retries up to three times with a 10 s pause.

## local-devnet — `validator-eviction-testing` exits during startup

`docker compose up --wait` failed on `main` `edb77810` (run 33748959015, green on rerun) and #1011 (run 33742430531), both on 2026-09-03, with `container ci-validator-eviction-testing-1 exited (1)`. The devnet artifacts show `celestia-appd` failing to parse its freshly written config (`toml: key broadcast-mode is already defined` during `init`; `must set the RPC GRPC listen address` during `start`). The config dir is per-container, so this is not a race between the two validators; the cause is inside the binary and has not recurred since. The action now prints the last 50 log lines of each service, tears the stack down with `down -v`, and tries once more before failing.

No change to what a real failure looks like: a persistent problem still fails the step, just later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bvFWKViYzDSdi9uiMZ5Pb
