### PR TITLE
fix(fibre): fix merge race

### DIFF
--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -654,11 +654,9 @@ mod tests {
     #[tokio::test]
     async fn close_cancels_inflight_upload_tasks() {
         let validators = [make_validator(100, 1), make_validator(100, 2)];
-        let val_set = ValidatorSet::try_new(
-            validators.iter().map(|(_, info)| info.clone()).collect(),
-            1,
-        )
-        .unwrap();
+        let val_set =
+            ValidatorSet::try_new(validators.iter().map(|(_, info)| info.clone()).collect(), 1)
+                .unwrap();
         let entered = Arc::new(AtomicUsize::new(0));
         let dropped = Arc::new(AtomicUsize::new(0));
         let connector = HangingConnector {

--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -654,10 +654,11 @@ mod tests {
     #[tokio::test]
     async fn close_cancels_inflight_upload_tasks() {
         let validators = [make_validator(100, 1), make_validator(100, 2)];
-        let val_set = ValidatorSet {
-            validators: validators.iter().map(|(_, info)| info.clone()).collect(),
-            height: 1,
-        };
+        let val_set = ValidatorSet::try_new(
+            validators.iter().map(|(_, info)| info.clone()).collect(),
+            1,
+        )
+        .unwrap();
         let entered = Arc::new(AtomicUsize::new(0));
         let dropped = Arc::new(AtomicUsize::new(0));
         let connector = HangingConnector {


### PR DESCRIPTION
## Overview

Cause: a merge race. #1020 (fef8a98) made ValidatorSet fields private and changed height to NonZeroU64 (fibre/src/validator/mod.rs:95-100). #1022 (41e55dc) landed right after with a new test that still used the old struct literal at fibre/src/client/upload.rs:657. Since clippy with --all-targets and cargo test both compile the test target, both failed on the same two errors.