### PR TITLE
Nikolai/retain validator info in connection

### DIFF
--- a/fibre/src/client/upload.rs
+++ b/fibre/src/client/upload.rs
@@ -306,14 +306,31 @@ impl FibreClient {
                                 }
                             }
                         }
-                        Some((val_idx, Some(Err(e)))) => {
+                        Some((val_idx, Some(Err(error)))) => {
                             stats.failed += 1;
                             let validator = &val_set.validators()[val_idx];
-                            tracing::warn!(
-                                validator = %validator.address_hex(),
-                                error = %e,
-                                "shard upload failed"
-                            );
+                            match error {
+                                FibreError::GrpcRequest {
+                                    method,
+                                    endpoint,
+                                    source,
+                                } => {
+                                    tracing::warn!(
+                                        validator = %validator.address_hex(),
+                                        method,
+                                        %endpoint,
+                                        error = %source,
+                                        "shard upload failed"
+                                    );
+                                }
+                                error => {
+                                    tracing::warn!(
+                                        validator = %validator.address_hex(),
+                                        %error,
+                                        "shard upload failed"
+                                    );
+                                }
+                            }
                         }
                         Some((val_idx, None)) => {
                             stats.failed += 1;

--- a/fibre/src/domain/error.rs
+++ b/fibre/src/domain/error.rs
@@ -255,6 +255,18 @@ pub enum FibreError {
     #[error("grpc client error: {0}")]
     GrpcClient(#[from] celestia_grpc::Error),
 
+    /// A gRPC request to a Fibre validator failed.
+    #[error("Fibre gRPC {method} request to {endpoint} failed: {source}")]
+    GrpcRequest {
+        /// Name of the failed gRPC method.
+        method: &'static str,
+        /// Validator endpoint handling the request.
+        endpoint: String,
+        /// The underlying gRPC failure.
+        #[source]
+        source: celestia_grpc::Error,
+    },
+
     /// An error while building a gRPC client.
     #[error("failed to build gRPC client: {0}")]
     GrpcClientBuilder(#[from] celestia_grpc::GrpcClientBuilderError),

--- a/fibre/src/transport/grpc_validator_client.rs
+++ b/fibre/src/transport/grpc_validator_client.rs
@@ -87,7 +87,6 @@ impl ValidatorConnector for GrpcValidatorConnector {
 
         let conn = Arc::new(GrpcValidatorConnection {
             client,
-            validator_address: validator.address,
             endpoint: url,
         });
 
@@ -117,7 +116,6 @@ fn normalize_host(raw: &str) -> String {
 /// Wraps a [`GrpcClient`] for issuing upload/download RPCs.
 pub struct GrpcValidatorConnection {
     client: GrpcClient,
-    validator_address: [u8; 20],
     endpoint: String,
 }
 
@@ -138,19 +136,15 @@ impl ValidatorConnection for GrpcValidatorConnection {
             shard: Some(proto_shard),
         };
 
-        let response = self
-            .client
-            .upload_shard(request)
-            .await
-            .inspect_err(|error| {
-                tracing::warn!(
-                    method = "UploadShard",
-                    validator = %hex::encode_upper(self.validator_address),
-                    endpoint = %self.endpoint,
-                    %error,
-                    "Fibre gRPC request failed"
-                );
-            })?;
+        let response =
+            self.client
+                .upload_shard(request)
+                .await
+                .map_err(|source| FibreError::GrpcRequest {
+                    method: "UploadShard",
+                    endpoint: self.endpoint.clone(),
+                    source,
+                })?;
 
         Ok(UploadResponse {
             validator_signature: response.validator_signature,

--- a/fibre/src/transport/grpc_validator_client.rs
+++ b/fibre/src/transport/grpc_validator_client.rs
@@ -79,13 +79,17 @@ impl ValidatorConnector for GrpcValidatorConnector {
         let url = normalize_host(&host.0);
 
         let client = crate::transport::tls::grpc_client(
-            url,
+            &url,
             validator.pubkey,
             self.chain_id.clone(),
             self.io_connector.clone(),
         )?;
 
-        let conn = Arc::new(GrpcValidatorConnection { client });
+        let conn = Arc::new(GrpcValidatorConnection {
+            client,
+            validator_address: validator.address,
+            endpoint: url,
+        });
 
         // Re-check cache under lock: another task may have inserted a
         // connection for this validator while we were resolving/building.
@@ -113,6 +117,8 @@ fn normalize_host(raw: &str) -> String {
 /// Wraps a [`GrpcClient`] for issuing upload/download RPCs.
 pub struct GrpcValidatorConnection {
     client: GrpcClient,
+    validator_address: [u8; 20],
+    endpoint: String,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -132,7 +138,19 @@ impl ValidatorConnection for GrpcValidatorConnection {
             shard: Some(proto_shard),
         };
 
-        let response = self.client.upload_shard(request).await?;
+        let response = self
+            .client
+            .upload_shard(request)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(
+                    method = "UploadShard",
+                    validator = %hex::encode_upper(self.validator_address),
+                    endpoint = %self.endpoint,
+                    %error,
+                    "Fibre gRPC request failed"
+                );
+            })?;
 
         Ok(UploadResponse {
             validator_signature: response.validator_signature,

--- a/fibre/src/transport/tls.rs
+++ b/fibre/src/transport/tls.rs
@@ -203,7 +203,7 @@ impl ServerCertVerifier for FibreServerCertVerifier {
 }
 
 pub(crate) fn grpc_client(
-    url: String,
+    url: &str,
     validator_key: VerifyingKey,
     chain_id: String,
     io_connector: Arc<dyn FibreIoConnector>,
@@ -211,7 +211,7 @@ pub(crate) fn grpc_client(
     let uri = url
         .parse::<http::Uri>()
         .map_err(|source| FibreError::InvalidEndpoint {
-            endpoint: url,
+            endpoint: url.to_owned(),
             source,
         })?;
     let host = uri
@@ -744,7 +744,7 @@ mod tests {
         let url = "not a valid url \0".to_string();
         let key = VerifyingKey::from_bytes(&[1u8; 32]).expect("key should be valid");
         let error = grpc_client(
-            url.clone(),
+            &url,
             key,
             "chain".to_string(),
             Arc::new(crate::transport::io_connector::NativeTcpConnector),
@@ -760,9 +760,10 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     fn grpc_client_rejects_uri_without_host() {
         let uri: http::Uri = "/relative".parse().expect("relative URI should parse");
+        let url = uri.to_string();
         let key = VerifyingKey::from_bytes(&[1u8; 32]).expect("key should be valid");
         let error = grpc_client(
-            uri.to_string(),
+            &url,
             key,
             "chain".to_string(),
             Arc::new(crate::transport::io_connector::NativeTcpConnector),


### PR DESCRIPTION
## Overview

Extracting helper from PR https://github.com/celestiaorg/lumina/pull/1019/ (commit 84e25468eccac0ca8dace3e7402a971068947615) to have enchaced information about failed validator requests, since there could be many of those connections in fibre.

Before

```
2026-09-09T17:18:14.806399Z  WARN lumina_utils::failover: failover: endpoint  network error: status: DeadlineExceeded, message: "request timed out", details: [], metadata: MetadataMap { headers: {} }
2026-09-09T17:18:14.806654Z  WARN celestia_fibre::transport::grpc_validator_client: Fibre gRPC request failed method="UploadShard" validator=BDAEFC96E57CE198F1164175C452F29FF36ECA8E endpoint=https://10.20.10.165:7980 error=status: DeadlineExceeded, message: "request timed out", details: [], metadata: MetadataMap { headers: {} }
```

```
2026-09-09T17:22:52.275996Z  WARN celestia_fibre::transport::grpc_validator_client: Fibre gRPC request failed method="UploadShard" validator=BDAEFC96E57CE198F1164175C452F29FF36ECA8E endpoint=https://10.20.10.165:7980 error=status: DeadlineExceeded, message: "request timed out", details: [], metadata: MetadataMap { headers: {} }
2026-09-09T17:22:52.276901Z  WARN lumina_utils::failover: failover: endpoint  network error: status: DeadlineExceeded, message: "request timed out", details: [], metadata: MetadataMap { headers: {} }
```